### PR TITLE
build: migrate from setuptools to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,14 +132,6 @@ source = "versioningit"
 [tool.hatch.build.targets.wheel]
 packages = ["agent_cli"]
 
-[tool.versioningit]
-default-version = "0.0.0"
-
-[tool.versioningit.vcs]
-method = "git"
-match = ["v*"]
-default-tag = "0.0.0"
-
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
@@ -209,6 +201,14 @@ max-complexity = 18
 
 [tool.mypy]
 python_version = "3.11"
+
+[tool.versioningit]
+default-version = "0.0.0"
+
+[tool.versioningit.vcs]
+method = "git"
+match = ["v*"]
+default-tag = "0.0.0"
 
 [tool.pylint.similarities]
 # Minimum lines number of a similarity (duplicate-code check)


### PR DESCRIPTION
## Summary
- Switch build backend from setuptools to hatchling for better package data handling
- Hatchling automatically includes all files in the package (including `dev/skill/*.md` files)
- Fixes `ag dev install-skill` command failing when installed via `uv tool install`
- Keeps versioningit for git-based versioning

## Test plan
- [x] Editable install works: `uv pip install -e .`
- [x] Non-editable install works: `uv pip install .`
- [x] Tool install works: `uv tool install .`
- [x] Skill files are included in installed package
- [x] `ag dev install-skill` works with tool-installed version
- [x] All dev CLI tests pass
- [x] Pre-commit checks pass