### PR TITLE
perf(rag): use mtime-first checking for faster startup

### DIFF
--- a/agent_cli/rag/models.py
+++ b/agent_cli/rag/models.py
@@ -36,6 +36,7 @@ class DocMetadata(BaseModel):
     total_chunks: int
     indexed_at: str
     file_hash: str
+    file_mtime: float
 
 
 class RagSource(BaseModel):

--- a/tests/rag/test_api.py
+++ b/tests/rag/test_api.py
@@ -14,7 +14,7 @@ def client() -> TestClient:
     with (
         patch("agent_cli.rag.api.init_collection"),
         patch("agent_cli.rag.api.get_reranker_model"),
-        patch("agent_cli.rag.api.load_hashes_from_metadata", return_value={}),
+        patch("agent_cli.rag.api.load_hashes_from_metadata", return_value=({}, {})),
         patch("pathlib.Path.mkdir"),
         patch("agent_cli.rag.api.watch_docs"),
         patch("asyncio.create_task"),
@@ -120,7 +120,7 @@ def test_chat_completion_server_api_key() -> None:
     with (
         patch("agent_cli.rag.api.init_collection"),
         patch("agent_cli.rag.api.get_reranker_model"),
-        patch("agent_cli.rag.api.load_hashes_from_metadata", return_value={}),
+        patch("agent_cli.rag.api.load_hashes_from_metadata", return_value=({}, {})),
         patch("pathlib.Path.mkdir"),
         patch("agent_cli.rag.api.watch_docs"),
         patch("asyncio.create_task"),

--- a/tests/rag/test_indexer.py
+++ b/tests/rag/test_indexer.py
@@ -19,6 +19,7 @@ async def test_watch_docs(tmp_path: Path) -> None:
     docs_folder = tmp_path / "docs"
     docs_folder.mkdir()
     file_hashes: dict[str, str] = {}
+    file_mtimes: dict[str, float] = {}
 
     # Create dummy files so is_file() returns True
     (docs_folder / "new.txt").touch()
@@ -47,7 +48,7 @@ async def test_watch_docs(tmp_path: Path) -> None:
         patch("agent_cli.rag._indexer.index_file") as mock_index,
         patch("agent_cli.rag._indexer.remove_file") as mock_remove,
     ):
-        await _indexer.watch_docs(mock_collection, docs_folder, file_hashes)
+        await _indexer.watch_docs(mock_collection, docs_folder, file_hashes, file_mtimes)
 
         # Check calls
         assert mock_index.call_count == 2  # added and modified
@@ -61,6 +62,7 @@ async def test_watch_docs_passes_ignore_filter(tmp_path: Path) -> None:
     docs_folder = tmp_path / "docs"
     docs_folder.mkdir()
     file_hashes: dict[str, str] = {}
+    file_mtimes: dict[str, float] = {}
 
     async def fake_watch_directory(
         _root: Path,
@@ -77,7 +79,7 @@ async def test_watch_docs_passes_ignore_filter(tmp_path: Path) -> None:
         "agent_cli.rag._indexer.watch_directory",
         side_effect=fake_watch_directory,
     ):
-        await _indexer.watch_docs(mock_collection, docs_folder, file_hashes)
+        await _indexer.watch_docs(mock_collection, docs_folder, file_hashes, file_mtimes)
 
 
 @pytest.mark.asyncio

--- a/tests/rag/test_rag_integration_liveish.py
+++ b/tests/rag/test_rag_integration_liveish.py
@@ -147,7 +147,7 @@ async def test_rag_tool_execution_flow(
     # We need to mock everything that `api.create_app` does so it doesn't fail
     monkeypatch.setattr(api, "init_collection", MagicMock())
     monkeypatch.setattr(api, "get_reranker_model", MagicMock())
-    monkeypatch.setattr(api, "load_hashes_from_metadata", MagicMock(return_value={}))
+    monkeypatch.setattr(api, "load_hashes_from_metadata", MagicMock(return_value=({}, {})))
     monkeypatch.setattr(api, "watch_docs", AsyncMock())
     monkeypatch.setattr(api, "initial_index", MagicMock())
 

--- a/tests/rag/test_rag_proxy_passthrough.py
+++ b/tests/rag/test_rag_proxy_passthrough.py
@@ -21,7 +21,7 @@ def mock_rag_dependencies(mocker: MockerFixture) -> None:
     """Mock the RAG dependencies to avoid side effects."""
     mocker.patch("agent_cli.rag.api.init_collection")
     mocker.patch("agent_cli.rag.api.get_reranker_model")
-    mocker.patch("agent_cli.rag.api.load_hashes_from_metadata", return_value={})
+    mocker.patch("agent_cli.rag.api.load_hashes_from_metadata", return_value=({}, {}))
     mocker.patch("agent_cli.rag.api.watch_docs")
     mocker.patch("agent_cli.rag.api.initial_index")
     # Also mock threading to prevent background threads


### PR DESCRIPTION
## Summary

- Check file modification time (mtime) before computing MD5 hash during RAG indexing
- Significantly improves startup performance for large knowledge bases by avoiding unnecessary file I/O
- Adds `file_mtime` field to `DocMetadata` model for tracking

## Optimized flow

```
mtime unchanged → skip (fast path, no file read needed)
mtime changed + hash unchanged → update mtime cache, skip (file was touched but not modified)
mtime changed + hash changed → reindex
```

## Files changed

- `agent_cli/rag/models.py`: Added `file_mtime: float` field
- `agent_cli/rag/_indexing.py`: Added mtime-first checking logic
- `agent_cli/rag/_indexer.py`: Pass mtime cache through file watcher
- `agent_cli/rag/api.py`: Updated to use new cache structure

## Test plan

- [x] All existing tests pass
- [x] Test mtime unchanged → skips without hash computation
- [x] Test mtime changed + hash unchanged → updates mtime cache, skips reindex
- [x] Test mtime changed + hash changed → reindexes file