### PR TITLE
refactor: move OnnxCrossEncoder to shared core module

### DIFF
--- a/agent_cli/core/reranker.py
+++ b/agent_cli/core/reranker.py
@@ -1,0 +1,119 @@
+"""Shared ONNX Cross-Encoder for reranking (used by both RAG and Memory)."""
+
+from __future__ import annotations
+
+import logging
+
+from huggingface_hub import hf_hub_download
+from onnxruntime import InferenceSession
+from transformers import AutoTokenizer
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _download_onnx_model(model_name: str, onnx_filename: str) -> str:
+    """Download the ONNX model, favoring the common `onnx/` folder layout."""
+    if "/" in onnx_filename:
+        return hf_hub_download(repo_id=model_name, filename=onnx_filename)
+
+    try:
+        return hf_hub_download(repo_id=model_name, filename=onnx_filename, subfolder="onnx")
+    except Exception as first_error:
+        LOGGER.debug(
+            "ONNX file not found under onnx/ for %s: %s. Falling back to repo root.",
+            model_name,
+            first_error,
+        )
+        try:
+            return hf_hub_download(repo_id=model_name, filename=onnx_filename)
+        except Exception as second_error:
+            LOGGER.exception(
+                "Failed to download ONNX model %s (filename=%s)",
+                model_name,
+                onnx_filename,
+                exc_info=second_error,
+            )
+            raise
+
+
+class OnnxCrossEncoder:
+    """A lightweight CrossEncoder using ONNX Runtime."""
+
+    def __init__(
+        self,
+        model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2",
+        onnx_filename: str = "model.onnx",
+    ) -> None:
+        """Initialize the ONNX CrossEncoder."""
+        self.model_name = model_name
+
+        # Download model if needed
+        LOGGER.info("Loading ONNX model: %s", model_name)
+        model_path = _download_onnx_model(model_name, onnx_filename)
+
+        self.session = InferenceSession(model_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    def predict(
+        self,
+        pairs: list[tuple[str, str]],
+        batch_size: int = 32,
+    ) -> list[float]:
+        """Predict relevance scores for query-document pairs."""
+        import numpy as np  # noqa: PLC0415
+
+        if not pairs:
+            return []
+
+        all_scores = []
+
+        # Process in batches
+        for i in range(0, len(pairs), batch_size):
+            batch = pairs[i : i + batch_size]
+            queries = [q for q, d in batch]
+            docs = [d for q, d in batch]
+
+            # Tokenize
+            inputs = self.tokenizer(
+                queries,
+                docs,
+                padding=True,
+                truncation=True,
+                return_tensors="np",
+                max_length=512,
+            )
+
+            # ONNX Input
+            # Check what inputs the model expects. usually input_ids, attention_mask, token_type_ids
+            # specific models might not need token_type_ids
+            ort_inputs = {
+                "input_ids": inputs["input_ids"].astype(np.int64),
+                "attention_mask": inputs["attention_mask"].astype(np.int64),
+            }
+            if "token_type_ids" in inputs:
+                ort_inputs["token_type_ids"] = inputs["token_type_ids"].astype(np.int64)
+
+            # Run inference
+            logits = self.session.run(None, ort_inputs)[0]
+
+            # Extract scores (usually shape [batch, 1] or [batch])
+            batch_scores = logits.flatten() if logits.ndim > 1 else logits
+
+            all_scores.extend(batch_scores.tolist())
+
+        return all_scores
+
+
+def get_reranker_model(
+    model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2",
+) -> OnnxCrossEncoder:
+    """Load the CrossEncoder model."""
+    return OnnxCrossEncoder(model_name)
+
+
+def predict_relevance(
+    model: OnnxCrossEncoder,
+    pairs: list[tuple[str, str]],
+) -> list[float]:
+    """Predict relevance scores for query-document pairs."""
+    return model.predict(pairs)

--- a/agent_cli/memory/_retrieval.py
+++ b/agent_cli/memory/_retrieval.py
@@ -7,6 +7,7 @@ import math
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from agent_cli.core.reranker import OnnxCrossEncoder, predict_relevance
 from agent_cli.memory._store import get_summary_entry, query_memories
 from agent_cli.memory.models import (
     ChatRequest,
@@ -16,7 +17,6 @@ from agent_cli.memory.models import (
     Message,
     StoredMemory,
 )
-from agent_cli.rag._retriever import OnnxCrossEncoder, predict_relevance
 
 if TYPE_CHECKING:
     from chromadb import Collection

--- a/agent_cli/memory/client.py
+++ b/agent_cli/memory/client.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Self
 
 from agent_cli.constants import DEFAULT_OPENAI_EMBEDDING_MODEL, DEFAULT_OPENAI_MODEL
+from agent_cli.core.reranker import get_reranker_model
 from agent_cli.memory._files import ensure_store_dirs
 from agent_cli.memory._git import init_repo
 from agent_cli.memory._indexer import MemoryIndex, initial_index, watch_memory_store
@@ -17,14 +18,13 @@ from agent_cli.memory._retrieval import augment_chat_request
 from agent_cli.memory._store import init_memory_collection
 from agent_cli.memory.engine import process_chat_request
 from agent_cli.memory.models import ChatRequest, MemoryRetrieval, Message
-from agent_cli.rag._retriever import get_reranker_model
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from chromadb import Collection
 
-    from agent_cli.rag._retriever import OnnxCrossEncoder
+    from agent_cli.core.reranker import OnnxCrossEncoder
 
 
 logger = logging.getLogger("agent_cli.memory.client")

--- a/agent_cli/memory/engine.py
+++ b/agent_cli/memory/engine.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 
     from chromadb import Collection
 
+    from agent_cli.core.reranker import OnnxCrossEncoder
     from agent_cli.memory.models import ChatRequest
-    from agent_cli.rag._retriever import OnnxCrossEncoder
 
 LOGGER = logging.getLogger(__name__)
 

--- a/agent_cli/rag/_retriever.py
+++ b/agent_cli/rag/_retriever.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from huggingface_hub import hf_hub_download
-from onnxruntime import InferenceSession
-from transformers import AutoTokenizer
-
+from agent_cli.core.reranker import OnnxCrossEncoder, predict_relevance
 from agent_cli.rag._store import query_docs
 from agent_cli.rag.models import RagSource, RetrievalResult
 
@@ -16,114 +13,6 @@ if TYPE_CHECKING:
     from chromadb import Collection
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _download_onnx_model(model_name: str, onnx_filename: str) -> str:
-    """Download the ONNX model, favoring the common `onnx/` folder layout."""
-    if "/" in onnx_filename:
-        return hf_hub_download(repo_id=model_name, filename=onnx_filename)
-
-    try:
-        return hf_hub_download(repo_id=model_name, filename=onnx_filename, subfolder="onnx")
-    except Exception as first_error:
-        LOGGER.debug(
-            "ONNX file not found under onnx/ for %s: %s. Falling back to repo root.",
-            model_name,
-            first_error,
-        )
-        try:
-            return hf_hub_download(repo_id=model_name, filename=onnx_filename)
-        except Exception as second_error:
-            LOGGER.exception(
-                "Failed to download ONNX model %s (filename=%s)",
-                model_name,
-                onnx_filename,
-                exc_info=second_error,
-            )
-            raise
-
-
-class OnnxCrossEncoder:
-    """A lightweight CrossEncoder using ONNX Runtime."""
-
-    def __init__(
-        self,
-        model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2",
-        onnx_filename: str = "model.onnx",
-    ) -> None:
-        """Initialize the ONNX CrossEncoder."""
-        self.model_name = model_name
-
-        # Download model if needed
-        LOGGER.info("Loading ONNX model: %s", model_name)
-        model_path = _download_onnx_model(model_name, onnx_filename)
-
-        self.session = InferenceSession(model_path)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-
-    def predict(
-        self,
-        pairs: list[tuple[str, str]],
-        batch_size: int = 32,
-    ) -> list[float]:
-        """Predict relevance scores for query-document pairs."""
-        import numpy as np  # noqa: PLC0415
-
-        if not pairs:
-            return []
-
-        all_scores = []
-
-        # Process in batches
-        for i in range(0, len(pairs), batch_size):
-            batch = pairs[i : i + batch_size]
-            queries = [q for q, d in batch]
-            docs = [d for q, d in batch]
-
-            # Tokenize
-            inputs = self.tokenizer(
-                queries,
-                docs,
-                padding=True,
-                truncation=True,
-                return_tensors="np",
-                max_length=512,
-            )
-
-            # ONNX Input
-            # Check what inputs the model expects. usually input_ids, attention_mask, token_type_ids
-            # specific models might not need token_type_ids
-            ort_inputs = {
-                "input_ids": inputs["input_ids"].astype(np.int64),
-                "attention_mask": inputs["attention_mask"].astype(np.int64),
-            }
-            if "token_type_ids" in inputs:
-                ort_inputs["token_type_ids"] = inputs["token_type_ids"].astype(np.int64)
-
-            # Run inference
-            logits = self.session.run(None, ort_inputs)[0]
-
-            # Extract scores (usually shape [batch, 1] or [batch])
-            batch_scores = logits.flatten() if logits.ndim > 1 else logits
-
-            all_scores.extend(batch_scores.tolist())
-
-        return all_scores
-
-
-def get_reranker_model(
-    model_name: str = "Xenova/ms-marco-MiniLM-L-6-v2",
-) -> OnnxCrossEncoder:
-    """Load the CrossEncoder model."""
-    return OnnxCrossEncoder(model_name)
-
-
-def predict_relevance(
-    model: OnnxCrossEncoder,
-    pairs: list[tuple[str, str]],
-) -> list[float]:
-    """Predict relevance scores for query-document pairs."""
-    return model.predict(pairs)
 
 
 def format_context(

--- a/agent_cli/rag/api.py
+++ b/agent_cli/rag/api.py
@@ -14,9 +14,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from agent_cli.constants import DEFAULT_OPENAI_EMBEDDING_MODEL
 from agent_cli.core.chroma import init_collection
 from agent_cli.core.openai_proxy import proxy_request_to_upstream
+from agent_cli.core.reranker import get_reranker_model
 from agent_cli.rag._indexer import watch_docs
 from agent_cli.rag._indexing import initial_index, load_hashes_from_metadata
-from agent_cli.rag._retriever import get_reranker_model
 from agent_cli.rag._store import get_all_metadata
 from agent_cli.rag.engine import process_chat_request
 from agent_cli.rag.models import ChatRequest  # noqa: TC001

--- a/agent_cli/rag/client.py
+++ b/agent_cli/rag/client.py
@@ -12,7 +12,8 @@ from agent_cli.constants import (
     DEFAULT_OPENAI_EMBEDDING_MODEL,
 )
 from agent_cli.core.chroma import init_collection
-from agent_cli.rag._retriever import format_context, get_reranker_model, rerank_and_filter
+from agent_cli.core.reranker import get_reranker_model
+from agent_cli.rag._retriever import format_context, rerank_and_filter
 from agent_cli.rag._utils import chunk_text, load_document_text
 from agent_cli.rag.models import RagSource, RetrievalResult
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
     from chromadb import Collection
 
-    from agent_cli.rag._retriever import OnnxCrossEncoder
+    from agent_cli.core.reranker import OnnxCrossEncoder
 
 logger = logging.getLogger("agent_cli.rag.client")
 

--- a/agent_cli/rag/engine.py
+++ b/agent_cli/rag/engine.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from pydantic_ai.messages import ModelRequest, ModelResponse
     from pydantic_ai.result import RunResult
 
-    from agent_cli.rag._retriever import OnnxCrossEncoder
+    from agent_cli.core.reranker import OnnxCrossEncoder
     from agent_cli.rag.models import ChatRequest
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/rag/test_retriever.py
+++ b/tests/rag/test_retriever.py
@@ -2,13 +2,14 @@
 
 from unittest.mock import MagicMock, patch
 
+from agent_cli.core import reranker
 from agent_cli.rag import _retriever
 
 
 def test_get_reranker_model_installed() -> None:
     """Test loading reranker when installed."""
-    with patch("agent_cli.rag._retriever.OnnxCrossEncoder") as mock_ce:
-        _retriever.get_reranker_model()
+    with patch("agent_cli.core.reranker.OnnxCrossEncoder") as mock_ce:
+        reranker.get_reranker_model()
         mock_ce.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- Moves the ONNX cross-encoder reranker from `rag/_retriever.py` to a new `core/reranker.py` module
- Updates imports in both memory and rag modules to use the shared module
- Fixes the issue where `uvx --from "agent-cli[memory]"` would fail because importing memory's retrieval code would trigger `rag/__init__.py` which checks for all rag dependencies including `markitdown`

## Problem

The memory module used the `OnnxCrossEncoder` from `rag/_retriever.py`. When importing anything from the `rag` package, Python first imports `rag/__init__.py` which runs an eager dependency check for ALL rag dependencies including `markitdown`. This meant users couldn't use the `[memory]` extra without also installing `markitdown`.

## Solution

Move the cross-encoder code to a shared location (`core/reranker.py`) that doesn't trigger the rag dependency check.

## Test plan

- [x] All existing tests pass (392 passed)
- [x] Memory module imports work without rag dependencies
- [x] RAG module still properly checks for its own dependencies
- [x] `uv run agent-cli memory proxy --help` works