### PR TITLE
feat: add support for llama-server via OpenAI-compatible API

### DIFF
--- a/agent_cli/agents/assistant.py
+++ b/agent_cli/agents/assistant.py
@@ -272,6 +272,7 @@ def assistant(
     llm_ollama_host: str = opts.LLM_OLLAMA_HOST,
     llm_openai_model: str = opts.LLM_OPENAI_MODEL,
     openai_api_key: str | None = opts.OPENAI_API_KEY,
+    openai_base_url: str | None = opts.OPENAI_BASE_URL,
     llm_gemini_model: str = opts.LLM_GEMINI_MODEL,
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
     # --- TTS Configuration ---
@@ -355,6 +356,7 @@ def assistant(
         openai_llm_cfg = config.OpenAILLM(
             llm_openai_model=llm_openai_model,
             openai_api_key=openai_api_key,
+            openai_base_url=openai_base_url,
         )
         gemini_llm_cfg = config.GeminiLLM(
             llm_gemini_model=llm_gemini_model,

--- a/agent_cli/agents/autocorrect.py
+++ b/agent_cli/agents/autocorrect.py
@@ -213,6 +213,7 @@ def autocorrect(
     # OpenAI
     llm_openai_model: str = opts.LLM_OPENAI_MODEL,
     openai_api_key: str | None = opts.OPENAI_API_KEY,
+    openai_base_url: str | None = opts.OPENAI_BASE_URL,
     # Gemini
     llm_gemini_model: str = opts.LLM_GEMINI_MODEL,
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
@@ -235,6 +236,7 @@ def autocorrect(
     openai_llm_cfg = config.OpenAILLM(
         llm_openai_model=llm_openai_model,
         openai_api_key=openai_api_key,
+        openai_base_url=openai_base_url,
     )
     gemini_llm_cfg = config.GeminiLLM(
         llm_gemini_model=llm_gemini_model,

--- a/agent_cli/agents/chat.py
+++ b/agent_cli/agents/chat.py
@@ -388,6 +388,7 @@ def chat(
     llm_ollama_host: str = opts.LLM_OLLAMA_HOST,
     llm_openai_model: str = opts.LLM_OPENAI_MODEL,
     openai_api_key: str | None = opts.OPENAI_API_KEY,
+    openai_base_url: str | None = opts.OPENAI_BASE_URL,
     llm_gemini_model: str = opts.LLM_GEMINI_MODEL,
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
     # --- TTS Configuration ---
@@ -480,6 +481,7 @@ def chat(
         openai_llm_cfg = config.OpenAILLM(
             llm_openai_model=llm_openai_model,
             openai_api_key=openai_api_key,
+            openai_base_url=openai_base_url,
         )
         gemini_llm_cfg = config.GeminiLLM(
             llm_gemini_model=llm_gemini_model,

--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -297,6 +297,7 @@ def transcribe(  # noqa: PLR0912
     llm_ollama_host: str = opts.LLM_OLLAMA_HOST,
     llm_openai_model: str = opts.LLM_OPENAI_MODEL,
     openai_api_key: str | None = opts.OPENAI_API_KEY,
+    openai_base_url: str | None = opts.OPENAI_BASE_URL,
     llm_gemini_model: str = opts.LLM_GEMINI_MODEL,
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
     llm: bool = opts.LLM,
@@ -381,6 +382,7 @@ def transcribe(  # noqa: PLR0912
     openai_llm_cfg = config.OpenAILLM(
         llm_openai_model=llm_openai_model,
         openai_api_key=openai_api_key,
+        openai_base_url=openai_base_url,
     )
     gemini_llm_cfg = config.GeminiLLM(
         llm_gemini_model=llm_gemini_model,

--- a/agent_cli/agents/voice_edit.py
+++ b/agent_cli/agents/voice_edit.py
@@ -186,6 +186,7 @@ def voice_edit(
     llm_ollama_host: str = opts.LLM_OLLAMA_HOST,
     llm_openai_model: str = opts.LLM_OPENAI_MODEL,
     openai_api_key: str | None = opts.OPENAI_API_KEY,
+    openai_base_url: str | None = opts.OPENAI_BASE_URL,
     llm_gemini_model: str = opts.LLM_GEMINI_MODEL,
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
     # --- TTS Configuration ---
@@ -274,6 +275,7 @@ def voice_edit(
         openai_llm_cfg = config.OpenAILLM(
             llm_openai_model=llm_openai_model,
             openai_api_key=openai_api_key,
+            openai_base_url=openai_base_url,
         )
         gemini_llm_cfg = config.GeminiLLM(
             llm_gemini_model=llm_gemini_model,

--- a/agent_cli/api.py
+++ b/agent_cli/api.py
@@ -196,6 +196,7 @@ def _load_transcription_configs() -> tuple[
     openai_llm_cfg = config.OpenAILLM(
         llm_openai_model=defaults.get("llm_openai_model", opts.LLM_OPENAI_MODEL.default),  # type: ignore[attr-defined]
         openai_api_key=defaults.get("openai_api_key", opts.OPENAI_API_KEY.default),  # type: ignore[attr-defined,union-attr]
+        openai_base_url=defaults.get("openai_base_url", opts.OPENAI_BASE_URL.default),  # type: ignore[attr-defined,union-attr]
     )
     gemini_llm_cfg = config.GeminiLLM(
         llm_gemini_model=defaults.get("llm_gemini_model", opts.LLM_GEMINI_MODEL.default),  # type: ignore[attr-defined]

--- a/agent_cli/config.py
+++ b/agent_cli/config.py
@@ -41,6 +41,7 @@ class OpenAILLM(BaseModel):
 
     llm_openai_model: str
     openai_api_key: str | None = None
+    openai_base_url: str | None = None
 
 
 class GeminiLLM(BaseModel):

--- a/agent_cli/opts.py
+++ b/agent_cli/opts.py
@@ -59,6 +59,12 @@ OPENAI_API_KEY: str | None = typer.Option(
     envvar="OPENAI_API_KEY",
     rich_help_panel="LLM Configuration: OpenAI",
 )
+OPENAI_BASE_URL: str | None = typer.Option(
+    None,
+    "--openai-base-url",
+    help="Custom base URL for OpenAI-compatible API (e.g., for llama-server: http://localhost:8080/v1).",
+    rich_help_panel="LLM Configuration: OpenAI",
+)
 # Gemini
 LLM_GEMINI_MODEL: str = typer.Option(
     "gemini-2.5-flash",

--- a/agent_cli/services/llm.py
+++ b/agent_cli/services/llm.py
@@ -26,10 +26,20 @@ def _openai_llm_model(openai_cfg: config.OpenAILLM) -> OpenAIModel:
     from pydantic_ai.models.openai import OpenAIModel  # noqa: PLC0415
     from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
 
-    if not openai_cfg.openai_api_key:
-        msg = "OpenAI API key is not set."
-        raise ValueError(msg)
-    provider = OpenAIProvider(api_key=openai_cfg.openai_api_key)
+    # For custom base URLs (like llama-server), API key might not be required
+    if openai_cfg.openai_base_url:
+        # Custom endpoint - API key is optional
+        provider = OpenAIProvider(
+            api_key=openai_cfg.openai_api_key or "dummy",
+            base_url=openai_cfg.openai_base_url,
+        )
+    else:
+        # Standard OpenAI - API key is required
+        if not openai_cfg.openai_api_key:
+            msg = "OpenAI API key is not set."
+            raise ValueError(msg)
+        provider = OpenAIProvider(api_key=openai_cfg.openai_api_key)
+
     model_name = openai_cfg.llm_openai_model
     return OpenAIModel(model_name=model_name, provider=provider)
 

--- a/example.agent-cli-config.toml
+++ b/example.agent-cli-config.toml
@@ -37,6 +37,8 @@ llm-ollama-model = "qwen3:4b"
 llm-ollama-host = "http://localhost:11434"
 # OpenAI
 llm-openai-model = "gpt-4o-mini"
+# For llama-server (llama-cpp) or other OpenAI-compatible APIs:
+# openai-base-url = "http://localhost:8080/v1"
 
 # --- ASR (Speech-to-Text) Settings ---
 # Wyoming (local)


### PR DESCRIPTION
- Add openai_base_url configuration option to OpenAILLM config
- Update OpenAI provider to support custom base URLs (e.g., llama-server)
- Make API key optional when using custom base URLs
- Add --openai-base-url CLI option to all agents
- Update example configuration with llama-server usage instructions

This allows using llama-cpp's llama-server by setting:
  --llm-provider openai --openai-base-url http://localhost:8080/v1