### PR TITLE
fix(skill): avoid backticks in special char examples that cause parsing error

### DIFF
--- a/.claude/skills/agent-cli-dev/SKILL.md
+++ b/.claude/skills/agent-cli-dev/SKILL.md
@@ -50,7 +50,7 @@ This creates:
 3. Opens a new terminal tab with an AI coding agent
 4. Passes your prompt to the agent
 
-**Important**: Use `--prompt-file` for prompts longer than a single line. The `--prompt` option passes text through the shell, which can cause issues with special characters (`!`, `$`, backticks, quotes) in ZSH and other shells. Using `--prompt-file` avoids all shell quoting issues.
+**Important**: Use `--prompt-file` for prompts longer than a single line. The `--prompt` option passes text through the shell, which can cause issues with special characters (exclamation marks, dollar signs, backticks, quotes) in ZSH and other shells. Using `--prompt-file` avoids all shell quoting issues.
 
 ## Writing effective prompts for spawned agents
 

--- a/agent_cli/dev/skill/SKILL.md
+++ b/agent_cli/dev/skill/SKILL.md
@@ -50,7 +50,7 @@ This creates:
 3. Opens a new terminal tab with an AI coding agent
 4. Passes your prompt to the agent
 
-**Important**: Use `--prompt-file` for prompts longer than a single line. The `--prompt` option passes text through the shell, which can cause issues with special characters (`!`, `$`, backticks, quotes) in ZSH and other shells. Using `--prompt-file` avoids all shell quoting issues.
+**Important**: Use `--prompt-file` for prompts longer than a single line. The `--prompt` option passes text through the shell, which can cause issues with special characters (exclamation marks, dollar signs, backticks, quotes) in ZSH and other shells. Using `--prompt-file` avoids all shell quoting issues.
 
 ## Writing effective prompts for spawned agents
 


### PR DESCRIPTION
## Summary
- Fix Claude Code skill loading error caused by backticks around special characters
- Replace `` `!`, `$` `` with spelled-out "exclamation marks, dollar signs"

## Problem
When loading the `agent-cli-dev` skill, Claude Code's skill parser was incorrectly evaluating inline code blocks containing special shell characters as shell commands:

```
Error: Bash command failed for pattern "!`, `": [stderr]
(eval):1: command not found: ,
```

The backticks around `!` and `$` were being interpreted as shell command substitution.

## Solution
Replace backticked special characters with their spelled-out names to prevent shell evaluation during skill loading.

## Test plan
- [x] Load the skill with `/agent-cli-dev` - should no longer error
- [ ] CI passes