### PR TITLE
Typo in macos.md

### DIFF
--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -29,7 +29,7 @@ Native macOS setup with full Metal GPU acceleration for optimal performance.
 3. **Install agent-cli:**
 
    ```bash
-   uv tools install agent-cli
+   uv tool install agent-cli
    # or: pip install agent-cli
    ```
 


### PR DESCRIPTION
However, when I ran 1. and 2., when I ran 3. i got "`agent-cli` is already installed"