### PR TITLE
chore: rename docker-compose.services.yml to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 - **[`memory`](docs/commands/memory.md)**: Long-term memory system with `memory proxy` and `memory add`.
 - **[`rag-proxy`](docs/commands/rag-proxy.md)**: RAG proxy server for chatting with your documents.
 - **[`dev`](docs/commands/dev.md)**: Parallel development with git worktrees and AI coding agents.
-- **[`server`](docs/commands/server.md)**: Local ASR and TTS servers with OpenAI-compatible API, Wyoming protocol for Home Assistant, and TTL-based memory management. Whisper uses MLX on Apple Silicon (Metal) or Faster Whisper on Linux (CUDA). TTS supports Kokoro (GPU) or Piper (CPU).
+- **[`server`](docs/commands/server.md)**: Local ASR and TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory management, and multi-platform acceleration. Whisper uses MLX on Apple Silicon or Faster Whisper on Linux/CUDA. TTS supports Kokoro (GPU) or Piper (CPU).
 - **[`transcribe-daemon`](docs/commands/transcribe-daemon.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]"`.
 
 ## Quick Start

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,13 +8,13 @@
 #
 # Usage:
 #   # Run all services with CUDA (GPU)
-#   docker compose -f docker/docker-compose.services.yml --profile cuda up
+#   docker compose -f docker/docker-compose.yml --profile cuda up
 #
 #   # Run all services with CPU only
-#   docker compose -f docker/docker-compose.services.yml --profile cpu up
+#   docker compose -f docker/docker-compose.yml --profile cpu up
 #
 #   # Build from source instead of using pre-built images
-#   docker compose -f docker/docker-compose.services.yml --profile cuda up --build
+#   docker compose -f docker/docker-compose.yml --profile cuda up --build
 #
 # Environment variables:
 #   WHISPER_MODEL      - Whisper model (default: large-v3 for CUDA, small for CPU)

--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -16,8 +16,10 @@ FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu22.04 AS cuda
 
 # Install system dependencies
 # espeak-ng is required for Kokoro's phoneme generation
+# build-essential is required for compiling C++ extensions (curated-tokenizers)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        build-essential \
         curl \
         ffmpeg \
         git \

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 | [`rag-proxy`](commands/rag-proxy.md) | Chat with your documents via RAG |
 | [`memory`](commands/memory.md) | Long-term memory system for conversations |
 | [`dev`](commands/dev.md) | Parallel development with git worktrees and AI coding agents |
-| [`server`](commands/server.md) | Local ASR & TTS servers with dual-protocol, TTL-based memory, and multi-platform acceleration (MLX/CUDA) |
+| [`server`](commands/server.md) | Local ASR & TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory, and multi-platform acceleration (MLX/CUDA) |
 
 ## Quick Start
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -24,19 +24,19 @@ Universal Docker setup that works on any platform with Docker support.
 1. **Start all services with GPU acceleration:**
 
    ```bash
-   docker compose -f docker/docker-compose.services.yml --profile cuda up
+   docker compose -f docker/docker-compose.yml --profile cuda up
    ```
 
    Or for CPU-only:
 
    ```bash
-   docker compose -f docker/docker-compose.services.yml --profile cpu up
+   docker compose -f docker/docker-compose.yml --profile cpu up
    ```
 
 2. **Check if services are running:**
 
    ```bash
-   docker compose -f docker/docker-compose.services.yml logs
+   docker compose -f docker/docker-compose.yml logs
    ```
 
 3. **Install agent-cli:**
@@ -85,16 +85,16 @@ The CUDA profile automatically enables GPU for Whisper and TTS. For Ollama GPU s
 
 ```bash
 # Start services in background
-docker compose -f docker/docker-compose.services.yml --profile cuda up -d
+docker compose -f docker/docker-compose.yml --profile cuda up -d
 
 # Stop services
-docker compose -f docker/docker-compose.services.yml --profile cuda down
+docker compose -f docker/docker-compose.yml --profile cuda down
 
 # View logs
-docker compose -f docker/docker-compose.services.yml logs -f
+docker compose -f docker/docker-compose.yml logs -f
 
 # Rebuild from source
-docker compose -f docker/docker-compose.services.yml --profile cuda up --build
+docker compose -f docker/docker-compose.yml --profile cuda up --build
 ```
 
 ## Data Persistence


### PR DESCRIPTION
## Summary
- Rename `docker-compose.services.yml` to `docker-compose.yml` for simpler usage
- Fix TTS CUDA Dockerfile missing `build-essential` for C++ extension compilation
- Clarify dual-protocol support as "(Wyoming & OpenAI)" in docs

## Changes
- `docker/docker-compose.services.yml` → `docker/docker-compose.yml`
- Added `build-essential` to TTS CUDA Dockerfile
- Updated all documentation references

## Test Results
All containers tested locally:
- [x] TTS CPU - healthy
- [x] TTS CUDA - healthy  
- [x] Whisper CPU - healthy
- [x] Whisper CUDA - healthy