### PR TITLE
fix(dev): use origin ref when creating worktrees from default branch

### DIFF
--- a/agent_cli/dev/worktree.py
+++ b/agent_cli/dev/worktree.py
@@ -439,8 +439,10 @@ def create_worktree(
         _run_git("fetch", "origin", cwd=repo_root, check=False)
 
     # Determine the reference to create from
+    # Use origin/{branch} to ensure we're using the freshly-fetched remote ref,
+    # not a potentially stale local branch
     if from_ref is None:
-        from_ref = get_default_branch(repo_root)
+        from_ref = f"origin/{get_default_branch(repo_root)}"
 
     # Check if branch exists remotely or locally
     remote_exists, local_exists = _check_branch_exists(branch_name, repo_root)


### PR DESCRIPTION
## Summary

- Fixed `dev new` to create worktrees from `origin/main` instead of `main`
- Previously, the command would fetch from origin but then use the potentially stale local branch
- Now it uses the freshly-fetched remote ref, ensuring worktrees start from the latest commit

## Problem

When running `dev new`, the output showed:
```
→ Running: git fetch origin
→ Running: git worktree add -b eager-newt /path/to/worktrees/eager-newt main
```

The `main` here refers to the local branch, which may be behind `origin/main` even though we just fetched. This could result in worktrees being created from outdated commits.

## Solution

Changed `from_ref` to use `origin/{default_branch}` instead of just `{default_branch}`:
```python
# Before
from_ref = get_default_branch(repo_root)  # Returns "main"

# After  
from_ref = f"origin/{get_default_branch(repo_root)}"  # Returns "origin/main"
```

## Test plan

- [x] All 198 existing tests pass
- [x] Pre-commit checks pass