### PR TITLE
fix: update broken links to server documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 - **[`memory`](docs/commands/memory.md)**: Long-term memory system with `memory proxy` and `memory add`.
 - **[`rag-proxy`](docs/commands/rag-proxy.md)**: RAG proxy server for chatting with your documents.
 - **[`dev`](docs/commands/dev.md)**: Parallel development with git worktrees and AI coding agents.
-- **[`server`](docs/commands/server.md)**: Local ASR and TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory management, and multi-platform acceleration. Whisper uses MLX on Apple Silicon or Faster Whisper on Linux/CUDA. TTS supports Kokoro (GPU) or Piper (CPU).
+- **[`server`](docs/commands/server/index.md)**: Local ASR and TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory management, and multi-platform acceleration. Whisper uses MLX on Apple Silicon or Faster Whisper on Linux/CUDA. TTS supports Kokoro (GPU) or Piper (CPU).
 - **[`transcribe-daemon`](docs/commands/transcribe-daemon.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]"`.
 
 ## Quick Start
@@ -309,7 +309,7 @@ Our installation scripts automatically handle all dependencies:
 |---------|---------|-----------------|
 | **[Ollama](https://ollama.ai/)** | Local LLM for text processing | ✅ Yes, with default model |
 | **[Wyoming Faster Whisper](https://github.com/rhasspy/wyoming-faster-whisper)** | Speech-to-text | ✅ Yes, via `uvx` |
-| **[`agent-cli server whisper`](docs/commands/server.md#whisper)** | Speech-to-text (alternative) | ✅ Built-in, `pip install "agent-cli[whisper]"` |
+| **[`agent-cli server whisper`](docs/commands/server/whisper.md)** | Speech-to-text (alternative) | ✅ Built-in, `pip install "agent-cli[whisper]"` |
 | **[Wyoming Piper](https://github.com/rhasspy/wyoming-piper)** | Text-to-speech | ✅ Yes, via `uvx` |
 | **[Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI)** | Premium TTS (optional) | ⚙️ Can be added later |
 | **[Wyoming openWakeWord](https://github.com/rhasspy/wyoming-openwakeword)** | Wake word detection | ✅ Yes, for `assistant` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,7 +235,7 @@ Now just run `agent-cli transcribe` - it automatically uses your local server.
 
 > [!TIP]
 > **OpenAI SDK users:** The server also exposes an OpenAI-compatible API on port 10301.
-> See [server whisper docs](commands/server.md#whisper) for all options.
+> See [server whisper docs](commands/server/whisper.md) for all options.
 
 ## Audio Device Configuration
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ For a complete local setup with all AI services:
 > pip install "agent-cli[whisper-mlx]"
 > agent-cli server whisper --backend mlx
 > ```
-> See [Local Whisper Server](commands/server.md#whisper) for details.
+> See [Local Whisper Server](commands/server/whisper.md) for details.
 
 === "Using CLI Commands"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 | [`rag-proxy`](commands/rag-proxy.md) | Chat with your documents via RAG |
 | [`memory`](commands/memory.md) | Long-term memory system for conversations |
 | [`dev`](commands/dev.md) | Parallel development with git worktrees and AI coding agents |
-| [`server`](commands/server.md) | Local ASR & TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory, and multi-platform acceleration (MLX/CUDA) |
+| [`server`](commands/server/index.md) | Local ASR & TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory, and multi-platform acceleration (MLX/CUDA) |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Fixed 5 broken documentation links that referenced the old `commands/server.md` path
- After #266 split the server documentation into dedicated pages, these references were not updated

## Changes

| File | Old Link | New Link |
|------|----------|----------|
| `README.md` (line 51) | `docs/commands/server.md` | `docs/commands/server/index.md` |
| `README.md` (line 312) | `docs/commands/server.md#whisper` | `docs/commands/server/whisper.md` |
| `docs/index.md` | `commands/server.md` | `commands/server/index.md` |
| `docs/configuration.md` | `commands/server.md#whisper` | `commands/server/whisper.md` |
| `docs/getting-started.md` | `commands/server.md#whisper` | `commands/server/whisper.md` |

## Test plan

- [x] Ran `uv run python docs/run_markdown_code_runner.py` - all 16 files updated successfully
- [x] Ran `uv run pytest tests/test_docs_gen.py` - 36 tests pass
- [x] Ran `uv run pre-commit run --all-files` - all checks pass
- [x] Verified no remaining references to old path with `grep -r "commands/server\.md"`