### PR TITLE
fix: Use correct path for custom_dir

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -58,7 +58,7 @@ nav = [
 ]
 
 [project.theme]
-custom_dir = "overrides"
+custom_dir = "docs/overrides"
 language = "en"
 logo = "logo-clean.svg"
 


### PR DESCRIPTION
Fix docs build by using correct path `docs/overrides` instead of `overrides`.