### PR TITLE
fix(server): escape Rich brackets in dependency error messages

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -48,7 +48,8 @@ def _check_server_deps() -> None:
     if not HAS_UVICORN or not HAS_FASTAPI:
         err_console.print(
             "[bold red]Error:[/bold red] Server dependencies not installed. "
-            "Run: [cyan]pip install agent-cli[server][/cyan]",
+            "Run: [cyan]pip install agent-cli\\[server][/cyan] "
+            "or [cyan]uv sync --extra server[/cyan]",
         )
         raise typer.Exit(1)
 
@@ -60,7 +61,8 @@ def _check_whisper_deps(backend: str, *, download_only: bool = False) -> None:
         if not HAS_FASTER_WHISPER:
             err_console.print(
                 "[bold red]Error:[/bold red] faster-whisper is required for --download-only. "
-                "Run: [cyan]pip install agent-cli[whisper][/cyan]",
+                "Run: [cyan]pip install agent-cli\\[whisper][/cyan] "
+                "or [cyan]uv sync --extra whisper[/cyan]",
             )
             raise typer.Exit(1)
         return
@@ -77,7 +79,8 @@ def _check_whisper_deps(backend: str, *, download_only: bool = False) -> None:
     if not HAS_FASTER_WHISPER:
         err_console.print(
             "[bold red]Error:[/bold red] Whisper dependencies not installed. "
-            "Run: [cyan]pip install agent-cli[whisper][/cyan]",
+            "Run: [cyan]pip install agent-cli\\[whisper][/cyan] "
+            "or [cyan]uv sync --extra whisper[/cyan]",
         )
         raise typer.Exit(1)
 


### PR DESCRIPTION
## Summary
- Fixed server CLI dependency error messages that were displaying incorrectly
- The `[server]` and `[whisper]` in pip install commands were being interpreted as Rich markup tags instead of literal text
- Added `uv sync --extra <name>` alternative for consistency with other dependency error messages in the codebase

**Before:** `Error: Server dependencies not installed. Run: pip install agent-cli`

**After:** `Error: Server dependencies not installed. Run: pip install agent-cli[server] or uv sync --extra server`

## Test plan
- [x] Verify error message displays correctly when running `agent-cli server whisper` without server deps installed