### PR TITLE
feat(dev): show cd hint after creating new worktree

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -451,6 +451,7 @@ def new(  # noqa: PLR0912
             border_style="green",
         ),
     )
+    console.print(f'[dim]To enter the worktree:[/dim] cd "$(ag dev path {branch})"')
 
 
 @app.command("list")


### PR DESCRIPTION
## Summary
- Print a helpful command after `ag dev new` showing how to enter the new worktree
- Uses existing `ag dev path` command: `cd "$(ag dev path <branch>)"`

## Test plan
- [x] Run `ag dev new` and verify hint is displayed
- [x] Pre-commit passes
- [x] Tests pass