### PR TITLE
docs: add 'Try It Now' quick start examples

### DIFF
--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -45,7 +45,7 @@ ollama pull embeddinggemma:300m  # for memory embeddings
 ollama pull qwen3:4b             # for chat
 
 # 2. Start the memory proxy (uvx handles installation automatically)
-uvx --from "agent-cli[memory]" agent-cli memory proxy \
+uvx -p 3.13 --from "agent-cli[memory]" agent-cli memory proxy \
   --memory-path ./my-memories \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m &
@@ -65,7 +65,7 @@ docker run -d -p 3000:8080 \
 ```bash
 # 1. Pull models and start proxy (same as above)
 ollama pull embeddinggemma:300m && ollama pull qwen3:4b
-uvx --from "agent-cli[memory]" agent-cli memory proxy \
+uvx -p 3.13 --from "agent-cli[memory]" agent-cli memory proxy \
   --memory-path ./my-memories \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m &

--- a/docs/architecture/rag.md
+++ b/docs/architecture/rag.md
@@ -39,7 +39,7 @@ ollama pull embeddinggemma:300m  # for document embeddings
 ollama pull qwen3:4b             # for chat
 
 # 2. Start the RAG proxy (uvx handles installation automatically)
-uvx --from "agent-cli[rag]" agent-cli rag-proxy \
+uvx -p 3.13 --from "agent-cli[rag]" agent-cli rag-proxy \
   --docs-folder ./my-docs \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m &
@@ -59,7 +59,7 @@ docker run -d -p 3000:8080 \
 ```bash
 # 1. Pull models and start proxy (same as above)
 ollama pull embeddinggemma:300m && ollama pull qwen3:4b
-uvx --from "agent-cli[rag]" agent-cli rag-proxy \
+uvx -p 3.13 --from "agent-cli[rag]" agent-cli rag-proxy \
   --docs-folder ./my-docs \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m &


### PR DESCRIPTION
## Summary

- Add "Try It Now" sections to both RAG and memory architecture docs
- Shows how to get a working demo in 3 lines using `uvx` and Open WebUI
- No installation required beyond Docker and Ollama

## Example (RAG)

```bash
uvx --from "agent-cli[rag]" agent-cli rag-proxy --docs-folder ./my-docs &
docker run -d -p 3000:8080 -e OPENAI_API_BASE_URL=http://host.docker.internal:8000/v1 ghcr.io/open-webui/open-webui:main
# Open http://localhost:3000
```

## Test plan

- [ ] Verify the RAG quick start works on macOS/Linux
- [ ] Verify the memory quick start works on macOS/Linux