### PR TITLE
refactor(tts): reuse openai client for kokoro tts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,10 +115,8 @@ target-version = "py311"
 select = ["ALL"]
 ignore = [
     "T20",
-    "ANN101",
     "S101",
     "S603",
-    "PD901",
     "ANN401",
     "D402",
     "PLW0603",


### PR DESCRIPTION
Refactors the Kokoro TTS implementation to reuse the existing OpenAI client logic, reducing code duplication. This maps the Kokoro configuration to a compatible OpenAI configuration and delegates the synthesis call. A test case has been added to verify this delegation.