### PR TITLE
refactor: centralize provider config construction to eliminate duplication

### DIFF
--- a/agent_cli/agents/assistant.py
+++ b/agent_cli/agents/assistant.py
@@ -339,70 +339,7 @@ def assistant(
         suppress(KeyboardInterrupt),
         maybe_live(not general_cfg.quiet) as live,
     ):
-        provider_cfg = config.ProviderSelection(
-            asr_provider=asr_provider,
-            llm_provider=llm_provider,
-            tts_provider=tts_provider,
-        )
-        audio_in_cfg = config.AudioInput(
-            input_device_index=input_device_index,
-            input_device_name=input_device_name,
-        )
-        wyoming_asr_cfg = config.WyomingASR(
-            asr_wyoming_ip=asr_wyoming_ip,
-            asr_wyoming_port=asr_wyoming_port,
-        )
-        openai_asr_cfg = config.OpenAIASR(
-            asr_openai_model=asr_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=openai_base_url,
-        )
-        gemini_asr_cfg = config.GeminiASR(
-            asr_gemini_model=asr_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        ollama_cfg = config.Ollama(
-            llm_ollama_model=llm_ollama_model,
-            llm_ollama_host=llm_ollama_host,
-        )
-        openai_llm_cfg = config.OpenAILLM(
-            llm_openai_model=llm_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=openai_base_url,
-        )
-        gemini_llm_cfg = config.GeminiLLM(
-            llm_gemini_model=llm_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        audio_out_cfg = config.AudioOutput(
-            enable_tts=enable_tts,
-            output_device_index=output_device_index,
-            output_device_name=output_device_name,
-            tts_speed=tts_speed,
-        )
-        wyoming_tts_cfg = config.WyomingTTS(
-            tts_wyoming_ip=tts_wyoming_ip,
-            tts_wyoming_port=tts_wyoming_port,
-            tts_wyoming_voice=tts_wyoming_voice,
-            tts_wyoming_language=tts_wyoming_language,
-            tts_wyoming_speaker=tts_wyoming_speaker,
-        )
-        openai_tts_cfg = config.OpenAITTS(
-            tts_openai_model=tts_openai_model,
-            tts_openai_voice=tts_openai_voice,
-            openai_api_key=openai_api_key,
-            tts_openai_base_url=tts_openai_base_url,
-        )
-        kokoro_tts_cfg = config.KokoroTTS(
-            tts_kokoro_model=tts_kokoro_model,
-            tts_kokoro_voice=tts_kokoro_voice,
-            tts_kokoro_host=tts_kokoro_host,
-        )
-        gemini_tts_cfg = config.GeminiTTS(
-            tts_gemini_model=tts_gemini_model,
-            tts_gemini_voice=tts_gemini_voice,
-            gemini_api_key=gemini_api_key,
-        )
+        cfgs = config.create_provider_configs_from_locals(locals())
         wake_word_cfg = config.WakeWord(
             wake_server_ip=wake_server_ip,
             wake_server_port=wake_server_port,
@@ -421,20 +358,20 @@ def assistant(
 
         asyncio.run(
             _async_main(
-                provider_cfg=provider_cfg,
+                provider_cfg=cfgs.provider,
                 general_cfg=general_cfg,
-                audio_in_cfg=audio_in_cfg,
-                wyoming_asr_cfg=wyoming_asr_cfg,
-                openai_asr_cfg=openai_asr_cfg,
-                gemini_asr_cfg=gemini_asr_cfg,
-                ollama_cfg=ollama_cfg,
-                openai_llm_cfg=openai_llm_cfg,
-                gemini_llm_cfg=gemini_llm_cfg,
-                audio_out_cfg=audio_out_cfg,
-                wyoming_tts_cfg=wyoming_tts_cfg,
-                openai_tts_cfg=openai_tts_cfg,
-                kokoro_tts_cfg=kokoro_tts_cfg,
-                gemini_tts_cfg=gemini_tts_cfg,
+                audio_in_cfg=cfgs.audio_in,
+                wyoming_asr_cfg=cfgs.wyoming_asr,
+                openai_asr_cfg=cfgs.openai_asr,
+                gemini_asr_cfg=cfgs.gemini_asr,
+                ollama_cfg=cfgs.ollama,
+                openai_llm_cfg=cfgs.openai_llm,
+                gemini_llm_cfg=cfgs.gemini_llm,
+                audio_out_cfg=cfgs.audio_out,
+                wyoming_tts_cfg=cfgs.wyoming_tts,
+                openai_tts_cfg=cfgs.openai_tts,
+                kokoro_tts_cfg=cfgs.kokoro_tts,
+                gemini_tts_cfg=cfgs.gemini_tts,
                 wake_word_cfg=wake_word_cfg,
                 system_prompt=system_prompt,
                 agent_instructions=agent_instructions,

--- a/agent_cli/agents/chat.py
+++ b/agent_cli/agents/chat.py
@@ -466,71 +466,7 @@ def chat(
         return
 
     with process.pid_file_context(process_name), suppress(KeyboardInterrupt):
-        provider_cfg = config.ProviderSelection(
-            asr_provider=asr_provider,
-            llm_provider=llm_provider,
-            tts_provider=tts_provider,
-        )
-        audio_in_cfg = config.AudioInput(
-            input_device_index=input_device_index,
-            input_device_name=input_device_name,
-        )
-        wyoming_asr_cfg = config.WyomingASR(
-            asr_wyoming_ip=asr_wyoming_ip,
-            asr_wyoming_port=asr_wyoming_port,
-        )
-        openai_asr_cfg = config.OpenAIASR(
-            asr_openai_model=asr_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=asr_openai_base_url or openai_base_url,
-            asr_openai_prompt=asr_openai_prompt,
-        )
-        gemini_asr_cfg = config.GeminiASR(
-            asr_gemini_model=asr_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        ollama_cfg = config.Ollama(
-            llm_ollama_model=llm_ollama_model,
-            llm_ollama_host=llm_ollama_host,
-        )
-        openai_llm_cfg = config.OpenAILLM(
-            llm_openai_model=llm_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=openai_base_url,
-        )
-        gemini_llm_cfg = config.GeminiLLM(
-            llm_gemini_model=llm_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        audio_out_cfg = config.AudioOutput(
-            enable_tts=enable_tts,
-            output_device_index=output_device_index,
-            output_device_name=output_device_name,
-            tts_speed=tts_speed,
-        )
-        wyoming_tts_cfg = config.WyomingTTS(
-            tts_wyoming_ip=tts_wyoming_ip,
-            tts_wyoming_port=tts_wyoming_port,
-            tts_wyoming_voice=tts_wyoming_voice,
-            tts_wyoming_language=tts_wyoming_language,
-            tts_wyoming_speaker=tts_wyoming_speaker,
-        )
-        openai_tts_cfg = config.OpenAITTS(
-            tts_openai_model=tts_openai_model,
-            tts_openai_voice=tts_openai_voice,
-            openai_api_key=openai_api_key,
-            tts_openai_base_url=tts_openai_base_url,
-        )
-        kokoro_tts_cfg = config.KokoroTTS(
-            tts_kokoro_model=tts_kokoro_model,
-            tts_kokoro_voice=tts_kokoro_voice,
-            tts_kokoro_host=tts_kokoro_host,
-        )
-        gemini_tts_cfg = config.GeminiTTS(
-            tts_gemini_model=tts_gemini_model,
-            tts_gemini_voice=tts_gemini_voice,
-            gemini_api_key=gemini_api_key,
-        )
+        cfgs = config.create_provider_configs_from_locals(locals())
         history_cfg = config.History(
             history_dir=history_dir,
             last_n_messages=last_n_messages,
@@ -538,20 +474,20 @@ def chat(
 
         asyncio.run(
             _async_main(
-                provider_cfg=provider_cfg,
+                provider_cfg=cfgs.provider,
                 general_cfg=general_cfg,
                 history_cfg=history_cfg,
-                audio_in_cfg=audio_in_cfg,
-                wyoming_asr_cfg=wyoming_asr_cfg,
-                openai_asr_cfg=openai_asr_cfg,
-                gemini_asr_cfg=gemini_asr_cfg,
-                ollama_cfg=ollama_cfg,
-                openai_llm_cfg=openai_llm_cfg,
-                gemini_llm_cfg=gemini_llm_cfg,
-                audio_out_cfg=audio_out_cfg,
-                wyoming_tts_cfg=wyoming_tts_cfg,
-                openai_tts_cfg=openai_tts_cfg,
-                kokoro_tts_cfg=kokoro_tts_cfg,
-                gemini_tts_cfg=gemini_tts_cfg,
+                audio_in_cfg=cfgs.audio_in,
+                wyoming_asr_cfg=cfgs.wyoming_asr,
+                openai_asr_cfg=cfgs.openai_asr,
+                gemini_asr_cfg=cfgs.gemini_asr,
+                ollama_cfg=cfgs.ollama,
+                openai_llm_cfg=cfgs.openai_llm,
+                gemini_llm_cfg=cfgs.gemini_llm,
+                audio_out_cfg=cfgs.audio_out,
+                wyoming_tts_cfg=cfgs.wyoming_tts,
+                openai_tts_cfg=cfgs.openai_tts,
+                kokoro_tts_cfg=cfgs.kokoro_tts,
+                gemini_tts_cfg=cfgs.gemini_tts,
             ),
         )

--- a/agent_cli/agents/voice_edit.py
+++ b/agent_cli/agents/voice_edit.py
@@ -257,86 +257,23 @@ def voice_edit(
         return
 
     with process.pid_file_context(process_name), suppress(KeyboardInterrupt):
-        provider_cfg = config.ProviderSelection(
-            asr_provider=asr_provider,
-            llm_provider=llm_provider,
-            tts_provider=tts_provider,
-        )
-        audio_in_cfg = config.AudioInput(
-            input_device_index=input_device_index,
-            input_device_name=input_device_name,
-        )
-        wyoming_asr_cfg = config.WyomingASR(
-            asr_wyoming_ip=asr_wyoming_ip,
-            asr_wyoming_port=asr_wyoming_port,
-        )
-        openai_asr_cfg = config.OpenAIASR(
-            asr_openai_model=asr_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=openai_base_url,
-        )
-        gemini_asr_cfg = config.GeminiASR(
-            asr_gemini_model=asr_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        ollama_cfg = config.Ollama(
-            llm_ollama_model=llm_ollama_model,
-            llm_ollama_host=llm_ollama_host,
-        )
-        openai_llm_cfg = config.OpenAILLM(
-            llm_openai_model=llm_openai_model,
-            openai_api_key=openai_api_key,
-            openai_base_url=openai_base_url,
-        )
-        gemini_llm_cfg = config.GeminiLLM(
-            llm_gemini_model=llm_gemini_model,
-            gemini_api_key=gemini_api_key,
-        )
-        audio_out_cfg = config.AudioOutput(
-            enable_tts=enable_tts,
-            output_device_index=output_device_index,
-            output_device_name=output_device_name,
-            tts_speed=tts_speed,
-        )
-        wyoming_tts_cfg = config.WyomingTTS(
-            tts_wyoming_ip=tts_wyoming_ip,
-            tts_wyoming_port=tts_wyoming_port,
-            tts_wyoming_voice=tts_wyoming_voice,
-            tts_wyoming_language=tts_wyoming_language,
-            tts_wyoming_speaker=tts_wyoming_speaker,
-        )
-        openai_tts_cfg = config.OpenAITTS(
-            tts_openai_model=tts_openai_model,
-            tts_openai_voice=tts_openai_voice,
-            openai_api_key=openai_api_key,
-            tts_openai_base_url=tts_openai_base_url,
-        )
-        kokoro_tts_cfg = config.KokoroTTS(
-            tts_kokoro_model=tts_kokoro_model,
-            tts_kokoro_voice=tts_kokoro_voice,
-            tts_kokoro_host=tts_kokoro_host,
-        )
-        gemini_tts_cfg = config.GeminiTTS(
-            tts_gemini_model=tts_gemini_model,
-            tts_gemini_voice=tts_gemini_voice,
-            gemini_api_key=gemini_api_key,
-        )
+        cfgs = config.create_provider_configs_from_locals(locals())
 
         asyncio.run(
             _async_main(
-                provider_cfg=provider_cfg,
+                provider_cfg=cfgs.provider,
                 general_cfg=general_cfg,
-                audio_in_cfg=audio_in_cfg,
-                wyoming_asr_cfg=wyoming_asr_cfg,
-                openai_asr_cfg=openai_asr_cfg,
-                gemini_asr_cfg=gemini_asr_cfg,
-                ollama_cfg=ollama_cfg,
-                openai_llm_cfg=openai_llm_cfg,
-                gemini_llm_cfg=gemini_llm_cfg,
-                audio_out_cfg=audio_out_cfg,
-                wyoming_tts_cfg=wyoming_tts_cfg,
-                openai_tts_cfg=openai_tts_cfg,
-                kokoro_tts_cfg=kokoro_tts_cfg,
-                gemini_tts_cfg=gemini_tts_cfg,
+                audio_in_cfg=cfgs.audio_in,
+                wyoming_asr_cfg=cfgs.wyoming_asr,
+                openai_asr_cfg=cfgs.openai_asr,
+                gemini_asr_cfg=cfgs.gemini_asr,
+                ollama_cfg=cfgs.ollama,
+                openai_llm_cfg=cfgs.openai_llm,
+                gemini_llm_cfg=cfgs.gemini_llm,
+                audio_out_cfg=cfgs.audio_out,
+                wyoming_tts_cfg=cfgs.wyoming_tts,
+                openai_tts_cfg=cfgs.openai_tts,
+                kokoro_tts_cfg=cfgs.kokoro_tts,
+                gemini_tts_cfg=cfgs.gemini_tts,
             ),
         )

--- a/agent_cli/config.py
+++ b/agent_cli/config.py
@@ -301,3 +301,171 @@ def _flatten_nested_sections(cfg: dict[str, Any], prefix: str = "") -> dict[str,
         else:
             result[full_key] = value
     return result
+
+
+# --- Common Config Bundle ---
+
+
+class ProviderConfigs(BaseModel):
+    """Bundle of all provider-related configs constructed from CLI parameters."""
+
+    provider: ProviderSelection
+    audio_in: AudioInput
+    wyoming_asr: WyomingASR
+    openai_asr: OpenAIASR
+    gemini_asr: GeminiASR
+    ollama: Ollama
+    openai_llm: OpenAILLM
+    gemini_llm: GeminiLLM
+    audio_out: AudioOutput
+    wyoming_tts: WyomingTTS
+    openai_tts: OpenAITTS
+    kokoro_tts: KokoroTTS
+    gemini_tts: GeminiTTS
+
+
+def create_provider_configs(
+    *,
+    # Provider selection
+    asr_provider: str,
+    llm_provider: str,
+    tts_provider: str,
+    # Audio input
+    input_device_index: int | None,
+    input_device_name: str | None,
+    # Wyoming ASR
+    asr_wyoming_ip: str,
+    asr_wyoming_port: int,
+    # OpenAI ASR
+    asr_openai_model: str,
+    asr_openai_base_url: str | None = None,
+    asr_openai_prompt: str | None = None,
+    # Gemini ASR
+    asr_gemini_model: str,
+    # Ollama LLM
+    llm_ollama_model: str,
+    llm_ollama_host: str,
+    # OpenAI LLM
+    llm_openai_model: str,
+    # Gemini LLM
+    llm_gemini_model: str,
+    # Shared API keys
+    openai_api_key: str | None,
+    openai_base_url: str | None,
+    gemini_api_key: str | None,
+    # Audio output
+    enable_tts: bool,
+    output_device_index: int | None,
+    output_device_name: str | None,
+    tts_speed: float,
+    # Wyoming TTS
+    tts_wyoming_ip: str,
+    tts_wyoming_port: int,
+    tts_wyoming_voice: str | None,
+    tts_wyoming_language: str | None,
+    tts_wyoming_speaker: str | None,
+    # OpenAI TTS
+    tts_openai_model: str,
+    tts_openai_voice: str,
+    tts_openai_base_url: str | None,
+    # Kokoro TTS
+    tts_kokoro_model: str,
+    tts_kokoro_voice: str,
+    tts_kokoro_host: str,
+    # Gemini TTS
+    tts_gemini_model: str,
+    tts_gemini_voice: str,
+) -> ProviderConfigs:
+    """Create all provider-related config objects from CLI parameters.
+
+    This factory function centralizes the construction of provider configs
+    to eliminate duplication across CLI commands.
+    """
+    return ProviderConfigs(
+        provider=ProviderSelection(
+            asr_provider=asr_provider,
+            llm_provider=llm_provider,
+            tts_provider=tts_provider,
+        ),
+        audio_in=AudioInput(
+            input_device_index=input_device_index,
+            input_device_name=input_device_name,
+        ),
+        wyoming_asr=WyomingASR(
+            asr_wyoming_ip=asr_wyoming_ip,
+            asr_wyoming_port=asr_wyoming_port,
+        ),
+        openai_asr=OpenAIASR(
+            asr_openai_model=asr_openai_model,
+            openai_api_key=openai_api_key,
+            openai_base_url=asr_openai_base_url or openai_base_url,
+            asr_openai_prompt=asr_openai_prompt,
+        ),
+        gemini_asr=GeminiASR(
+            asr_gemini_model=asr_gemini_model,
+            gemini_api_key=gemini_api_key,
+        ),
+        ollama=Ollama(
+            llm_ollama_model=llm_ollama_model,
+            llm_ollama_host=llm_ollama_host,
+        ),
+        openai_llm=OpenAILLM(
+            llm_openai_model=llm_openai_model,
+            openai_api_key=openai_api_key,
+            openai_base_url=openai_base_url,
+        ),
+        gemini_llm=GeminiLLM(
+            llm_gemini_model=llm_gemini_model,
+            gemini_api_key=gemini_api_key,
+        ),
+        audio_out=AudioOutput(
+            enable_tts=enable_tts,
+            output_device_index=output_device_index,
+            output_device_name=output_device_name,
+            tts_speed=tts_speed,
+        ),
+        wyoming_tts=WyomingTTS(
+            tts_wyoming_ip=tts_wyoming_ip,
+            tts_wyoming_port=tts_wyoming_port,
+            tts_wyoming_voice=tts_wyoming_voice,
+            tts_wyoming_language=tts_wyoming_language,
+            tts_wyoming_speaker=tts_wyoming_speaker,
+        ),
+        openai_tts=OpenAITTS(
+            tts_openai_model=tts_openai_model,
+            tts_openai_voice=tts_openai_voice,
+            openai_api_key=openai_api_key,
+            tts_openai_base_url=tts_openai_base_url,
+        ),
+        kokoro_tts=KokoroTTS(
+            tts_kokoro_model=tts_kokoro_model,
+            tts_kokoro_voice=tts_kokoro_voice,
+            tts_kokoro_host=tts_kokoro_host,
+        ),
+        gemini_tts=GeminiTTS(
+            tts_gemini_model=tts_gemini_model,
+            tts_gemini_voice=tts_gemini_voice,
+            gemini_api_key=gemini_api_key,
+        ),
+    )
+
+
+# Parameter names used by create_provider_configs (all keyword-only)
+_PROVIDER_CONFIG_PARAMS = frozenset(
+    create_provider_configs.__code__.co_varnames[
+        : create_provider_configs.__code__.co_kwonlyargcount
+    ],
+)
+
+
+def create_provider_configs_from_locals(local_vars: dict[str, Any]) -> ProviderConfigs:
+    """Create provider configs by extracting parameters from a locals() dict.
+
+    This helper enables one-line config creation in CLI commands by automatically
+    extracting the relevant parameters from the command's local variables.
+
+    Usage:
+        cfgs = config.create_provider_configs_from_locals(locals())
+    """
+    kwargs = {k: v for k, v in local_vars.items() if k in _PROVIDER_CONFIG_PARAMS}
+    return create_provider_configs(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,8 +194,7 @@ default-tag = "0.0.0"
 # Minimum lines number of a similarity (duplicate-code check)
 # Set higher than jscpd (15) to catch only very large duplications
 # jscpd is the primary checker; pylint is a secondary safety net
-# Current codebase has ~65-line duplications; set to 70 to pass but catch larger ones
-min-similarity-lines = 70
+min-similarity-lines = 20
 # Ignore comments when computing similarities
 ignore-comments = true
 # Ignore docstrings when computing similarities


### PR DESCRIPTION
## Summary

- Add `ProviderConfigs` dataclass bundling all 13 provider-related config objects
- Add `create_provider_configs()` factory function that constructs all configs from CLI parameters
- Add `create_provider_configs_from_locals()` helper enabling one-line config creation via `locals()`
- Update `assistant.py`, `chat.py`, `voice_edit.py` to use the new helper
- Lower pylint `min-similarity-lines` threshold from 70 to 20 for stricter duplicate detection

## Test plan

- [x] All 737 tests pass
- [x] Pre-commit checks pass (including pylint duplicate-code and jscpd)