### PR TITLE
docs: use GitHub-flavored markdown admonitions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,12 @@ A collection of **local-first**, AI-powered command-line agents that run entirel
 
 Agent CLI provides a suite of powerful tools for voice and text interaction, designed for privacy, offline capability, and seamless integration with system-wide hotkeys and workflows.
 
-!!! important "Local and Private by Design"
-    All agents can run **100% locally**. Your data—whether from your clipboard, microphone, or files—stays on your machine unless you configure a cloud provider. This keeps workflows private and allows the tools to work offline.
-
-    You can optionally configure the agents to use OpenAI/Gemini services.
+> [!IMPORTANT]
+> **Local and Private by Design**
+>
+> All agents can run **100% locally**. Your data—whether from your clipboard, microphone, or files—stays on your machine unless you configure a cloud provider. This keeps workflows private and allows the tools to work offline.
+>
+> You can optionally configure the agents to use OpenAI/Gemini services.
 
 ## Quick Demo
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -20,9 +20,11 @@ agent-cli install-hotkeys
 
 This automatically installs all dependencies (skhd, terminal-notifier) and creates a default configuration with common hotkeys. See [`install-hotkeys`](commands/install-hotkeys.md) for all options.
 
-!!! note "Accessibility Permission Required"
-    After installation, grant Accessibility permissions to skhd:
-    System Settings → Privacy & Security → Accessibility → enable "skhd"
+> [!NOTE]
+> **Accessibility Permission Required**
+>
+> After installation, grant Accessibility permissions to skhd:
+> System Settings → Privacy & Security → Accessibility → enable "skhd"
 
 ### Manual skhd Configuration
 


### PR DESCRIPTION
## Summary
- Convert MkDocs Material admonition syntax (`!!! note`) to GitHub-flavored markdown syntax (`> [!NOTE]`)
- Updated `index.md` and `system-integration.md`
- Better compatibility and more readable in raw markdown

## Test plan
- [x] Verify admonitions render correctly in docs