### PR TITLE
fix(docs): use Unicode emojis instead of shortcodes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,11 +101,11 @@ agent-cli autocorrect "this has an eror"
 
 The setup automatically installs:
 
-- :white_check_mark: Package managers (Homebrew/uv) if needed
-- :white_check_mark: All AI services (Ollama, Whisper, TTS, etc.)
-- :white_check_mark: The `agent-cli` tool
-- :white_check_mark: System dependencies
-- :white_check_mark: Hotkey managers (if using hotkey scripts)
+- ✅ Package managers (Homebrew/uv) if needed
+- ✅ All AI services (Ollama, Whisper, TTS, etc.)
+- ✅ The `agent-cli` tool
+- ✅ System dependencies
+- ✅ Hotkey managers (if using hotkey scripts)
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Replace GitHub-style emoji shortcodes (`:white_check_mark:`) with Unicode emojis (✅)
- Ensures emojis render correctly on all platforms, not just GitHub

## Test plan
- [x] Verify emojis display correctly in docs preview