### PR TITLE
feat: add __version__ and -v/--version CLI flag

### DIFF
--- a/agent_cli/__init__.py
+++ b/agent_cli/__init__.py
@@ -1,1 +1,5 @@
 """A suite of AI-powered command-line tools for text correction, audio transcription, and voice assistance."""
+
+from importlib.metadata import version
+
+__version__ = version("agent-cli")

--- a/agent_cli/cli.py
+++ b/agent_cli/cli.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import typer
 
+from . import __version__
 from .config import load_config, normalize_provider_defaults
 from .core.utils import console
 
@@ -16,9 +19,25 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"agent-cli {__version__}")
+        raise typer.Exit
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
+    version: Annotated[  # noqa: ARG001
+        bool,
+        typer.Option(
+            "-v",
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show version and exit.",
+        ),
+    ] = False,
 ) -> None:
     """A suite of AI-powered tools."""
     if ctx.invoked_subcommand is None:


### PR DESCRIPTION
## Summary
- Add `__version__` to `agent_cli/__init__.py` using `importlib.metadata`
- Add `-v` and `--version` CLI flags to show version and exit

## Test plan
- [x] `python -c "from agent_cli import __version__; print(__version__)"` works
- [x] `agent-cli --version` shows version
- [x] `agent-cli -v` shows version
- [x] All tests pass