### PR TITLE
feat(rag): add RagIndex composable abstraction for personal knowledge systems

### DIFF
--- a/agent_cli/rag/index.py
+++ b/agent_cli/rag/index.py
@@ -1,0 +1,309 @@
+"""RagIndex - Composable RAG abstraction for indexing and search."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from agent_cli.constants import (
+    DEFAULT_OPENAI_BASE_URL,
+    DEFAULT_OPENAI_EMBEDDING_MODEL,
+)
+from agent_cli.core.chroma import init_collection
+from agent_cli.rag._retriever import get_reranker_model, predict_relevance
+from agent_cli.rag._utils import chunk_text, load_document_text
+from agent_cli.rag.models import RagSource, RetrievalResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from chromadb import Collection
+
+    from agent_cli.rag._retriever import OnnxCrossEncoder
+
+logger = logging.getLogger("agent_cli.rag.index")
+
+
+class RagIndex:
+    """A composable RAG index for adding documents and searching.
+
+    Designed for building personal knowledge systems. Supports:
+    - Adding raw text with metadata (for chat ingestion)
+    - Adding files (auto-chunked)
+    - Search with metadata filtering
+    - Delete by ID or metadata filter
+
+    Example:
+        index = RagIndex(chroma_path=Path("./my_index"))
+        index.add("User asked about Python", metadata={"source": "chatgpt"})
+        results = index.search("Python", filters={"source": "chatgpt"})
+
+    """
+
+    def __init__(
+        self,
+        chroma_path: Path,
+        embedding_model: str = DEFAULT_OPENAI_EMBEDDING_MODEL,
+        openai_base_url: str = DEFAULT_OPENAI_BASE_URL,
+        openai_api_key: str | None = None,
+        collection_name: str = "rag_index",
+        chunk_size: int = 800,
+        chunk_overlap: int = 200,
+    ) -> None:
+        """Initialize the RAG index.
+
+        Args:
+            chroma_path: Path for ChromaDB persistence.
+            embedding_model: OpenAI embedding model name.
+            openai_base_url: Base URL for embedding API.
+            openai_api_key: API key for embeddings.
+            collection_name: Name of the ChromaDB collection.
+            chunk_size: Maximum chunk size in characters.
+            chunk_overlap: Overlap between chunks in characters.
+
+        """
+        self.chroma_path = chroma_path
+        self._chunk_size = chunk_size
+        self._chunk_overlap = chunk_overlap
+
+        logger.info("Initializing RAG index at %s", chroma_path)
+        self.collection: Collection = init_collection(
+            chroma_path,
+            name=collection_name,
+            embedding_model=embedding_model,
+            openai_base_url=openai_base_url,
+            openai_api_key=openai_api_key,
+        )
+
+        logger.info("Loading reranker model...")
+        self.reranker: OnnxCrossEncoder = get_reranker_model()
+
+    def add(
+        self,
+        text: str,
+        metadata: dict[str, Any] | None = None,
+        doc_id: str | None = None,
+    ) -> str:
+        """Add text to the index.
+
+        Text is automatically chunked if it exceeds chunk_size.
+
+        Args:
+            text: The text content to add.
+            metadata: Optional metadata dict (e.g., {"source": "chatgpt"}).
+            doc_id: Optional document ID. Auto-generated if not provided.
+
+        Returns:
+            The document ID (useful for deletion).
+
+        """
+        doc_id = doc_id or str(uuid.uuid4())
+        metadata = metadata or {}
+
+        # Add indexing timestamp
+        metadata["indexed_at"] = datetime.now(UTC).isoformat()
+        metadata["doc_id"] = doc_id
+
+        # Chunk the text
+        chunks = chunk_text(text, self._chunk_size, self._chunk_overlap)
+
+        if not chunks:
+            logger.warning("No chunks generated for doc_id=%s", doc_id)
+            return doc_id
+
+        # Generate chunk IDs and metadata
+        ids = [f"{doc_id}:{i}" for i in range(len(chunks))]
+        metadatas = [
+            {
+                **metadata,
+                "chunk_index": i,
+                "total_chunks": len(chunks),
+            }
+            for i in range(len(chunks))
+        ]
+
+        # Upsert to collection
+        self.collection.upsert(ids=ids, documents=chunks, metadatas=metadatas)
+        logger.info("Added doc_id=%s with %d chunks", doc_id, len(chunks))
+
+        return doc_id
+
+    def add_file(
+        self,
+        file_path: Path,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Add a file to the index.
+
+        File is read, chunked, and indexed with file metadata.
+
+        Args:
+            file_path: Path to the file to add.
+            metadata: Optional additional metadata.
+
+        Returns:
+            The document ID.
+
+        Raises:
+            ValueError: If file cannot be read.
+
+        """
+        text = load_document_text(file_path)
+        if text is None:
+            msg = f"Could not read file: {file_path}"
+            raise ValueError(msg)
+
+        file_metadata = {
+            "source": file_path.name,
+            "file_path": str(file_path),
+            "file_type": file_path.suffix.lstrip("."),
+            **(metadata or {}),
+        }
+
+        return self.add(text, file_metadata)
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> RetrievalResult:
+        """Search the index with optional metadata filtering.
+
+        Uses bi-encoder for initial retrieval, then cross-encoder for reranking.
+
+        Args:
+            query: The search query.
+            top_k: Number of results to return.
+            filters: ChromaDB where clause (e.g., {"source": "chatgpt"}).
+
+        Returns:
+            RetrievalResult with context string and sources.
+
+        """
+        # Over-fetch for reranking
+        n_candidates = top_k * 3
+
+        # Query with optional filter
+        results = self.collection.query(
+            query_texts=[query],
+            n_results=n_candidates,
+            where=filters,
+            include=["documents", "metadatas", "distances"],
+        )
+
+        docs = results.get("documents", [[]])[0]
+        metas = results.get("metadatas", [[]])[0]
+
+        if not docs:
+            return RetrievalResult(context="", sources=[])
+
+        # Rerank
+        pairs = [(query, doc) for doc in docs]
+        scores = predict_relevance(self.reranker, pairs)
+
+        # Sort by score, take top_k
+        ranked = sorted(
+            zip(docs, metas, scores, strict=False),
+            key=lambda x: x[2],
+            reverse=True,
+        )[:top_k]
+
+        # Build context string
+        context_parts = []
+        for doc, meta, _score in ranked:
+            source = meta.get("source", "unknown")
+            chunk_idx = meta.get("chunk_index", 0)
+            context_parts.append(f"### {source} (chunk {chunk_idx})\n{doc}")
+
+        context = "\n\n---\n\n".join(context_parts)
+
+        # Build sources
+        sources = [
+            RagSource(
+                source=meta.get("source", "unknown"),
+                path=meta.get("file_path", meta.get("doc_id", "unknown")),
+                chunk_id=meta.get("chunk_index", 0),
+                score=float(score),
+            )
+            for _doc, meta, score in ranked
+        ]
+
+        return RetrievalResult(context=context, sources=sources)
+
+    def delete(self, doc_id: str) -> int:
+        """Delete all chunks for a document ID.
+
+        Args:
+            doc_id: The document ID to delete.
+
+        Returns:
+            Number of chunks deleted.
+
+        """
+        # Get all chunk IDs for this doc_id
+        results = self.collection.get(
+            where={"doc_id": doc_id},
+            include=[],
+        )
+        ids = results.get("ids", [])
+
+        if ids:
+            self.collection.delete(ids=ids)
+            logger.info("Deleted %d chunks for doc_id=%s", len(ids), doc_id)
+
+        return len(ids)
+
+    def delete_by_metadata(self, filters: dict[str, Any]) -> int:
+        """Delete all documents matching a metadata filter.
+
+        Args:
+            filters: ChromaDB where clause.
+
+        Returns:
+            Number of chunks deleted.
+
+        """
+        results = self.collection.get(
+            where=filters,
+            include=[],
+        )
+        ids = results.get("ids", [])
+
+        if ids:
+            self.collection.delete(ids=ids)
+            logger.info("Deleted %d chunks matching filters=%s", len(ids), filters)
+
+        return len(ids)
+
+    def count(self, filters: dict[str, Any] | None = None) -> int:
+        """Count documents in the index.
+
+        Args:
+            filters: Optional ChromaDB where clause.
+
+        Returns:
+            Number of chunks (not documents).
+
+        """
+        if filters is None:
+            return self.collection.count()
+
+        results = self.collection.get(where=filters, include=[])
+        return len(results.get("ids", []))
+
+    def list_sources(self) -> list[str]:
+        """List unique source values in the index.
+
+        Returns:
+            Sorted list of unique source values.
+
+        """
+        results = self.collection.get(include=["metadatas"])
+        metadatas = results.get("metadatas", []) or []
+
+        sources = {meta.get("source") for meta in metadatas if meta and meta.get("source")}
+
+        return sorted(sources)

--- a/tests/rag/test_rag_index.py
+++ b/tests/rag/test_rag_index.py
@@ -1,0 +1,263 @@
+"""Tests for RagIndex."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from agent_cli.rag.index import RagIndex
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _DummyReranker:
+    """Dummy reranker for testing."""
+
+    def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        # Return decreasing scores so first doc ranks highest
+        return [1.0 - i * 0.1 for i in range(len(pairs))]
+
+
+class _FakeCollection:
+    """Minimal Chroma-like collection for testing."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[str, dict[str, Any]]] = {}
+
+    def upsert(
+        self,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+    ) -> None:
+        for doc_id, doc, meta in zip(ids, documents, metadatas, strict=False):
+            self._store[doc_id] = (doc, meta)
+
+    def query(
+        self,
+        *,
+        query_texts: list[str],  # noqa: ARG002
+        n_results: int,
+        where: dict[str, Any] | None = None,
+        include: list[str] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        # Filter by where clause
+        items = []
+        for doc_id, (doc, meta) in self._store.items():
+            if where:
+                # Simple equality filter
+                match = all(meta.get(k) == v for k, v in where.items())
+                if not match:
+                    continue
+            items.append((doc_id, doc, meta))
+
+        items = items[:n_results]
+        docs = [doc for _, doc, _ in items]
+        metas = [meta for _, _, meta in items]
+        ids = [doc_id for doc_id, _, _ in items]
+        return {
+            "documents": [docs],
+            "metadatas": [metas],
+            "ids": [ids],
+            "distances": [[0.0] * len(docs)],
+        }
+
+    def get(
+        self,
+        *,
+        where: dict[str, Any] | None = None,
+        include: list[str] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        items = []
+        for doc_id, (doc, meta) in self._store.items():
+            if where:
+                match = all(meta.get(k) == v for k, v in where.items())
+                if not match:
+                    continue
+            items.append((doc_id, doc, meta))
+
+        docs = [doc for _, doc, _ in items]
+        metas = [meta for _, _, meta in items]
+        ids = [doc_id for doc_id, _, _ in items]
+        return {"documents": docs, "metadatas": metas, "ids": ids}
+
+    def count(self) -> int:
+        return len(self._store)
+
+    def delete(
+        self,
+        ids: list[str] | None = None,
+        where: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> None:
+        if ids:
+            for doc_id in ids:
+                self._store.pop(doc_id, None)
+
+
+@pytest.fixture
+def rag_index(tmp_path: Path) -> RagIndex:
+    """Create a RagIndex for testing with mocked dependencies."""
+    with (
+        patch(
+            "agent_cli.rag.index.init_collection",
+            return_value=_FakeCollection(),
+        ),
+        patch(
+            "agent_cli.rag.index.get_reranker_model",
+            return_value=_DummyReranker(),
+        ),
+    ):
+        return RagIndex(chroma_path=tmp_path / "chroma")
+
+
+def test_add_text(rag_index: RagIndex) -> None:
+    """Test adding raw text."""
+    doc_id = rag_index.add("Hello world, this is a test.")
+    assert doc_id is not None
+    assert rag_index.count() == 1
+
+
+def test_add_text_with_metadata(rag_index: RagIndex) -> None:
+    """Test adding text with custom metadata."""
+    doc_id = rag_index.add(
+        "Python is a great language",
+        metadata={"source": "chatgpt", "topic": "programming"},
+    )
+    assert doc_id is not None
+
+    # Verify metadata is stored
+    results = rag_index.collection.get(where={"source": "chatgpt"})
+    assert len(results["ids"]) == 1
+    assert results["metadatas"][0]["topic"] == "programming"
+
+
+def test_add_text_with_custom_id(rag_index: RagIndex) -> None:
+    """Test adding text with a custom document ID."""
+    doc_id = rag_index.add("Test content", doc_id="my-custom-id")
+    assert doc_id == "my-custom-id"
+
+
+def test_add_file(rag_index: RagIndex, tmp_path: Path) -> None:
+    """Test adding a file."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("This is file content for testing.")
+
+    doc_id = rag_index.add_file(test_file)
+    assert doc_id is not None
+    assert rag_index.count() == 1
+
+    # Check file metadata
+    results = rag_index.collection.get(include=["metadatas"])
+    meta = results["metadatas"][0]
+    assert meta["source"] == "test.txt"
+    assert meta["file_type"] == "txt"
+
+
+def test_add_file_not_found(rag_index: RagIndex, tmp_path: Path) -> None:
+    """Test adding a non-existent file raises error."""
+    with pytest.raises(ValueError, match="Could not read file"):
+        rag_index.add_file(tmp_path / "nonexistent.txt")
+
+
+def test_search_basic(rag_index: RagIndex) -> None:
+    """Test basic search without filters."""
+    rag_index.add("Python is great for data science", metadata={"source": "doc1"})
+    rag_index.add("JavaScript is used for web development", metadata={"source": "doc2"})
+
+    results = rag_index.search("Python programming")
+    assert results.context != ""
+    assert len(results.sources) > 0
+
+
+def test_search_empty(rag_index: RagIndex) -> None:
+    """Test search on empty index."""
+    results = rag_index.search("anything")
+    assert results.context == ""
+    assert results.sources == []
+
+
+def test_search_with_filters(rag_index: RagIndex) -> None:
+    """Test search with metadata filtering."""
+    rag_index.add("Python tip from ChatGPT", metadata={"source": "chatgpt"})
+    rag_index.add("Python tip from Claude", metadata={"source": "claude"})
+
+    # Search only chatgpt
+    results = rag_index.search("Python", filters={"source": "chatgpt"})
+    assert len(results.sources) == 1
+    assert results.sources[0].source == "chatgpt"
+
+
+def test_delete_by_id(rag_index: RagIndex) -> None:
+    """Test deleting by document ID."""
+    doc_id = rag_index.add("Content to delete")
+    assert rag_index.count() == 1
+
+    deleted = rag_index.delete(doc_id)
+    assert deleted == 1
+    assert rag_index.count() == 0
+
+
+def test_delete_by_metadata(rag_index: RagIndex) -> None:
+    """Test deleting by metadata filter."""
+    rag_index.add("Old content", metadata={"source": "old"})
+    rag_index.add("New content", metadata={"source": "new"})
+    assert rag_index.count() == 2
+
+    deleted = rag_index.delete_by_metadata({"source": "old"})
+    assert deleted == 1
+    assert rag_index.count() == 1
+
+
+def test_count_no_filter(rag_index: RagIndex) -> None:
+    """Test count without filter."""
+    assert rag_index.count() == 0
+
+    rag_index.add("Doc 1")
+    rag_index.add("Doc 2")
+    assert rag_index.count() == 2
+
+
+def test_count_with_filter(rag_index: RagIndex) -> None:
+    """Test count with filter."""
+    rag_index.add("ChatGPT doc", metadata={"source": "chatgpt"})
+    rag_index.add("Claude doc", metadata={"source": "claude"})
+
+    assert rag_index.count(filters={"source": "chatgpt"}) == 1
+    assert rag_index.count(filters={"source": "claude"}) == 1
+    assert rag_index.count() == 2
+
+
+def test_list_sources(rag_index: RagIndex) -> None:
+    """Test listing unique sources."""
+    rag_index.add("Doc 1", metadata={"source": "chatgpt"})
+    rag_index.add("Doc 2", metadata={"source": "claude"})
+    rag_index.add("Doc 3", metadata={"source": "chatgpt"})  # duplicate
+
+    sources = rag_index.list_sources()
+    assert sources == ["chatgpt", "claude"]  # sorted, deduplicated
+
+
+def test_list_sources_empty(rag_index: RagIndex) -> None:
+    """Test listing sources on empty index."""
+    sources = rag_index.list_sources()
+    assert sources == []
+
+
+def test_chunking_long_text(rag_index: RagIndex) -> None:
+    """Test that long text is chunked."""
+    # Create text longer than default chunk size
+    long_text = "This is a sentence. " * 100  # ~2000 chars
+
+    doc_id = rag_index.add(long_text)
+    assert doc_id is not None
+
+    # Should have multiple chunks
+    assert rag_index.count() > 1
+
+    # All chunks should have same doc_id in metadata
+    results = rag_index.collection.get(include=["metadatas"])
+    doc_ids = {meta["doc_id"] for meta in results["metadatas"]}
+    assert doc_ids == {doc_id}


### PR DESCRIPTION
## Summary

- Adds `RagIndex` class - composable RAG abstraction for building personal knowledge systems
- Designed for combining with `MemoryClient` to ingest chat exports and build searchable knowledge bases
- Simpler API than the HTTP proxy - add text/files with metadata, search with filters

## Key Features

- **Add raw text or files** with custom metadata (source, date, topic, etc.)
- **Search with metadata filtering** - find content by source, date range, etc.
- **Delete by ID or metadata filter** - bulk cleanup by source
- **Auto-chunking** with configurable size/overlap
- **Bi-encoder + cross-encoder reranking** for quality results

## API

```python
from agent_cli.rag.index import RagIndex

index = RagIndex(chroma_path=Path("./my_knowledge"))

# Add chat export
index.add(
    text="User: What's the best Python web framework?\nAssistant: It depends...",
    metadata={"source": "chatgpt", "date": "2024-01-15"},
)

# Search with filtering
results = index.search("Python web frameworks", filters={"source": "chatgpt"})

# Combine with MemoryClient for personal knowledge
memory = MemoryClient(...)
facts = await memory.search("Python preferences")
rag_context = index.search("Python frameworks")
```

## Test plan

- [x] 15 unit tests covering add, search, delete, count, list_sources
- [x] 98% code coverage on `index.py`
- [x] All 314 tests pass
- [x] Mypy and ruff pass