### PR TITLE
fix: set filelock logger to INFO level in proxies

### DIFF
--- a/agent_cli/agents/memory/proxy.py
+++ b/agent_cli/agents/memory/proxy.py
@@ -126,6 +126,7 @@ def proxy(
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("chromadb").setLevel(logging.WARNING)
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    logging.getLogger("filelock").setLevel(logging.INFO)
 
     memory_path = memory_path.resolve()
     entries_dir, _ = ensure_store_dirs(memory_path)

--- a/agent_cli/agents/rag_proxy.py
+++ b/agent_cli/agents/rag_proxy.py
@@ -74,6 +74,7 @@ def rag_proxy(
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("chromadb").setLevel(logging.WARNING)
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    logging.getLogger("filelock").setLevel(logging.INFO)
 
     try:
         import uvicorn  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- Sets the default verbosity of the `filelock` logger to `INFO` level in both memory proxy and RAG proxy
- Reduces verbose DEBUG output from the filelock library when huggingface_hub downloads or caches models

## Test plan
- [ ] Start memory proxy and verify filelock DEBUG messages are no longer shown
- [ ] Start RAG proxy and verify filelock DEBUG messages are no longer shown