### PR TITLE
fix(rag-proxy): validate docs-folder and chroma-path don't overlap

### DIFF
--- a/agent_cli/agents/rag_proxy.py
+++ b/agent_cli/agents/rag_proxy.py
@@ -88,6 +88,27 @@ def rag_proxy(
 
     docs_folder = docs_folder.resolve()
     chroma_path = chroma_path.resolve()
+
+    # Validate paths don't overlap - mixing docs and DB causes corruption
+    if docs_folder == chroma_path:
+        print_error_message(
+            "docs-folder and chroma-path cannot be the same directory.\n"
+            "ChromaDB creates internal files that would be indexed as documents.",
+        )
+        raise typer.Exit(1)
+    if chroma_path in docs_folder.parents:
+        print_error_message(
+            f"docs-folder ({docs_folder}) is inside chroma-path ({chroma_path}).\n"
+            "ChromaDB creates internal files that would be indexed as documents.",
+        )
+        raise typer.Exit(1)
+    if docs_folder in chroma_path.parents:
+        print_error_message(
+            f"chroma-path ({chroma_path}) is inside docs-folder ({docs_folder}).\n"
+            "ChromaDB files may be accidentally deleted when managing documents.",
+        )
+        raise typer.Exit(1)
+
     if openai_base_url is None:
         openai_base_url = constants.DEFAULT_OPENAI_BASE_URL
 


### PR DESCRIPTION
## Summary
- Add validation to prevent `docs-folder` and `chroma-path` from overlapping
- Prevents database corruption when ChromaDB files are accidentally deleted or indexed

## Problem
When `docs-folder` is inside `chroma-path` (or vice versa), ChromaDB creates internal files (like `chroma.sqlite3` and UUID-named segment directories) that can be:
1. Accidentally indexed as documents
2. Accidentally deleted when managing document files

This causes `InternalError: Error in compaction: Failed to apply logs to the hnsw segment writer` errors.

## Solution
Check for three overlap conditions at startup:
1. Same directory
2. `docs-folder` inside `chroma-path`
3. `chroma-path` inside `docs-folder`

## Test plan
- [x] Existing RAG tests pass (75 passed)
- [x] Pre-commit hooks pass (ruff, mypy)
- [ ] Manual test: run `rag-proxy --docs-folder ./rag_db/docs --chroma-path ./rag_db` → should error