### PR TITLE
fix: add TERMINAL_WIDTH env var for Typer help formatting

### DIFF
--- a/docs/run_markdown_code_runner.py
+++ b/docs/run_markdown_code_runner.py
@@ -43,7 +43,8 @@ def run_markdown_code_runner(files: list[Path], repo_root: Path) -> bool:
 
     # Set fixed terminal width for reproducible Rich/Typer CLI help output
     env = os.environ.copy()
-    env["COLUMNS"] = FIXED_TERMINAL_WIDTH
+    env["COLUMNS"] = FIXED_TERMINAL_WIDTH  # Rich Console width
+    env["TERMINAL_WIDTH"] = FIXED_TERMINAL_WIDTH  # Typer MAX_WIDTH for help panels
     # Prevent Typer from forcing terminal mode in CI (GITHUB_ACTIONS),
     # which treats TERM=dumb as a fixed 80-column terminal.
     env["_TYPER_FORCE_DISABLE_TERMINAL"] = "1"


### PR DESCRIPTION
## Summary
- Add `TERMINAL_WIDTH` env var alongside `COLUMNS` in `run_markdown_code_runner.py`
- Typer uses `TERMINAL_WIDTH` as `MAX_WIDTH` for help panel formatting (see [typer/rich_utils.py:69](https://github.com/fastapi/typer/blob/54712cd9a6b8a4342f98991c9fe7942100a43720/typer/rich_utils.py#L69))
- `COLUMNS` is used by Rich for console width - both are needed for consistent 90-char output

## Test plan
- [x] CI passes with no doc changes pushed