### PR TITLE
fix(tests): skip VAD tests on Windows to prevent torch hang

### DIFF
--- a/tests/core/test_vad.py
+++ b/tests/core/test_vad.py
@@ -9,6 +9,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Skip all tests in this module on Windows - torch/silero-vad can hang during initialization
+if sys.platform == "win32":
+    pytest.skip(
+        "silero-vad/torch initialization can hang on Windows CI",
+        allow_module_level=True,
+    )
+
 from agent_cli.core.vad import VoiceActivityDetector
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary

- Skip the entire `test_vad.py` module on Windows before importing to prevent torch/silero-vad initialization hang

## Problem

The Windows CI was failing because `test_vad_initialization` timed out. The silero-vad/torch initialization can hang indefinitely on Windows CI.

## Solution

Use `pytest.skip(..., allow_module_level=True)` before the import to skip the entire module on Windows.