### PR TITLE
docs: add high-level overviews to architecture docs

### DIFF
--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -4,7 +4,7 @@ This document serves as the authoritative technical reference for the `agent-cli
 
 ## High-Level Overview
 
-*For sharing with colleagues who want the gist without the technical deep-dive.*
+*For sharing with friends who want the gist without the technical deep-dive.*
 
 ### The Problem
 

--- a/docs/architecture/rag.md
+++ b/docs/architecture/rag.md
@@ -4,7 +4,7 @@ This document describes the architectural decisions, design rationale, and techn
 
 ## High-Level Overview
 
-*For sharing with colleagues who want the gist without the technical deep-dive.*
+*For sharing with friends who want the gist without the technical deep-dive.*
 
 ### The Problem
 


### PR DESCRIPTION
## Summary

- Add non-technical "High-Level Overview" sections to both `docs/architecture/rag.md` and `docs/architecture/memory.md`
- Each overview explains the problem, how it works, what makes it different, and a one-sentence summary
- Designed for sharing with colleagues who want to understand the systems without reading full technical specs

## Test plan

- [ ] Review the added sections for clarity and accuracy
- [ ] Verify markdown renders correctly on GitHub