### PR TITLE
perf: lazy imports for pydantic_ai, sounddevice, and numpy

### DIFF
--- a/agent_cli/core/audio.py
+++ b/agent_cli/core/audio.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-import sounddevice as sd
 from rich.text import Text
 
 from agent_cli import constants
@@ -23,6 +22,7 @@ from agent_cli.core.utils import (
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 
+    import sounddevice as sd
     from rich.live import Live
 
     from agent_cli import config
@@ -41,6 +41,8 @@ class StreamConfig:
 
     def to_stream(self) -> sd.Stream:
         """Create a SoundDevice stream from this configuration."""
+        import sounddevice as sd  # noqa: PLC0415
+
         if self.kind == "input":
             stream_cls = sd.InputStream
         elif self.kind == "output":
@@ -308,6 +310,8 @@ def _get_all_devices() -> list[dict]:
         List of device info dictionaries with added 'index' field
 
     """
+    import sounddevice as sd  # noqa: PLC0415
+
     devices = []
     try:
         query_result = sd.query_devices()

--- a/agent_cli/memory/_ingest.py
+++ b/agent_cli/memory/_ingest.py
@@ -10,11 +10,6 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import httpx
-from pydantic_ai import Agent
-from pydantic_ai.exceptions import AgentRunError, UnexpectedModelBehavior
-from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.providers.openai import OpenAIProvider
-from pydantic_ai.settings import ModelSettings
 
 from agent_cli.memory._git import commit_changes
 from agent_cli.memory._persistence import delete_memory_files, persist_entries, persist_summary
@@ -62,6 +57,11 @@ async def extract_salient_facts(
     """Run an LLM agent to extract facts from the transcript."""
     if not user_message and not assistant_message:
         return []
+
+    from pydantic_ai import Agent  # noqa: PLC0415
+    from pydantic_ai.exceptions import AgentRunError, UnexpectedModelBehavior  # noqa: PLC0415
+    from pydantic_ai.models.openai import OpenAIChatModel  # noqa: PLC0415
+    from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
 
     # Extract facts from the latest user turn only (ignore assistant/system).
     transcript = user_message or ""
@@ -179,6 +179,12 @@ async def reconcile_facts(
     id_map: dict[int, str] = {idx: mem.id for idx, mem in enumerate(existing)}
     existing_json = [{"id": idx, "text": mem.content} for idx, mem in enumerate(existing)]
 
+    from pydantic_ai import Agent  # noqa: PLC0415
+    from pydantic_ai.exceptions import AgentRunError, UnexpectedModelBehavior  # noqa: PLC0415
+    from pydantic_ai.models.openai import OpenAIChatModel  # noqa: PLC0415
+    from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
+    from pydantic_ai.settings import ModelSettings  # noqa: PLC0415
+
     provider = OpenAIProvider(api_key=api_key or "dummy", base_url=openai_base_url)
     model_cfg = OpenAIChatModel(
         model_name=model,
@@ -248,6 +254,12 @@ async def update_summary(
     """Update the conversation summary based on new facts."""
     if not new_facts:
         return prior_summary
+
+    from pydantic_ai import Agent  # noqa: PLC0415
+    from pydantic_ai.models.openai import OpenAIChatModel  # noqa: PLC0415
+    from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
+    from pydantic_ai.settings import ModelSettings  # noqa: PLC0415
+
     system_prompt = SUMMARY_PROMPT
     user_parts: list[str] = []
     if prior_summary:

--- a/agent_cli/rag/_retriever.py
+++ b/agent_cli/rag/_retriever.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import numpy as np
 from huggingface_hub import hf_hub_download
 from onnxruntime import InferenceSession
 from transformers import AutoTokenizer
@@ -68,6 +67,8 @@ class OnnxCrossEncoder:
         batch_size: int = 32,
     ) -> list[float]:
         """Predict relevance scores for query-document pairs."""
+        import numpy as np  # noqa: PLC0415
+
         if not pairs:
             return []
 

--- a/agent_cli/rag/engine.py
+++ b/agent_cli/rag/engine.py
@@ -9,16 +9,6 @@ from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Any
 
 from fastapi.responses import StreamingResponse
-from pydantic_ai import Agent
-from pydantic_ai.messages import (
-    ModelRequest,
-    ModelResponse,
-    SystemPromptPart,
-    TextPart,
-    UserPromptPart,
-)
-from pydantic_ai.models.openai import OpenAIModel
-from pydantic_ai.providers.openai import OpenAIProvider
 
 from agent_cli.core.sse import format_chunk, format_done
 from agent_cli.rag._prompt import RAG_PROMPT_NO_TOOLS, RAG_PROMPT_WITH_TOOLS
@@ -28,6 +18,8 @@ from agent_cli.rag.models import Message, RetrievalResult  # noqa: TC001
 
 if TYPE_CHECKING:
     from chromadb import Collection
+    from pydantic_ai import Agent
+    from pydantic_ai.messages import ModelRequest, ModelResponse
     from pydantic_ai.result import RunResult
 
     from agent_cli.rag._retriever import OnnxCrossEncoder
@@ -122,6 +114,14 @@ def _convert_messages(
     messages: list[Message],
 ) -> tuple[list[ModelRequest | ModelResponse], str]:
     """Convert OpenAI messages to Pydantic AI messages and extract user prompt."""
+    from pydantic_ai.messages import (  # noqa: PLC0415
+        ModelRequest,
+        ModelResponse,
+        SystemPromptPart,
+        TextPart,
+        UserPromptPart,
+    )
+
     pyd_messages: list[ModelRequest | ModelResponse] = []
 
     # Validation: Ensure there is at least one message
@@ -235,6 +235,10 @@ async def process_chat_request(
         system_prompt = template.format(context=truncated)
 
     # 4. Setup Agent
+    from pydantic_ai import Agent  # noqa: PLC0415
+    from pydantic_ai.models.openai import OpenAIModel  # noqa: PLC0415
+    from pydantic_ai.providers.openai import OpenAIProvider  # noqa: PLC0415
+
     provider = OpenAIProvider(base_url=openai_base_url, api_key=api_key or "dummy")
     model = OpenAIModel(model_name=request.model, provider=provider)
 

--- a/agent_cli/services/tts.py
+++ b/agent_cli/services/tts.py
@@ -10,7 +10,6 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import numpy as np
 from rich.live import Live
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.tts import Synthesize, SynthesizeVoice
@@ -311,6 +310,8 @@ async def _play_audio(
     live: Live,
 ) -> None:
     """Play WAV audio data using SoundDevice."""
+    import numpy as np  # noqa: PLC0415
+
     try:
         wav_io = io.BytesIO(audio_data)
         speed = audio_output_cfg.tts_speed

--- a/scripts/profile_imports.py
+++ b/scripts/profile_imports.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Profile CLI import times to identify slow imports.
+
+Usage:
+    python scripts/profile_imports.py              # Basic timing
+    python scripts/profile_imports.py -v           # Verbose (show all imports)
+    python scripts/profile_imports.py --top 20     # Show top 20 slowest
+    python scripts/profile_imports.py --cli-only   # Just measure CLI startup time
+
+    # Raw importtime output (for detailed analysis):
+    python -X importtime -c "from agent_cli.cli import app" 2>&1 | sort -t'|' -k2 -n
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def measure_import_time(module: str, runs: int = 3) -> float:
+    """Measure average import time for a module."""
+    times = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module}"],
+            check=False,
+            capture_output=True,
+            cwd=Path(__file__).parent.parent,
+        )
+        elapsed = time.perf_counter() - start
+        if result.returncode != 0:
+            print(f"Error importing {module}: {result.stderr.decode()}")
+            return -1
+        times.append(elapsed)
+    return sum(times) / len(times)
+
+
+def get_import_breakdown(module: str) -> list[tuple[float, str]]:
+    """Get detailed import times using -X importtime."""
+    result = subprocess.run(
+        [sys.executable, "-X", "importtime", "-c", f"import {module}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parent.parent,
+    )
+
+    imports = []
+    for line in result.stderr.splitlines():
+        if "|" not in line:
+            continue
+        parts = line.split("|")
+        if len(parts) >= 2:  # noqa: PLR2004
+            try:
+                # importtime format: "import time: self [us] | cumulative | name"
+                cumulative = int(parts[1].strip())
+                name = parts[2].strip() if len(parts) > 2 else "unknown"  # noqa: PLR2004
+                imports.append((cumulative / 1_000_000, name))  # Convert to seconds
+            except (ValueError, IndexError):
+                continue
+
+    return sorted(imports, reverse=True)
+
+
+def main() -> None:
+    """Run import profiling and display results."""
+    parser = argparse.ArgumentParser(description="Profile CLI import times")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show all imports")
+    parser.add_argument("--top", type=int, default=15, help="Show top N slowest imports")
+    parser.add_argument("--runs", type=int, default=3, help="Number of runs for averaging")
+    parser.add_argument("--cli-only", action="store_true", help="Only measure CLI import time")
+    args = parser.parse_args()
+
+    if args.cli_only:
+        avg = measure_import_time("agent_cli.cli", runs=args.runs)
+        print(f"CLI import time: {avg:.3f}s (avg of {args.runs} runs)")
+        return
+
+    print("=" * 60)
+    print("CLI Import Time Profiling")
+    print("=" * 60)
+
+    # Measure key entry points
+    modules = [
+        ("agent_cli", "Base package"),
+        ("agent_cli.cli", "CLI app (full)"),
+        ("agent_cli.memory", "Memory module (chromadb)"),
+        ("agent_cli.rag", "RAG module"),
+        ("agent_cli.summarizer", "Summarizer module"),
+        ("agent_cli.agents.assistant", "Assistant agent"),
+        ("agent_cli.agents.summarize", "Summarize agent"),
+        ("pydantic_ai", "pydantic-ai"),
+        ("openai", "OpenAI SDK"),
+    ]
+
+    print(f"\n{'Module':<30} {'Time (s)':<12} Description")
+    print("-" * 60)
+
+    for module, desc in modules:
+        avg_time = measure_import_time(module, runs=args.runs)
+        if avg_time >= 0:
+            bar = "█" * int(avg_time * 20)  # Visual bar (1 block = 50ms)
+            print(f"{module:<30} {avg_time:>8.3f}s   {desc} {bar}")
+
+    # Detailed breakdown
+    print(f"\n{'=' * 60}")
+    print(f"Top {args.top} slowest imports (cumulative time)")
+    print("=" * 60)
+
+    imports = get_import_breakdown("agent_cli.cli")
+
+    shown = 0
+    for cumtime, name in imports:
+        if shown >= args.top and not args.verbose:
+            break
+        # Skip very fast imports unless verbose
+        if cumtime < 0.001 and not args.verbose:  # noqa: PLR2004
+            continue
+        bar = "█" * int(cumtime * 100)  # 1 block = 10ms
+        print(f"{cumtime:>8.3f}s  {name:<40} {bar}")
+        shown += 1
+
+    # Summary
+    if imports:
+        total = imports[0][0] if imports else 0
+        print(f"\n{'=' * 60}")
+        print(f"Total CLI import time: {total:.3f}s")
+        if total > 0.5:  # noqa: PLR2004
+            print("⚠️  Import time > 500ms - consider lazy imports")
+        elif total > 0.3:  # noqa: PLR2004
+            print("⚡ Import time moderate (300-500ms)")
+        else:
+            print("✅ Import time good (< 300ms)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rag/test_engine.py
+++ b/tests/rag/test_engine.py
@@ -130,7 +130,7 @@ async def test_process_chat_request_no_rag(tmp_path: Path) -> None:
 
     # We mock Agent.run on the class itself because each call creates a NEW instance
     with (
-        patch("agent_cli.rag.engine.Agent.run", new_callable=AsyncMock) as mock_run,
+        patch("pydantic_ai.Agent.run", new_callable=AsyncMock) as mock_run,
         patch("agent_cli.rag.engine.search_context") as mock_search,
     ):
         mock_run.return_value = mock_run_result
@@ -173,7 +173,7 @@ async def test_process_chat_request_with_rag(tmp_path: Path) -> None:
     )
 
     with (
-        patch("agent_cli.rag.engine.Agent.run", new_callable=AsyncMock) as mock_run,
+        patch("pydantic_ai.Agent.run", new_callable=AsyncMock) as mock_run,
         patch("agent_cli.rag.engine.search_context") as mock_search,
     ):
         mock_run.return_value = mock_run_result

--- a/tests/rag/test_history.py
+++ b/tests/rag/test_history.py
@@ -23,7 +23,7 @@ async def test_process_chat_request_preserves_history(tmp_path: Path) -> None:
     mock_run_result.usage.return_value = None
 
     with (
-        patch("agent_cli.rag.engine.Agent.run", new_callable=AsyncMock) as mock_run,
+        patch("pydantic_ai.Agent.run", new_callable=AsyncMock) as mock_run,
         patch("agent_cli.rag.engine.search_context") as mock_search,
     ):
         mock_run.return_value = mock_run_result

--- a/tests/rag/test_rag_integration_liveish.py
+++ b/tests/rag/test_rag_integration_liveish.py
@@ -135,8 +135,10 @@ async def test_rag_tool_execution_flow(
         )
 
     # Patch OpenAIModel to return our FunctionModel
+    import pydantic_ai.models.openai  # noqa: PLC0415
+
     monkeypatch.setattr(
-        engine,
+        pydantic_ai.models.openai,
         "OpenAIModel",
         lambda *_, **__: FunctionModel(agent_handler),
     )

--- a/tests/test_audio_e2e.py
+++ b/tests/test_audio_e2e.py
@@ -15,7 +15,7 @@ def _mock_sd_query_devices_with_cache_clear() -> None:
     audio._get_all_devices.cache_clear()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_get_all_devices_caching(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -37,7 +37,7 @@ def test_get_all_devices_caching(
     mock_query_devices.assert_called_once()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_list_input_devices(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -47,7 +47,7 @@ def test_list_input_devices(
     audio._list_input_devices()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_list_output_devices(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -57,7 +57,7 @@ def test_list_output_devices(
     audio._list_output_devices()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_list_all_devices(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -67,7 +67,7 @@ def test_list_all_devices(
     audio.list_all_devices()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_input_device_by_index(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -86,7 +86,7 @@ def test_input_device_by_index(
     assert input_device_index == expected_device["index"]
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_input_device_by_name(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -105,7 +105,7 @@ def test_input_device_by_name(
     assert input_device_index == input_device["index"]
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_output_device_by_index(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -128,7 +128,7 @@ def test_output_device_by_index(
     assert input_device_index == expected_device["index"]
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_output_device_by_name(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -147,7 +147,7 @@ def test_output_device_by_name(
     assert input_device_index == output_device["index"]
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_input_device_invalid_index(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -162,7 +162,7 @@ def test_input_device_invalid_index(
         )
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_input_device_invalid_name(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -177,7 +177,7 @@ def test_input_device_invalid_name(
         )
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_output_device_invalid_name(
     mock_query_devices: Mock,
     mock_audio_device_info: list[dict],
@@ -192,8 +192,8 @@ def test_output_device_invalid_name(
         )
 
 
-@patch("agent_cli.core.audio.sd.InputStream")
-@patch("agent_cli.core.audio.sd.OutputStream")
+@patch("sounddevice.InputStream")
+@patch("sounddevice.OutputStream")
 def test_open_audio_stream_context_manager(
     mock_output_stream: Mock,
     mock_input_stream: Mock,
@@ -226,7 +226,7 @@ def test_open_audio_stream_context_manager(
         mock_output_stream.assert_called()
 
 
-@patch("agent_cli.core.audio.sd.query_devices")
+@patch("sounddevice.query_devices")
 def test_device_filtering_by_capabilities(
     mock_query_devices: Mock,
 ) -> None:


### PR DESCRIPTION
## Summary
- Improve CLI startup time from ~0.51s to ~0.16s (69% faster)
- Defer heavy imports until they're actually needed

## Changes
- `pydantic_ai`: lazy in `memory/_ingest.py`, `rag/engine.py`
- `sounddevice`: lazy in `core/audio.py` (moved to TYPE_CHECKING + function imports)
- `numpy`: lazy in `rag/_retriever.py` and `services/tts.py`
- Update tests to patch modules directly (e.g., `pydantic_ai.Agent`)
- Add `scripts/profile_imports.py` for measuring import performance