### PR TITLE
refactor: organize CLI commands into logical help panels

### DIFF
--- a/agent_cli/agents/assistant.py
+++ b/agent_cli/agents/assistant.py
@@ -253,7 +253,7 @@ async def _async_main(
                 print_with_style("✨ Ready for next command...", style="green")
 
 
-@app.command("assistant")
+@app.command("assistant", rich_help_panel="Voice Commands")
 def assistant(
     *,
     # --- Provider Selection ---

--- a/agent_cli/agents/autocorrect.py
+++ b/agent_cli/agents/autocorrect.py
@@ -208,7 +208,7 @@ async def _async_autocorrect(
         sys.exit(1)
 
 
-@app.command("autocorrect")
+@app.command("autocorrect", rich_help_panel="Text Commands")
 def autocorrect(
     *,
     text: str | None = typer.Argument(

--- a/agent_cli/agents/chat.py
+++ b/agent_cli/agents/chat.py
@@ -373,7 +373,7 @@ async def _async_main(
         raise
 
 
-@app.command("chat")
+@app.command("chat", rich_help_panel="Voice Commands")
 def chat(
     *,
     # --- Provider Selection ---

--- a/agent_cli/agents/memory/__init__.py
+++ b/agent_cli/agents/memory/__init__.py
@@ -14,7 +14,7 @@ memory_app = typer.Typer(
     no_args_is_help=True,
 )
 
-app.add_typer(memory_app, name="memory")
+app.add_typer(memory_app, name="memory", rich_help_panel="Servers")
 
 
 @memory_app.callback()

--- a/agent_cli/agents/rag_proxy.py
+++ b/agent_cli/agents/rag_proxy.py
@@ -17,7 +17,7 @@ from agent_cli.core.utils import (
 )
 
 
-@app.command("rag-proxy")
+@app.command("rag-proxy", rich_help_panel="Servers")
 def rag_proxy(
     docs_folder: Path = typer.Option(  # noqa: B008
         "./rag_docs",

--- a/agent_cli/agents/speak.py
+++ b/agent_cli/agents/speak.py
@@ -79,7 +79,7 @@ async def _async_main(
     return text
 
 
-@app.command("speak")
+@app.command("speak", rich_help_panel="Text Commands")
 def speak(
     *,
     text: str | None = typer.Argument(

--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -460,7 +460,7 @@ async def _async_main(  # noqa: PLR0912, PLR0915, C901
     )
 
 
-@app.command("transcribe")
+@app.command("transcribe", rich_help_panel="Voice Commands")
 def transcribe(  # noqa: PLR0912
     *,
     extra_instructions: str | None = typer.Option(

--- a/agent_cli/agents/transcribe_daemon.py
+++ b/agent_cli/agents/transcribe_daemon.py
@@ -286,7 +286,7 @@ async def _daemon_loop(cfg: DaemonConfig) -> None:  # noqa: PLR0912, PLR0915
                     await asyncio.wait(background_tasks, timeout=2.0)
 
 
-@app.command("transcribe-daemon")
+@app.command("transcribe-daemon", rich_help_panel="Voice Commands")
 def transcribe_daemon(  # noqa: PLR0912
     *,
     # Daemon-specific options

--- a/agent_cli/agents/voice_edit.py
+++ b/agent_cli/agents/voice_edit.py
@@ -172,7 +172,7 @@ async def _async_main(
         )
 
 
-@app.command("voice-edit")
+@app.command("voice-edit", rich_help_panel="Voice Commands")
 def voice_edit(
     *,
     # --- Provider Selection ---

--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -122,7 +122,7 @@ app = typer.Typer(
     rich_markup_mode="markdown",
     no_args_is_help=True,
 )
-main_app.add_typer(app, name="dev")
+main_app.add_typer(app, name="dev", rich_help_panel="Development")
 
 
 @app.callback()

--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -34,7 +34,7 @@ app = typer.Typer(
     rich_markup_mode="markdown",
     no_args_is_help=True,
 )
-main_app.add_typer(app, name="server")
+main_app.add_typer(app, name="server", rich_help_panel="Servers")
 
 
 @app.callback()


### PR DESCRIPTION
## Summary

- Organize 13+ CLI commands into logical groups in the `--help` output
- Makes the CLI feel less overwhelming without any breaking changes
- Uses Typer's `rich_help_panel` feature to group related commands

## Changes

Commands are now grouped into:
- **Voice Commands**: transcribe, chat, voice-edit, assistant, transcribe-daemon
- **Text Commands**: autocorrect, speak
- **Servers**: rag-proxy, server, memory
- **Development**: dev
- *(existing panels preserved)*: Installation, Service Management, Configuration

## Before/After

**Before:** All commands in a flat list

**After:**
```
╭─ Voice Commands ─────────────────────────────────────────────────────────────╮
│ assistant           Wake word-based voice assistant...                       │
│ chat                An chat agent that you can talk to.                      │
│ transcribe          Wyoming ASR Client for streaming microphone audio...     │
│ voice-edit          Interact with clipboard text via a voice command...      │
│ transcribe-daemon   Run a continuous transcription daemon...                 │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Text Commands ──────────────────────────────────────────────────────────────╮
│ autocorrect         Correct text from clipboard using a local or remote LLM. │
│ speak               Convert text to speech...                                │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ Servers ────────────────────────────────────────────────────────────────────╮
│ rag-proxy           Start the RAG Proxy Server.                              │
│ memory              Memory system operations (add, proxy, etc.).             │
│ server              Run ASR/TTS servers...                                   │
╰──────────────────────────────────────────────────────────────────────────────╯
...
```

## Test plan

- [x] All 875 tests pass
- [x] Pre-commit hooks pass
- [x] Verified `agent-cli --help` shows correct grouping