### PR TITLE
feat(dev): add status command to show worktree git status

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -92,6 +92,76 @@ agent-cli dev list [OPTIONS]
 |--------|-------------|
 | `--porcelain`, `-p` | Machine-readable output (path + branch) |
 
+### `dev status`
+
+Show status of all dev environments with git status information.
+
+```bash
+agent-cli dev status [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--stale-days`, `-s` | Highlight worktrees inactive for N+ days (default: 7) |
+| `--porcelain`, `-p` | Machine-readable output |
+
+**Output columns:**
+
+| Column | Description |
+|--------|-------------|
+| Name | Worktree directory name |
+| Branch | Git branch name |
+| Changes | File changes: `M` modified, `S` staged, `?` untracked |
+| ↑/↓ | Commits ahead (+) / behind (-) upstream |
+| Last Commit | Relative time since last commit |
+
+**Examples:**
+
+```bash
+# Show status of all worktrees
+agent-cli dev status
+
+# Highlight worktrees inactive for 14+ days
+agent-cli dev status --stale-days 14
+
+# Machine-readable output for scripting
+agent-cli dev status --porcelain
+```
+
+**Example output:**
+
+```
+                          Dev Environment Status
+┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━━━┓
+┃ Name        ┃ Branch          ┃ Changes ┃ ↑/↓ ┃ Last Commit    ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━━━┩
+│ main        │ main            │      3M │  —  │ 24 minutes ago │
+│ my-feature  │ feat/my-feature │   clean │  —  │ 9 days ago ⚠️   │
+└─────────────┴─────────────────┴─────────┴─────┴────────────────┘
+
+2 worktrees · 1 with uncommitted changes · 1 stale (>7 days)
+```
+
+**Legend:**
+- `M` = Modified files (not staged)
+- `S` = Staged files
+- `?` = Untracked files
+- `+N` = N commits ahead of upstream
+- `-N` = N commits behind upstream
+- `⚠️` = Stale worktree (inactive for longer than `--stale-days`)
+
+**Porcelain format:**
+
+Tab-separated values: `name`, `branch`, `modified`, `staged`, `untracked`, `ahead`, `behind`, `timestamp`
+
+```bash
+$ agent-cli dev status --porcelain
+main	main	3	0	0	0	0	1768343512
+my-feature	feat/my-feature	0	0	0	0	0	1767544043
+```
+
 ### `dev rm`
 
 Remove a dev environment (worktree).


### PR DESCRIPTION
## Summary

- Add `dev status` command that displays a unified view of all worktrees
- Shows file changes (Modified/Staged/Untracked), commits ahead/behind upstream, and last commit time
- Highlights stale worktrees (inactive for 7+ days by default) with ⚠️ warning
- Includes `--porcelain` option for machine-readable output

## Example output

```
                          Dev Environment Status
┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Name       ┃ Branch                   ┃ Changes ┃ ↑/↓ ┃ Last Commit    ┃
┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━━━┩
│ main       │ main                     │      3M │  —  │ 24 minutes ago │
│ agent-cli2 │ feat/interactive-chat-ui │   clean │  —  │ 9 days ago ⚠️   │
└────────────┴──────────────────────────┴─────────┴─────┴────────────────┘

2 worktrees · 1 with uncommitted changes · 1 stale (>7 days)
```

## Test plan

- [x] `uv run pytest tests/dev/` - all 211 tests pass
- [x] `uv run pre-commit run --all-files` - passes
- [x] Manual testing of `dev status` and `dev status --porcelain`