### PR TITLE
fix(memory): adopt mem0-style reconciliation prompt for correct ADD/UPDATE decisions

### DIFF
--- a/agent_cli/memory/_ingest.py
+++ b/agent_cli/memory/_ingest.py
@@ -227,28 +227,6 @@ async def reconcile_facts(
         created_at=created_at,
     )
 
-    # Safeguard: if the model produced no additions and the new facts would otherwise be lost,
-    # retain the new facts. This prevents ending up with an empty fact set after deletes.
-    # We trust the LLM if it explicitly decided to KEEP (NONE) or ADD/UPDATE content.
-    # We only override if it returned nothing or only DELETEs (which implies replacement failure).
-    has_keep_action = any(d.event in ("ADD", "UPDATE", "NONE") for d in decisions)
-
-    if not has_keep_action and new_facts:
-        LOGGER.info(
-            "Reconcile produced no additions/keeps; retaining new facts to avoid empty store",
-        )
-        to_add = [
-            Fact(
-                id=str(uuid4()),
-                conversation_id=conversation_id,
-                content=f,
-                source_id=source_id,
-                created_at=created_at,
-            )
-            for f in new_facts
-            if f.strip()
-        ]
-
     LOGGER.info(
         "Reconcile decisions: add=%d, delete=%d, events=%s",
         len(to_add),


### PR DESCRIPTION
The previous prompt only asked for decisions about new facts, causing models to incorrectly choose UPDATE for unrelated topics. This adopts mem0's approach:

1. Require model to output ALL memories (existing + new) in response
2. Each existing memory must have an explicit event (NONE, UPDATE, DELETE)
3. New unrelated facts get ADD with a new sequential ID
4. Clear examples showing NONE for unrelated + ADD for new facts

Changes:
- Update UPDATE_MEMORY_PROMPT with mem0-style format requiring {"memory": [...]}
- Add MemoryUpdateResponse wrapper model for structured parsing
- Update reconcile_facts to use MemoryUpdateResponse output type
- Update test to match new response format

This forces the model to be deliberate about every decision rather than just outputting changes, fixing the semantic similarity judgment issue.