### PR TITLE
refactor: Migrate audio stack from PyAudio to SoundDevice

### DIFF
--- a/agent_cli/agents/assistant.py
+++ b/agent_cli/agents/assistant.py
@@ -191,9 +191,9 @@ async def _async_main(
     audio_in_cfg.input_device_index = input_device_index
     audio_out_cfg.output_device_index = tts_output_device_index
 
-    stream_kwargs = audio.setup_input_stream(input_device_index)
+    stream_config = audio.setup_input_stream(input_device_index)
     with (
-        audio.open_audio_stream(**stream_kwargs) as stream,
+        audio.open_audio_stream(stream_config) as stream,
         signal_handling_context(LOGGER, general_cfg.quiet) as stop_event,
     ):
         while not stop_event.is_set():

--- a/agent_cli/services/asr.py
+++ b/agent_cli/services/asr.py
@@ -258,8 +258,8 @@ async def record_audio_with_manual_stop(
         """Buffer audio chunk."""
         audio_buffer.write(chunk)
 
-    stream_kwargs = setup_input_stream(input_device_index)
-    with open_audio_stream(**stream_kwargs) as stream:
+    stream_config = setup_input_stream(input_device_index)
+    with open_audio_stream(stream_config) as stream:
         await read_audio_stream(
             stream=stream,
             stop_event=stop_event,
@@ -339,8 +339,8 @@ async def _transcribe_live_audio_wyoming(
             logger,
             quiet=quiet,
         ) as client:
-            stream_kwargs = setup_input_stream(audio_input_cfg.input_device_index)
-            with open_audio_stream(**stream_kwargs) as stream:
+            stream_config = setup_input_stream(audio_input_cfg.input_device_index)
+            with open_audio_stream(stream_config) as stream:
                 _, recv_task = await manage_send_receive_tasks(
                     _send_audio(
                         client,

--- a/agent_cli/services/tts.py
+++ b/agent_cli/services/tts.py
@@ -324,15 +324,15 @@ async def _play_audio(
             sample_rate = int(sample_rate * speed)
         base_msg = f"🔊 Playing audio at {speed}x speed" if speed != 1.0 else "🔊 Playing audio"
         async with live_timer(live, base_msg, style="blue", quiet=quiet):
-            stream_kwargs = setup_output_stream(
+            stream_config = setup_output_stream(
                 audio_output_cfg.output_device_index,
                 sample_rate=sample_rate,
                 sample_width=sample_width,
                 channels=channels,
             )
-            dtype = stream_kwargs["dtype"]
+            dtype = stream_config.dtype
 
-            with open_audio_stream(**stream_kwargs) as stream:
+            with open_audio_stream(stream_config) as stream:
                 chunk_size_frames = constants.AUDIO_CHUNK_SIZE
                 bytes_per_frame = channels * sample_width
                 chunk_bytes = chunk_size_frames * bytes_per_frame

--- a/tests/agents/test_speak_e2e.py
+++ b/tests/agents/test_speak_e2e.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,7 +31,7 @@ async def test_speak_e2e(
 
     # Setup device info (input_index, input_name, output_index)
     mock_setup_devices.return_value = (None, None, 0)
-    mock_setup_output_stream.return_value = {"dtype": "int16"}
+    mock_setup_output_stream.return_value = SimpleNamespace(dtype="int16")
 
     # Setup mock Wyoming client
     mock_tts_client = MockTTSClient(b"fake audio data")

--- a/tests/test_audio_e2e.py
+++ b/tests/test_audio_e2e.py
@@ -200,18 +200,28 @@ def test_open_audio_stream_context_manager(
 ) -> None:
     """Test open_audio_stream context manager."""
     # Test input stream
-    with audio.open_audio_stream(
-        input=True,
-        input_device_index=0,
-    ) as stream:
+    input_config = audio.StreamConfig(
+        rate=16000,
+        channels=1,
+        dtype="int16",
+        device=0,
+        blocksize=1024,
+        kind="input",
+    )
+    with audio.open_audio_stream(input_config) as stream:
         assert stream is not None
         mock_input_stream.assert_called()
 
     # Test output stream
-    with audio.open_audio_stream(
-        output=True,
-        output_device_index=1,
-    ) as stream:
+    output_config = audio.StreamConfig(
+        rate=24000,
+        channels=1,
+        dtype="int16",
+        device=1,
+        blocksize=1024,
+        kind="output",
+    )
+    with audio.open_audio_stream(output_config) as stream:
         assert stream is not None
         mock_output_stream.assert_called()
 


### PR DESCRIPTION
- Replace `pyaudio` with `sounddevice` to remove system-level dependencies (PortAudio) and simplify cross-platform installation.
- Introduce `StreamConfig` dataclass for type-safe and explicit audio stream configuration, replacing untyped dictionary passing.
- Refactor `agent_cli/core/audio.py` to implement `open_audio_stream`, `setup_input_stream`, and `setup_output_stream` using `sounddevice`.
- Update ASR and TTS services (`agent_cli/services/asr.py`, `agent_cli/services/tts.py`) to use the new audio API.
- Update `agent_cli/constants.py` to use `numpy` dtype strings (e.g., 'int16') instead of PyAudio format constants.
- Remove PyAudio references from `pyproject.toml`, documentation, and scripts.
- Update tests and mocks (`tests/mocks/audio.py`, `tests/test_audio_e2e.py`) to verify `sounddevice` integration.
- Add safety check to reject 24-bit audio playback (not natively supported by numpy) to prevent silent data corruption.