### PR TITLE
fix: handle git submodules correctly in dev command

### DIFF
--- a/agent_cli/dev/worktree.py
+++ b/agent_cli/dev/worktree.py
@@ -91,10 +91,11 @@ def get_main_repo_root(path: Path | None = None) -> Path | None:
         return common_dir.parent
     # Check if we're in a submodule (common_dir is inside .git/modules/)
     # e.g., /path/to/parent/.git/modules/submodule-name
-    common_dir_str = str(common_dir)
-    if "/.git/modules/" in common_dir_str or "\\.git\\modules\\" in common_dir_str:
-        # For submodules, use --show-toplevel to get the submodule's working directory
-        return get_repo_root(path)
+    parts = common_dir.parts
+    for i, part in enumerate(parts[:-1]):
+        if part == ".git" and parts[i + 1] == "modules":
+            # For submodules, use --show-toplevel to get the submodule's working directory
+            return get_repo_root(path)
     # For bare repos or unusual setups, try to go up from common_dir
     return common_dir.parent
 


### PR DESCRIPTION
## Summary

- Fix `dev new` failing with `PermissionError` when run inside a git submodule
- Detect submodule paths (inside `.git/modules/`) and use `--show-toplevel` instead of `--git-common-dir` parent

## Problem

When running `agent-cli dev new` inside a git submodule (e.g., `/opt/stacks/compose-farm`), the `get_main_repo_root()` function incorrectly returned `/opt/stacks/.git/modules` instead of `/opt/stacks/compose-farm`.

This caused the worktree base directory to be calculated as `/opt/stacks-worktrees`, which requires root permissions to create.

## Root Cause

For submodules, `git rev-parse --git-common-dir` returns paths like `/path/to/parent/.git/modules/submodule-name`. The existing code checked if `common_dir.name == ".git"` and if not, returned `common_dir.parent` - which for submodules gives `.git/modules/` instead of the actual working directory.

## Test plan

- [x] Added tests for `get_main_repo_root()` covering regular repos and submodules
- [x] All existing tests pass
- [x] Pre-commit checks pass