### PR TITLE
fix(server): remove -h short option from --host

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -130,7 +130,6 @@ def whisper_cmd(  # noqa: PLR0912, PLR0915
         str,
         typer.Option(
             "--host",
-            "-h",
             help="Host to bind the server to",
         ),
     ] = "0.0.0.0",  # noqa: S104
@@ -338,7 +337,7 @@ def whisper_cmd(  # noqa: PLR0912, PLR0915
 def transcription_proxy_cmd(
     host: Annotated[
         str,
-        typer.Option("--host", "-h", help="Host to bind the server to"),
+        typer.Option("--host", help="Host to bind the server to"),
     ] = "0.0.0.0",  # noqa: S104
     port: Annotated[
         int,


### PR DESCRIPTION
## Summary
- Remove `-h` short option from `--host` in `whisper` and `transcription-proxy` server commands
- The `-h` was conflicting with the standard `--help` flag

## Test plan
- [x] Pre-commit hooks pass
- [x] Verify `agent server whisper --help` works correctly
- [x] Verify `agent server transcription-proxy --help` works correctly