### PR TITLE
docs: add llama.cpp and other OpenAI-compatible servers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The setup scripts automatically install:
     - [Core Requirements (Auto-installed)](#core-requirements-auto-installed)
     - [AI Services (Auto-installed and configured)](#ai-services-auto-installed-and-configured)
     - [Alternative Cloud Services (Optional)](#alternative-cloud-services-optional)
+    - [Alternative Local LLM Servers](#alternative-local-llm-servers)
 - [Usage](#usage)
   - [Installation Commands](#installation-commands)
   - [Configuration](#configuration)


### PR DESCRIPTION
## Summary
- Added documentation for llama.cpp support via the existing `--openai-base-url` flag
- Included other OpenAI-compatible servers (vLLM) as alternatives
- Created new "Alternative Local LLM Servers" section in the README

## Details
This PR documents the existing functionality that allows users to connect to llama.cpp and other OpenAI-compatible local LLM servers using the `--openai-base-url` parameter. This makes it clear that agent-cli is not limited to Ollama for local LLM inference.

## Test plan
- [x] Documentation only change, no code modifications needed
- [x] Verified that the existing `--openai-base-url` flag works with llama.cpp server