### PR TITLE
feat(dev): save prompt to .claude/TASK.md in worktree

### DIFF
--- a/agent_cli/dev/skill/SKILL.md
+++ b/agent_cli/dev/skill/SKILL.md
@@ -47,8 +47,9 @@ agent-cli dev new <branch-name> --agent --prompt-file path/to/prompt.md
 This creates:
 1. A new git worktree with its own branch
 2. Runs project setup (installs dependencies)
-3. Opens a new terminal tab with an AI coding agent
-4. Passes your prompt to the agent
+3. Saves your prompt to `.claude/TASK.md` in the worktree (for reference)
+4. Opens a new terminal tab with an AI coding agent
+5. Passes your prompt to the agent
 
 **Important**: Use `--prompt-file` for prompts longer than a single line. The `--prompt` option passes text through the shell, which can cause issues with special characters (exclamation marks, dollar signs, backticks, quotes) in ZSH and other shells. Using `--prompt-file` avoids all shell quoting issues.
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -61,8 +61,8 @@ agent-cli dev new [BRANCH] [OPTIONS]
 | `--with-editor` | Specific editor (cursor, vscode, zed, etc.) |
 | `--with-agent` | Specific agent (claude, codex, gemini, aider) |
 | `--agent-args` | Extra arguments to pass to the agent |
-| `--prompt`, `-p` | Initial prompt to pass to the AI agent |
-| `--prompt-file`, `-P` | Read initial prompt from a file (avoids shell quoting issues) |
+| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree) |
+| `--prompt-file`, `-P` | Read initial prompt from a file (saved to `.claude/TASK.md` in worktree) |
 | `--direnv` | Generate .envrc file for direnv (auto-detects venv) |
 | `--setup/--no-setup` | Run automatic project setup (default: enabled) |
 | `--copy-env/--no-copy-env` | Copy .env files from main repo (default: enabled) |
@@ -223,8 +223,8 @@ agent-cli dev agent NAME [--agent/-a AGENT] [--agent-args ARGS] [--prompt/-p PRO
 |--------|-------------|
 | `--agent`, `-a` | Specific agent (claude, codex, gemini, aider) |
 | `--agent-args` | Extra arguments to pass to the agent |
-| `--prompt`, `-p` | Initial prompt to pass to the AI agent |
-| `--prompt-file`, `-P` | Read initial prompt from a file (avoids shell quoting issues) |
+| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree) |
+| `--prompt-file`, `-P` | Read initial prompt from a file (saved to `.claude/TASK.md` in worktree) |
 
 **Examples:**
 


### PR DESCRIPTION
## Summary
- When using `--prompt` or `--prompt-file` with `dev new` or `dev agent`, the prompt is now automatically saved to `.claude/TASK.md` in the worktree
- This provides a persistent record of the task assigned to the worktree and serves as reference material for spawned agents

## Changes
- Added `_write_prompt_to_worktree()` helper function that creates `.claude/TASK.md`
- Both `dev new` and `dev agent` commands now save the prompt to the worktree before launching the agent
- Updated documentation to reflect this behavior

## Test plan
- [x] All 885 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual testing: `agent-cli dev new test-branch --prompt "Fix the bug"` creates `.claude/TASK.md`