### PR TITLE
docs: add NixOS/CDI GPU configuration comment for Docker Compose

### DIFF
--- a/docker/docker-compose.whisper.yml
+++ b/docker/docker-compose.whisper.yml
@@ -36,6 +36,9 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+    # For NixOS or other CDI-based Docker setups, replace the `deploy` section with:
+    #   devices:
+    #     - nvidia.com/gpu=0    # Single GPU (use nvidia.com/gpu=all for all GPUs)
     restart: unless-stopped
 
   whisper-cpu:


### PR DESCRIPTION
## Summary
- Add a comment in `docker/docker-compose.whisper.yml` explaining that for NixOS or other CDI-based Docker setups, users should replace the `deploy.resources.reservations.devices` section with `devices: [nvidia.com/gpu=0]` (or `nvidia.com/gpu=all` for all GPUs)
- The standard nvidia runtime approach doesn't work on NixOS since it uses CDI instead

## Test plan
- [x] Verify the YAML syntax is valid
- [x] Verify the comment is clear and accurate