### PR TITLE
refactor: remove Python 3.14 version markers from optional deps

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import sys
 from importlib.util import find_spec
-
-# Dependencies that don't support Python 3.14 yet
-_PYTHON_314_INCOMPATIBLE = {"chromadb", "onnxruntime"}
 
 
 def ensure_optional_dependencies(
@@ -21,18 +17,6 @@ def ensure_optional_dependencies(
     ]
     if not missing:
         return
-
-    # Check if running on Python 3.14+ with incompatible dependencies
-    is_py314 = sys.version_info >= (3, 14)
-    incompatible = set(missing) & _PYTHON_314_INCOMPATIBLE
-
-    if is_py314 and incompatible:
-        msg = (
-            f"The '{extra_name}' feature requires {', '.join(sorted(incompatible))}, "
-            f"which {'does' if len(incompatible) == 1 else 'do'} not support Python 3.14 yet. "
-            f"Please use Python 3.13 or earlier for this feature."
-        )
-        raise ImportError(msg)
 
     hint = install_hint or f"`pip install agent-cli[{extra_name}]`"
     msg = f"Missing required dependencies for {extra_name}: {', '.join(missing)}. Please install with {hint}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,21 +38,18 @@ server = [
 ]
 rag = [
     "fastapi[standard]",
-    # TODO: remove python_version constraint when deps support 3.14 (https://github.com/basnijholt/agent-cli/issues/199)
-    "chromadb>=0.4.22; python_version < '3.14'",
-    "onnxruntime>=1.17.0; python_version < '3.14'",
+    "chromadb>=0.4.22",
+    "onnxruntime>=1.17.0",
     "huggingface-hub>=0.20.0",
     "transformers>=4.30.0",
     "watchfiles>=0.21.0",
     # Until here same as 'memory' extras
-    # TODO: remove python_version constraint when markitdown's magika->onnxruntime dep supports 3.14
-    "markitdown[docx,pdf,pptx]>=0.1.3; python_version < '3.14'",
+    "markitdown[docx,pdf,pptx]>=0.1.3",
 ]
 memory = [
     "fastapi[standard]",
-    # TODO: remove python_version constraint when deps support 3.14 (https://github.com/basnijholt/agent-cli/issues/199)
-    "chromadb>=0.4.22; python_version < '3.14'",
-    "onnxruntime>=1.17.0; python_version < '3.14'",
+    "chromadb>=0.4.22",
+    "onnxruntime>=1.17.0",
     "huggingface-hub>=0.20.0",
     "transformers>=4.30.0",
     "watchfiles>=0.21.0",
@@ -60,8 +57,7 @@ memory = [
     "pyyaml>=6.0.0",
 ]
 vad = [
-    # TODO: remove python_version constraint when silero-vad's onnxruntime dep supports 3.14
-    "silero-vad>=5.1; python_version < '3.14'",
+    "silero-vad>=5.1",
 ]
 whisper = [
     "fastapi[standard]",


### PR DESCRIPTION
## Summary
- Remove `python_version < '3.14'` constraints from onnxruntime, chromadb, silero-vad, and markitdown
- Remove Python 3.14 runtime check from `agent_cli/core/deps.py`

Since `requires-python` is now `>=3.11,<3.14` (#284), these individual version markers are no longer needed.

## Related
- Reverts the approach from #198
- Closes #199