### PR TITLE
fix(server): properly release MLX memory on TTL unload

### DIFF
--- a/agent_cli/server/whisper/backends/base.py
+++ b/agent_cli/server/whisper/backends/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
@@ -106,32 +107,29 @@ def release_memory() -> None:
     - CUDA memory cache (for faster-whisper with GPU)
     - MLX buffer cache (for mlx-whisper on Apple Silicon)
     - mlx_whisper's internal ModelHolder cache
+
+    Only clears caches for modules that are already imported to avoid
+    triggering slow imports unnecessarily.
     """
     gc.collect()
 
-    # Clear CUDA memory if available
-    try:
+    # Clear CUDA memory if available (only if torch is already imported)
+    if "torch" in sys.modules:
         import torch  # noqa: PLC0415
 
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-    except ImportError:
-        pass
 
-    # Clear MLX buffer cache
-    try:
+    # Clear MLX buffer cache (only if mlx is already imported)
+    if "mlx.core" in sys.modules:
         import mlx.core as mx  # noqa: PLC0415
 
         mx.clear_cache()
-    except ImportError:
-        pass
 
-    # Clear mlx_whisper's ModelHolder cache
+    # Clear mlx_whisper's ModelHolder cache (only if already imported)
     # The library caches the model at class level for reuse across transcribe() calls
-    try:
+    if "mlx_whisper.transcribe" in sys.modules:
         from mlx_whisper.transcribe import ModelHolder  # noqa: PLC0415
 
         ModelHolder.model = None
         ModelHolder.model_path = None
-    except ImportError:
-        pass


### PR DESCRIPTION
## Summary

- Fix TTL-based model unloading not actually freeing memory on the MLX backend
- Clear MLX buffer cache via `mx.clear_cache()`
- Clear mlx_whisper's internal `ModelHolder` cache which stores models at the class level

## Problem

The TTL mechanism was working logically (tracking state, gating requests), but was **not freeing Metal memory** because:

1. **mlx_whisper caches models internally** via a `ModelHolder` class with class-level variables
2. **MLX's Metal buffer cache** was never cleared

## Solution

Extend `release_memory()` to clear both caching layers:

```python
# Clear MLX buffer cache
try:
    import mlx.core as mx
    mx.clear_cache()
except ImportError:
    pass

# Clear mlx_whisper's ModelHolder cache
try:
    from mlx_whisper.transcribe import ModelHolder
    ModelHolder.model = None
    ModelHolder.model_path = None
except ImportError:
    pass
```

## References

- [MLX GPU Memory Management Issue #742](https://github.com/ml-explore/mlx/issues/742)
- [MLX Metal Cache Control PR #390](https://github.com/ml-explore/mlx/pull/390)

## Test plan

- [x] All existing tests pass
- [x] Manual test on macOS: verify memory is freed after TTL expires