### PR TITLE
fix(dev): print errors to stderr for shell integration

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -107,6 +107,7 @@ if TYPE_CHECKING:
     from .editors.base import Editor
 
 console = Console()
+err_console = Console(stderr=True)
 
 app = typer.Typer(
     name="dev",
@@ -132,7 +133,7 @@ def dev_callback(
 
 def _error(msg: str) -> NoReturn:
     """Print an error message and exit."""
-    console.print(f"[bold red]Error:[/bold red] {msg}")
+    err_console.print(f"[bold red]Error:[/bold red] {msg}")
     raise typer.Exit(1)
 
 


### PR DESCRIPTION
## Summary
- Fix `_error()` to print to stderr instead of stdout
- Enables proper shell integration with command substitution like `cd "$(ag dev path my-branch)"`

## Problem
When using `cd "$(ag dev path merry-otter)"` for a non-existent worktree, the error message was being captured by the command substitution and passed to `cd`, resulting in:
```
cd: no such file or directory: \n/Users/.../Error: Worktree not found: merry-otter
```

## Solution
Created a separate `err_console = Console(stderr=True)` and use it in `_error()` so error messages go to stderr, not stdout.

## Test plan
- [x] Verified `ag dev path non-existent 2>/dev/null` outputs nothing to stdout
- [x] Verified error message still appears on stderr
- [x] All existing tests pass