### PR TITLE
refactor(rag): rename RagIndex to RagClient for consistency

### DIFF
--- a/agent_cli/rag/client.py
+++ b/agent_cli/rag/client.py
@@ -1,4 +1,4 @@
-"""RagIndex - Composable RAG abstraction for indexing and search."""
+"""RagClient - Composable RAG abstraction for indexing and search."""
 
 from __future__ import annotations
 
@@ -23,10 +23,10 @@ if TYPE_CHECKING:
 
     from agent_cli.rag._retriever import OnnxCrossEncoder
 
-logger = logging.getLogger("agent_cli.rag.index")
+logger = logging.getLogger("agent_cli.rag.client")
 
 
-class RagIndex:
+class RagClient:
     """A composable RAG index for adding documents and searching.
 
     Designed for building personal knowledge systems. Supports:
@@ -36,7 +36,7 @@ class RagIndex:
     - Delete by ID or metadata filter
 
     Example:
-        index = RagIndex(chroma_path=Path("./my_index"))
+        index = RagClient(chroma_path=Path("./my_index"))
         index.add("User asked about Python", metadata={"source": "chatgpt"})
         results = index.search("Python", filters={"source": "chatgpt"})
 

--- a/tests/rag/test_rag_client.py
+++ b/tests/rag/test_rag_client.py
@@ -1,4 +1,4 @@
-"""Tests for RagIndex."""
+"""Tests for RagClient."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from agent_cli.rag.index import RagIndex
+from agent_cli.rag.client import RagClient
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,166 +98,166 @@ class _FakeCollection:
 
 
 @pytest.fixture
-def rag_index(tmp_path: Path) -> RagIndex:
-    """Create a RagIndex for testing with mocked dependencies."""
+def rag_client(tmp_path: Path) -> RagClient:
+    """Create a RagClient for testing with mocked dependencies."""
     with (
         patch(
-            "agent_cli.rag.index.init_collection",
+            "agent_cli.rag.client.init_collection",
             return_value=_FakeCollection(),
         ),
         patch(
-            "agent_cli.rag.index.get_reranker_model",
+            "agent_cli.rag.client.get_reranker_model",
             return_value=_DummyReranker(),
         ),
     ):
-        return RagIndex(chroma_path=tmp_path / "chroma")
+        return RagClient(chroma_path=tmp_path / "chroma")
 
 
-def test_add_text(rag_index: RagIndex) -> None:
+def test_add_text(rag_client: RagClient) -> None:
     """Test adding raw text."""
-    doc_id = rag_index.add("Hello world, this is a test.")
+    doc_id = rag_client.add("Hello world, this is a test.")
     assert doc_id is not None
-    assert rag_index.count() == 1
+    assert rag_client.count() == 1
 
 
-def test_add_text_with_metadata(rag_index: RagIndex) -> None:
+def test_add_text_with_metadata(rag_client: RagClient) -> None:
     """Test adding text with custom metadata."""
-    doc_id = rag_index.add(
+    doc_id = rag_client.add(
         "Python is a great language",
         metadata={"source": "chatgpt", "topic": "programming"},
     )
     assert doc_id is not None
 
     # Verify metadata is stored
-    results = rag_index.collection.get(where={"source": "chatgpt"})
+    results = rag_client.collection.get(where={"source": "chatgpt"})
     assert len(results["ids"]) == 1
     assert results["metadatas"][0]["topic"] == "programming"
 
 
-def test_add_text_with_custom_id(rag_index: RagIndex) -> None:
+def test_add_text_with_custom_id(rag_client: RagClient) -> None:
     """Test adding text with a custom document ID."""
-    doc_id = rag_index.add("Test content", doc_id="my-custom-id")
+    doc_id = rag_client.add("Test content", doc_id="my-custom-id")
     assert doc_id == "my-custom-id"
 
 
-def test_add_file(rag_index: RagIndex, tmp_path: Path) -> None:
+def test_add_file(rag_client: RagClient, tmp_path: Path) -> None:
     """Test adding a file."""
     test_file = tmp_path / "test.txt"
     test_file.write_text("This is file content for testing.")
 
-    doc_id = rag_index.add_file(test_file)
+    doc_id = rag_client.add_file(test_file)
     assert doc_id is not None
-    assert rag_index.count() == 1
+    assert rag_client.count() == 1
 
     # Check file metadata
-    results = rag_index.collection.get(include=["metadatas"])
+    results = rag_client.collection.get(include=["metadatas"])
     meta = results["metadatas"][0]
     assert meta["source"] == "test.txt"
     assert meta["file_type"] == "txt"
 
 
-def test_add_file_not_found(rag_index: RagIndex, tmp_path: Path) -> None:
+def test_add_file_not_found(rag_client: RagClient, tmp_path: Path) -> None:
     """Test adding a non-existent file raises error."""
     with pytest.raises(ValueError, match="Could not read file"):
-        rag_index.add_file(tmp_path / "nonexistent.txt")
+        rag_client.add_file(tmp_path / "nonexistent.txt")
 
 
-def test_search_basic(rag_index: RagIndex) -> None:
+def test_search_basic(rag_client: RagClient) -> None:
     """Test basic search without filters."""
-    rag_index.add("Python is great for data science", metadata={"source": "doc1"})
-    rag_index.add("JavaScript is used for web development", metadata={"source": "doc2"})
+    rag_client.add("Python is great for data science", metadata={"source": "doc1"})
+    rag_client.add("JavaScript is used for web development", metadata={"source": "doc2"})
 
-    results = rag_index.search("Python programming")
+    results = rag_client.search("Python programming")
     assert results.context != ""
     assert len(results.sources) > 0
 
 
-def test_search_empty(rag_index: RagIndex) -> None:
+def test_search_empty(rag_client: RagClient) -> None:
     """Test search on empty index."""
-    results = rag_index.search("anything")
+    results = rag_client.search("anything")
     assert results.context == ""
     assert results.sources == []
 
 
-def test_search_with_filters(rag_index: RagIndex) -> None:
+def test_search_with_filters(rag_client: RagClient) -> None:
     """Test search with metadata filtering."""
-    rag_index.add("Python tip from ChatGPT", metadata={"source": "chatgpt"})
-    rag_index.add("Python tip from Claude", metadata={"source": "claude"})
+    rag_client.add("Python tip from ChatGPT", metadata={"source": "chatgpt"})
+    rag_client.add("Python tip from Claude", metadata={"source": "claude"})
 
     # Search only chatgpt
-    results = rag_index.search("Python", filters={"source": "chatgpt"})
+    results = rag_client.search("Python", filters={"source": "chatgpt"})
     assert len(results.sources) == 1
     assert results.sources[0].source == "chatgpt"
 
 
-def test_delete_by_id(rag_index: RagIndex) -> None:
+def test_delete_by_id(rag_client: RagClient) -> None:
     """Test deleting by document ID."""
-    doc_id = rag_index.add("Content to delete")
-    assert rag_index.count() == 1
+    doc_id = rag_client.add("Content to delete")
+    assert rag_client.count() == 1
 
-    deleted = rag_index.delete(doc_id)
+    deleted = rag_client.delete(doc_id)
     assert deleted == 1
-    assert rag_index.count() == 0
+    assert rag_client.count() == 0
 
 
-def test_delete_by_metadata(rag_index: RagIndex) -> None:
+def test_delete_by_metadata(rag_client: RagClient) -> None:
     """Test deleting by metadata filter."""
-    rag_index.add("Old content", metadata={"source": "old"})
-    rag_index.add("New content", metadata={"source": "new"})
-    assert rag_index.count() == 2
+    rag_client.add("Old content", metadata={"source": "old"})
+    rag_client.add("New content", metadata={"source": "new"})
+    assert rag_client.count() == 2
 
-    deleted = rag_index.delete_by_metadata({"source": "old"})
+    deleted = rag_client.delete_by_metadata({"source": "old"})
     assert deleted == 1
-    assert rag_index.count() == 1
+    assert rag_client.count() == 1
 
 
-def test_count_no_filter(rag_index: RagIndex) -> None:
+def test_count_no_filter(rag_client: RagClient) -> None:
     """Test count without filter."""
-    assert rag_index.count() == 0
+    assert rag_client.count() == 0
 
-    rag_index.add("Doc 1")
-    rag_index.add("Doc 2")
-    assert rag_index.count() == 2
+    rag_client.add("Doc 1")
+    rag_client.add("Doc 2")
+    assert rag_client.count() == 2
 
 
-def test_count_with_filter(rag_index: RagIndex) -> None:
+def test_count_with_filter(rag_client: RagClient) -> None:
     """Test count with filter."""
-    rag_index.add("ChatGPT doc", metadata={"source": "chatgpt"})
-    rag_index.add("Claude doc", metadata={"source": "claude"})
+    rag_client.add("ChatGPT doc", metadata={"source": "chatgpt"})
+    rag_client.add("Claude doc", metadata={"source": "claude"})
 
-    assert rag_index.count(filters={"source": "chatgpt"}) == 1
-    assert rag_index.count(filters={"source": "claude"}) == 1
-    assert rag_index.count() == 2
+    assert rag_client.count(filters={"source": "chatgpt"}) == 1
+    assert rag_client.count(filters={"source": "claude"}) == 1
+    assert rag_client.count() == 2
 
 
-def test_list_sources(rag_index: RagIndex) -> None:
+def test_list_sources(rag_client: RagClient) -> None:
     """Test listing unique sources."""
-    rag_index.add("Doc 1", metadata={"source": "chatgpt"})
-    rag_index.add("Doc 2", metadata={"source": "claude"})
-    rag_index.add("Doc 3", metadata={"source": "chatgpt"})  # duplicate
+    rag_client.add("Doc 1", metadata={"source": "chatgpt"})
+    rag_client.add("Doc 2", metadata={"source": "claude"})
+    rag_client.add("Doc 3", metadata={"source": "chatgpt"})  # duplicate
 
-    sources = rag_index.list_sources()
+    sources = rag_client.list_sources()
     assert sources == ["chatgpt", "claude"]  # sorted, deduplicated
 
 
-def test_list_sources_empty(rag_index: RagIndex) -> None:
+def test_list_sources_empty(rag_client: RagClient) -> None:
     """Test listing sources on empty index."""
-    sources = rag_index.list_sources()
+    sources = rag_client.list_sources()
     assert sources == []
 
 
-def test_chunking_long_text(rag_index: RagIndex) -> None:
+def test_chunking_long_text(rag_client: RagClient) -> None:
     """Test that long text is chunked."""
     # Create text longer than default chunk size
     long_text = "This is a sentence. " * 100  # ~2000 chars
 
-    doc_id = rag_index.add(long_text)
+    doc_id = rag_client.add(long_text)
     assert doc_id is not None
 
     # Should have multiple chunks
-    assert rag_index.count() > 1
+    assert rag_client.count() > 1
 
     # All chunks should have same doc_id in metadata
-    results = rag_index.collection.get(include=["metadatas"])
+    results = rag_client.collection.get(include=["metadatas"])
     doc_ids = {meta["doc_id"] for meta in results["metadatas"]}
     assert doc_ids == {doc_id}


### PR DESCRIPTION
## Summary

- Renames `RagIndex` → `RagClient` for consistency with `MemoryClient`
- Renames files: `index.py` → `client.py`, `test_rag_index.py` → `test_rag_client.py`
- Updates logger name and test fixture names

## Rationale

| Class | Purpose |
|-------|---------|
| `MemoryClient` | Add/search/delete facts |
| `RagClient` | Add/search/delete documents |

Same pattern, same naming convention.

## Test plan

- [x] All 15 RagClient tests pass
- [x] All 314 tests pass
- [x] 98% coverage on `client.py`