### PR TITLE
feat(dev): auto-pull Git LFS files in new worktrees

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -495,6 +495,16 @@ git submodule update --init --recursive
 
 This ensures all submodule dependencies are available in the worktree.
 
+### Git LFS
+
+If the repository uses Git LFS (detected via `filter=lfs` in `.gitattributes`), LFS files are automatically pulled:
+
+```bash
+git lfs pull
+```
+
+This ensures large files tracked by LFS are available in the worktree.
+
 ### Environment Files
 
 The following files are automatically copied to new dev environments:


### PR DESCRIPTION
## Summary

- Automatically run `git lfs pull` when creating new dev environments
- Detect LFS usage via `filter=lfs` in `.gitattributes`
- Skip gracefully if git-lfs is not installed or LFS is not used

## Changes

- Added `_pull_lfs()` function to `worktree.py`
- Called after `_init_submodules()` in `create_worktree()`
- Added documentation in `docs/commands/dev.md`
- Added 4 tests for the new functionality

## Test plan

- [x] Run `uv run pytest tests/dev/test_worktree.py -v` - all 40 tests pass
- [x] Run `uv run pre-commit run --all-files` on changed files - all checks pass
- [x] Manual test: `agent-cli dev new test-branch` in a repo with Git LFS