### PR TITLE
fix: add spacy model download to TTS Docker image

### DIFF
--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -46,6 +46,9 @@ ENV UV_PYTHON=3.13 \
 
 RUN uv tool install --python 3.13 "agent-cli[tts-kokoro]"
 
+# Download spacy model required by misaki/Kokoro for grapheme-to-phoneme conversion
+RUN /opt/uv-tools/agent-cli/bin/python -m spacy download en_core_web_sm
+
 # Create cache directory for models
 RUN mkdir -p /home/tts/.cache && chown -R tts:tts /home/tts
 


### PR DESCRIPTION
## Summary
- Add spacy English model (en_core_web_sm) download during Docker image build for the CUDA target

## Problem
The `agent-cli-tts:latest-cuda` Docker image fails on first TTS request with `SystemExit: 1`.

Kokoro TTS uses misaki for grapheme-to-phoneme conversion, which requires the spacy English model. When the model loads, spacy tries to `pip install` the model at runtime, but:
1. The container runs as non-root user `tts` (uid 1000)
2. The site-packages directory `/opt/uv-tools/agent-cli/lib/python3.13/site-packages/` is owned by root
3. The pip install fails with "Permission denied"

## Solution
Pre-install the spacy model during the Docker image build, after the `uv tool install` line.

## Test plan
- [ ] Build the CUDA Docker image: `docker build -f docker/tts.Dockerfile --target cuda -t agent-cli-tts:cuda .`
- [ ] Run container and verify TTS works on first request without errors