### PR TITLE
docs: use Linux logo icon for Linux installation page

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -1,5 +1,5 @@
 ---
-icon: lucide/terminal
+icon: fontawesome/brands/linux
 ---
 
 # Linux Native Installation


### PR DESCRIPTION
Use `fontawesome/brands/linux` (Tux) instead of `lucide/terminal` for the Linux installation page menu icon, matching how macOS uses the Apple logo.