### PR TITLE
fix: change default TTS response_format to mp3 for OpenAI compatibility

### DIFF
--- a/agent_cli/server/tts/api.py
+++ b/agent_cli/server/tts/api.py
@@ -109,7 +109,7 @@ class SpeechRequest(BaseModel):
     input: str
     model: str = "tts-1"
     voice: str = "alloy"
-    response_format: Literal["wav", "pcm", "mp3"] = "pcm"
+    response_format: Literal["mp3", "wav", "pcm"] = "mp3"
     speed: float = 1.0
     stream_format: Literal["audio"] | None = None
 


### PR DESCRIPTION
## Summary
- Change default `response_format` from `pcm` to `mp3` to match OpenAI's TTS API behavior
- Fixes compatibility with OpenAI-compatible clients like LibreChat that expect MP3 by default

## Problem
The OpenAI TTS API (`/v1/audio/speech`) defaults to `mp3` format, but our server defaulted to `pcm`. Clients like LibreChat don't specify `response_format` and expect MP3, so they received raw PCM data that couldn't be played.

## Solution
Changed the default from `pcm` to `mp3`. The MP3 conversion adds ~40-70ms latency but provides 3-4x compression, which often results in faster total response time over networks.

## Test plan
- [x] All existing tests pass
- [x] Added new test for default MP3 format behavior
- [x] Verified MP3 output is valid with `file` and `ffprobe`
- [ ] Test with LibreChat after rebuilding Docker image