### PR TITLE
fix(dev): fix --force skipping confirmation and --from warning for existing branches

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -570,6 +570,10 @@ def new(  # noqa: PLR0912, PLR0915
     assert result.path is not None
     _success(f"Created worktree at {result.path}")
 
+    # Show warning if --from was ignored
+    if result.warning:
+        _warn(result.warning)
+
     # Copy env files
     if copy_env:
         copied = copy_env_files(repo_root, result.path)
@@ -842,7 +846,7 @@ def remove(
     if wt.is_main:
         _error("Cannot remove the main worktree")
 
-    if not yes:
+    if not yes and not force:
         console.print(f"[bold]Will remove:[/bold] {wt.path}")
         if delete_branch:
             console.print(f"[bold]Will delete branch:[/bold] {wt.branch}")


### PR DESCRIPTION
## Summary
- Fix `--force` flag in `dev rm` to skip confirmation prompt (previously only passed force to git but still prompted)
- Add warning when `--from` flag is specified but branch already exists (previously silently used existing branch)

## Test plan
- [x] Added tests for `dev rm --force` skipping confirmation
- [x] Added tests for `dev rm --yes` skipping confirmation  
- [x] Added tests for `dev rm` prompting without flags
- [x] Added tests for `--from` warning when local branch exists
- [x] Added tests for `--from` warning when remote branch exists
- [x] Added tests for no warning when `--from` not specified
- [x] Added tests for no warning when branch is new
- [x] All tests pass (`pytest tests/dev/`)
- [x] Pre-commit hooks pass