### PR TITLE
fix(docs): enable GitHub-style admonitions in Zensical

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install Zensical
-        run: uv tool install zensical
+      - name: Install Zensical with extensions
+        run: uv tool install zensical --with markdown-gfm-admonition
 
       - name: Build docs
         run: zensical build

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -15,7 +15,7 @@ Choose the best installation method for your platform and performance needs.
 | **NixOS**        | [System Integration](nixos.md) | ✅ NVIDIA GPU | Best        |
 | **Any Platform** | [Docker Setup](docker.md)      | ⚠️ Limited\*  | Good        |
 
-> [!NOTE]
+> [!WARNING]
 > Docker on macOS does not support GPU acceleration. For best performance on Mac, use the [native setup](macos.md).
 
 ## Installation Methods

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -6,7 +6,7 @@ icon: lucide/terminal
 
 Native Linux setup with full NVIDIA GPU acceleration for optimal performance.
 
-> [!NOTE]
+> [!TIP]
 > **🐧 Recommended for Linux** — Optimal performance with full NVIDIA GPU acceleration.
 
 ## Prerequisites

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -6,7 +6,7 @@ icon: lucide/apple
 
 Native macOS setup with full Metal GPU acceleration for optimal performance.
 
-> [!NOTE]
+> [!TIP]
 > **🍎 Recommended for macOS** — ~10x better performance than Docker via Metal GPU acceleration.
 
 ## Prerequisites
@@ -61,7 +61,8 @@ The `setup-macos.sh` script:
 | **Piper**        | Wyoming Piper (via uv) | 10200 | N/A                  |
 | **OpenWakeWord** | Wyoming OpenWakeWord   | 10400 | N/A                  |
 
-> **Note:** Whisper uses [wyoming-mlx-whisper](https://github.com/basnijholt/wyoming-mlx-whisper) with `whisper-large-v3-turbo` for near real-time transcription on Apple Silicon.
+> [!NOTE]
+> Whisper uses [wyoming-mlx-whisper](https://github.com/basnijholt/wyoming-mlx-whisper) with `whisper-large-v3-turbo` for near real-time transcription on Apple Silicon.
 
 ## Session Management with Zellij
 

--- a/docs/installation/nixos.md
+++ b/docs/installation/nixos.md
@@ -6,7 +6,7 @@ icon: lucide/snowflake
 
 Native NixOS setup using system configuration with full GPU acceleration support.
 
-> [!NOTE]
+> [!TIP]
 > **❄️ For NixOS Users** — Integrates agent-cli services directly into your NixOS system configuration.
 
 ## Prerequisites

--- a/scripts/macos-hotkeys/README.md
+++ b/scripts/macos-hotkeys/README.md
@@ -16,7 +16,8 @@ System-wide hotkeys for agent-cli voice AI features on macOS.
 
 Results appear in notifications and clipboard.
 
-> **Tip:** For a persistent “Listening…” indicator, open System Settings → Notifications → *terminal-notifier* and set the Alert style to **Persistent** (or choose **Alerts** on older macOS versions).
+> [!TIP]
+> For a persistent "Listening…" indicator, open System Settings → Notifications → *terminal-notifier* and set the Alert style to **Persistent** (or choose **Alerts** on older macOS versions).
 > Also enable "Allow notification when mirroring or sharing the display".
 > The scripts keep that alert pinned while dismissing status/result notifications automatically.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -123,3 +123,7 @@ link = "https://pypi.org/project/agent-cli/"
 [[project.extra.social]]
 icon = "fontawesome/brands/youtube"
 link = "https://www.youtube.com/watch?v=7sBTCgttH48"
+
+# Enable GitHub-style admonitions (> [!NOTE], > [!TIP], etc.)
+# This converts them to Zensical's native !!! syntax during build
+[project.markdown_extensions.gfm_admonition]


### PR DESCRIPTION
## Summary
- Add `markdown-gfm-admonition` extension to convert GitHub callout syntax (`> [!NOTE]`, `> [!TIP]`, etc.) to Zensical's native admonition format during build
- Update callout types for better semantics (NOTE→TIP for recommendations, NOTE→WARNING for limitations)
- Convert legacy `> **Note:**` syntax to proper `> [!NOTE]` format

This ensures callouts render correctly on both GitHub and the documentation site (https://agent-cli.nijho.lt/).

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Check https://agent-cli.nijho.lt/installation/macos/ renders TIP callout correctly after deploy
- [ ] Verify GitHub preview of markdown files shows callouts properly