### PR TITLE
fix(skills): auto-load examples.md in agent-cli-dev skill

### DIFF
--- a/.claude/skills/agent-cli-dev/SKILL.md
+++ b/.claude/skills/agent-cli-dev/SKILL.md
@@ -3,6 +3,8 @@ name: agent-cli-dev
 description: Spawn parallel AI coding agents in isolated git worktrees. Use when tasks can be parallelized across multiple independent features, when work benefits from isolation, or when the user asks to work on multiple things at once.
 ---
 
+@examples.md
+
 # Parallel Development with agent-cli dev
 
 This skill teaches you how to spawn parallel AI coding agents in isolated git worktrees using the `agent-cli dev` command.
@@ -131,7 +133,3 @@ Each agent works independently in its own branch. Results can be reviewed and me
 | `--from` / `-f` | Base branch (default: origin/main) |
 | `--with-agent` | Specific agent: claude, aider, codex, gemini |
 | `--agent-args` | Extra arguments for the agent |
-
-## Before spawning agents
-
-**Important**: Before spawning any agents, read [examples.md](examples.md) in this skill directory for comprehensive prompt templates and real-world scenarios. The examples show the proper structure for self-contained prompts that spawned agents can execute independently.


### PR DESCRIPTION
## Summary

- Use `@examples.md` reference syntax to ensure the examples file is automatically loaded when the skill is invoked
- Remove redundant "Before spawning agents" instruction that relied on Claude manually reading the file

## Problem

The `agent-cli-dev` skill's `examples.md` file was not automatically loaded when the skill was invoked. It was only mentioned as a text instruction ("Before spawning agents, read examples.md") which Claude might ignore.

## Solution

The `@file.md` syntax tells Claude Code to include the referenced file automatically when the skill is loaded, rather than relying on progressive disclosure (markdown links) or text instructions.

## Test plan

- [ ] Invoke the `agent-cli-dev` skill and verify Claude has access to the examples.md content
- [ ] Spawned agent prompts should follow the detailed templates from examples.md