### PR TITLE
feat(memory): add output validation with ModelRetry for reconciliation

### DIFF
--- a/agent_cli/memory/_ingest.py
+++ b/agent_cli/memory/_ingest.py
@@ -121,9 +121,10 @@ def process_reconciliation_decisions(
                 )
         elif isinstance(dec, MemoryUpdate):
             orig = id_map.get(dec.id)
-            if orig:
-                text = dec.text.strip()
-                if text:
+            text = dec.text.strip()
+            if text:
+                if orig:
+                    # Update existing memory: delete old, add new
                     new_id = str(uuid4())
                     to_delete.append(orig)
                     to_add.append(
@@ -136,6 +137,17 @@ def process_reconciliation_decisions(
                         ),
                     )
                     replacement_map[orig] = new_id
+                else:
+                    # UPDATE with unknown ID = treat as ADD (model used wrong event)
+                    to_add.append(
+                        Fact(
+                            id=str(uuid4()),
+                            conversation_id=conversation_id,
+                            content=text,
+                            source_id=source_id,
+                            created_at=created_at,
+                        ),
+                    )
         elif isinstance(dec, MemoryDelete):
             orig = id_map.get(dec.id)
             if orig:
@@ -178,8 +190,9 @@ async def reconcile_facts(
         return entries, [], {}
     id_map: dict[int, str] = {idx: mem.id for idx, mem in enumerate(existing)}
     existing_json = [{"id": idx, "text": mem.content} for idx, mem in enumerate(existing)]
+    existing_ids = set(id_map.keys())
 
-    from pydantic_ai import Agent  # noqa: PLC0415
+    from pydantic_ai import Agent, ModelRetry  # noqa: PLC0415
     from pydantic_ai.exceptions import AgentRunError, UnexpectedModelBehavior  # noqa: PLC0415
     from pydantic_ai.models.openai import OpenAIChatModel  # noqa: PLC0415
     from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
@@ -198,9 +211,43 @@ async def reconcile_facts(
         retries=3,
     )
 
-    payload_obj = {"existing": existing_json, "new_facts": new_facts}
-    payload = json.dumps(payload_obj, ensure_ascii=False, indent=2)
-    LOGGER.info("Reconcile payload JSON: %s", payload)
+    @agent.output_validator
+    def validate_decisions(decisions: list[MemoryDecision]) -> list[MemoryDecision]:
+        """Validate LLM decisions and provide feedback for retry."""
+        errors = []
+        for dec in decisions:
+            if (
+                isinstance(dec, (MemoryUpdate, MemoryDelete, MemoryIgnore))
+                and dec.id not in existing_ids
+            ):
+                if isinstance(dec, MemoryUpdate):
+                    errors.append(
+                        f"UPDATE with id={dec.id} is invalid: that ID doesn't exist. "
+                        f"Valid existing IDs are: {sorted(existing_ids)}. "
+                        f"For NEW facts, use ADD with a new ID.",
+                    )
+                elif isinstance(dec, MemoryDelete):
+                    errors.append(f"DELETE with id={dec.id} is invalid: that ID doesn't exist.")
+                else:  # MemoryIgnore (NONE)
+                    errors.append(f"NONE with id={dec.id} is invalid: that ID doesn't exist.")
+        if errors:
+            msg = "Invalid memory decisions:\n" + "\n".join(f"- {e}" for e in errors)
+            raise ModelRetry(msg)
+        return decisions
+
+    # Format with separate sections for existing and new facts
+    existing_str = json.dumps(existing_json, ensure_ascii=False, indent=2)
+    new_facts_str = json.dumps(new_facts, ensure_ascii=False, indent=2)
+    payload = f"""Current memory:
+```
+{existing_str}
+```
+
+New facts to process:
+```
+{new_facts_str}
+```"""
+    LOGGER.info("Reconcile payload: %s", payload)
     try:
         result = await agent.run(payload)
         decisions = result.output

--- a/agent_cli/memory/_prompt.py
+++ b/agent_cli/memory/_prompt.py
@@ -21,67 +21,68 @@ FACT_INSTRUCTIONS = """
 Return only factual sentences grounded in the user text. No assistant acknowledgements or meta-text.
 """.strip()
 
-UPDATE_MEMORY_PROMPT = """
-You are a smart memory manager which controls the memory of a system.
-You can perform four operations: (1) ADD into memory, (2) UPDATE memory, (3) DELETE from memory, (4) NONE (no change).
+UPDATE_MEMORY_PROMPT = """You are a smart memory manager which controls the memory of a system.
+You can perform four operations: (1) ADD into the memory, (2) UPDATE the memory, (3) DELETE from the memory, and (4) NONE (no change).
 
-For each new fact, compare it with existing memories and decide what to do.
+Compare new facts with existing memory. For each new fact, decide whether to:
+- ADD: Add it to the memory as a new element (new information not present in any existing memory)
+- UPDATE: Update an existing memory element (only if facts are about THE SAME TOPIC, e.g., both about pizza preferences)
+- DELETE: Delete an existing memory element (if new fact explicitly contradicts it)
+- NONE: Make no change (if fact is already present, a duplicate, or the existing memory is unrelated to new facts)
 
-Guidelines:
+**Guidelines:**
 
-1. **ADD**: New fact contains information NOT present in any existing memory.
-   - Generate a new ID for added memories (next sequential integer).
-   - Existing unrelated memories remain unchanged (NONE).
+1. **ADD**: If the new fact contains new information not present in any existing memory, add it with a new ID.
+   - Existing unrelated memories should have event "NONE".
+- **Example**:
+    - Current memory: [{"id": 0, "text": "User is a software engineer"}]
+    - New facts: ["Name is John"]
+    - Output: [
+        {"id": 0, "text": "User is a software engineer", "event": "NONE"},
+        {"id": 1, "text": "Name is John", "event": "ADD"}
+      ]
 
-2. **UPDATE**: New fact refines/expands an existing memory about THE SAME TOPIC.
+2. **UPDATE**: Only if the new fact refines/expands an existing memory about THE SAME TOPIC.
    - Keep the same ID, update the text.
-   - Only update if facts are about the same subject (e.g., both about pizza preferences).
+   - Example: "User likes pizza" + "User loves pepperoni pizza" → UPDATE (same topic: pizza)
+   - Example: "Met Sarah today" + "Went running" → NOT same topic, do NOT update!
+- **Example**:
+    - Current memory: [{"id": 0, "text": "User likes pizza"}]
+    - New facts: ["User loves pepperoni pizza"]
+    - Output: [{"id": 0, "text": "User loves pepperoni pizza", "event": "UPDATE"}]
 
-3. **DELETE**: New fact explicitly contradicts an existing memory.
-   - Mark the old memory for deletion.
+3. **DELETE**: If the new fact explicitly contradicts an existing memory.
+- **Example**:
+    - Current memory: [{"id": 0, "text": "Loves pizza"}, {"id": 1, "text": "Name is John"}]
+    - New facts: ["Hates pizza"]
+    - Output: [
+        {"id": 0, "text": "Loves pizza", "event": "DELETE"},
+        {"id": 1, "text": "Name is John", "event": "NONE"},
+        {"id": 2, "text": "Hates pizza", "event": "ADD"}
+      ]
 
-4. **NONE**: Existing memory is unrelated to new facts, OR new fact is exact duplicate.
-   - No change needed.
+4. **NONE**: If the new fact is already present or existing memory is unrelated to new facts.
+- **Example**:
+    - Current memory: [{"id": 0, "text": "Name is John"}]
+    - New facts: ["Name is John"]
+    - Output: [{"id": 0, "text": "Name is John", "event": "NONE"}]
 
-**CRITICAL**: You must return ALL memories (existing + new) in your response.
-Each existing memory must have an event (NONE, UPDATE, or DELETE).
-Each new unrelated fact must be ADDed with a new ID.
+5. **IMPORTANT - Unrelated topics example**:
+    - Current memory: [{"id": 0, "text": "Met Sarah to discuss quantum computing"}]
+    - New facts: ["Went for a 5km run"]
+    - These are COMPLETELY DIFFERENT topics (meeting vs running). Do NOT use UPDATE!
+    - Output: [
+        {"id": 0, "text": "Met Sarah to discuss quantum computing", "event": "NONE"},
+        {"id": 1, "text": "Went for a 5km run", "event": "ADD"}
+      ]
 
-Examples:
+**CRITICAL RULES:**
+- You MUST return ALL memories (existing + new) in your response.
+- Each existing memory MUST have an event (NONE, UPDATE, or DELETE).
+- Each genuinely NEW fact (not related to any existing memory) MUST be ADDed with a new ID.
+- Do NOT use UPDATE for unrelated topics! "Met Sarah" and "Went running" are DIFFERENT topics → use NONE for existing + ADD for new.
 
-1. UNRELATED new fact → ADD it, existing stays NONE
-   Existing: [{"id": 0, "text": "User is a software engineer"}]
-   New facts: ["Name is John"]
-   Output: [
-     {"id": 0, "text": "User is a software engineer", "event": "NONE"},
-     {"id": 1, "text": "Name is John", "event": "ADD"}
-   ]
-
-2. RELATED facts (same topic) → UPDATE existing
-   Existing: [{"id": 0, "text": "User likes pizza"}]
-   New facts: ["User loves pepperoni pizza"]
-   Output: [
-     {"id": 0, "text": "User loves pepperoni pizza", "event": "UPDATE"}
-   ]
-
-3. CONTRADICTING facts → DELETE old
-   Existing: [{"id": 0, "text": "Loves pizza"}, {"id": 1, "text": "Name is John"}]
-   New facts: ["Hates pizza"]
-   Output: [
-     {"id": 0, "text": "Loves pizza", "event": "DELETE"},
-     {"id": 1, "text": "Name is John", "event": "NONE"},
-     {"id": 2, "text": "Hates pizza", "event": "ADD"}
-   ]
-
-4. DUPLICATE → NONE for all
-   Existing: [{"id": 0, "text": "Name is John"}]
-   New facts: ["Name is John"]
-   Output: [
-     {"id": 0, "text": "Name is John", "event": "NONE"}
-   ]
-
-Return ONLY a JSON list. No prose or code fences.
-""".strip()
+Return ONLY a JSON list. No prose or code fences.""".strip()
 
 SUMMARY_PROMPT = """
 You are a concise conversation summarizer. Update the running summary with the new facts.


### PR DESCRIPTION
## Summary
- Add structured output validation using pydantic_ai's ModelRetry
- Ensures LLM responses conform to expected JSON schema during memory reconciliation

## Changes
- `agent_cli/memory/_ingest.py`: Add ModelRetry validation wrapper
- `agent_cli/memory/_prompt.py`: Update prompts for structured output