### PR TITLE
fix(dev): init submodules in worktrees and use conda-lock.yml

### DIFF
--- a/agent_cli/dev/worktree.py
+++ b/agent_cli/dev/worktree.py
@@ -314,6 +314,33 @@ def _check_branch_exists(branch_name: str, repo_root: Path) -> tuple[bool, bool]
     return remote_exists, local_exists
 
 
+def _init_submodules(
+    worktree_path: Path,
+    *,
+    on_log: Callable[[str], None] | None = None,
+) -> None:
+    """Initialize git submodules in a worktree.
+
+    Git worktrees don't automatically initialize submodules, so we need to do it
+    manually after creating a worktree.
+    """
+    # Check if there are any submodules configured
+    gitmodules_path = worktree_path / ".gitmodules"
+    if not gitmodules_path.exists():
+        return
+
+    if on_log:
+        on_log("Running: git submodule update --init --recursive")
+    _run_git(
+        "submodule",
+        "update",
+        "--init",
+        "--recursive",
+        cwd=worktree_path,
+        check=False,  # Don't fail if submodules can't be initialized
+    )
+
+
 def _add_worktree(
     branch_name: str,
     worktree_path: Path,
@@ -456,6 +483,9 @@ def create_worktree(
             force=force,
             on_log=on_log,
         )
+
+        # Initialize submodules in the new worktree
+        _init_submodules(worktree_path, on_log=on_log)
 
         return CreateWorktreeResult(
             success=True,


### PR DESCRIPTION
## Summary
- Initialize git submodules after creating a worktree by running `git submodule update --init --recursive`
- Auto-detect `conda-lock.yml` in unidep projects and add `-f conda-lock.yml` flag

## Problem
1. **Submodules not initialized**: Git worktrees don't automatically clone submodules, causing errors like:
   ```
   RuntimeError: `../some-submodule` in `local_dependencies` is not pip installable 
   because it is an empty folder. Is it perhaps an uninitialized Git submodule?
   ```

2. **conda-lock.yml not used**: When a `conda-lock.yml` exists, the unidep install command should use `-f conda-lock.yml` for reproducible dependency installation, but it wasn't being detected.

## Test plan
- [x] Run `pre-commit run --all-files` - passes
- [x] Run `pytest` - passes
- [x] Test `dev new` on a repo with submodules
- [x] Test `dev new` on a repo with `conda-lock.yml`