### PR TITLE
fix(docs): enable tabs and icon rendering in zensical

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -133,3 +133,12 @@ link = "https://www.youtube.com/watch?v=7sBTCgttH48"
 anchor_linenums = true
 
 [project.markdown_extensions.pymdownx.superfences]
+
+# Enable tabs (=== "Tab Name" syntax)
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+
+# Enable emoji/icon support (:fontawesome-brands-apple: etc.)
+[project.markdown_extensions.pymdownx.emoji]
+emoji_index = "zensical.extensions.emoji.twemoji"
+emoji_generator = "zensical.extensions.emoji.to_svg"


### PR DESCRIPTION
## Summary
- Add `pymdownx.tabbed` extension to enable `=== "Tab Name"` content tabs syntax
- Add `pymdownx.emoji` extension to render icon shortcodes like `:fontawesome-brands-apple:`

## Test plan
- [x] Verify `uv run zensical build` succeeds
- [x] Check tabs render correctly in getting-started page
- [x] Check icons render as SVGs in platform table