### PR TITLE
fix(tests): prevent sounddevice Pa_Initialize hang on Windows CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 from rich.console import Console
 
 
-def pytest_configure(_config: pytest.Config) -> None:
+def pytest_configure() -> None:
     """Pre-configure mocks before test collection.
 
     This is needed because @patch("sounddevice.query_devices") decorators


### PR DESCRIPTION
## Summary
- Mock `sounddevice` in `sys.modules` during `pytest_configure` to prevent PortAudio initialization hang
- Fixes flaky test timeout on Windows CI where `Pa_Initialize()` hangs without audio hardware
- The `@patch("sounddevice.query_devices")` decorators import sounddevice during test collection, triggering the hang before any test runs

## Test plan
- [ ] Verify Windows CI tests pass without timeout on `test_get_all_devices_caching`
- [ ] Verify audio tests still function correctly on all platforms