### PR TITLE
docs: add -p 3.13 to uv tool install commands

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -17,10 +17,10 @@ The plugin provides a skill that enables Claude Code to:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Or run directly without installing
-uvx agent-cli dev new my-feature --agent --prompt "..."
+uvx --python 3.13 agent-cli dev new my-feature --agent --prompt "..."
 ```
 
 ### Install the Claude Code plugin

--- a/.claude-plugin/skills/agent-cli-dev/SKILL.md
+++ b/.claude-plugin/skills/agent-cli-dev/SKILL.md
@@ -13,10 +13,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Or run directly without installing
-uvx agent-cli dev new <branch-name> --agent --prompt "..."
+uvx --python 3.13 agent-cli dev new <branch-name> --agent --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/.claude/skills/agent-cli-dev/SKILL.md
+++ b/.claude/skills/agent-cli-dev/SKILL.md
@@ -13,10 +13,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Or run directly without installing
-uvx agent-cli dev new <branch-name> --agent --prompt "..."
+uvx --python 3.13 agent-cli dev new <branch-name> --agent --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 - **[`rag-proxy`](docs/commands/rag-proxy.md)**: RAG proxy server for chatting with your documents.
 - **[`dev`](docs/commands/dev.md)**: Parallel development with git worktrees and AI coding agents.
 - **[`server`](docs/commands/server/index.md)**: Local ASR and TTS servers with dual-protocol (Wyoming & OpenAI), TTL-based memory management, and multi-platform acceleration. Whisper uses MLX on Apple Silicon or Faster Whisper on Linux/CUDA. TTS supports Kokoro (GPU) or Piper (CPU).
-- **[`transcribe-daemon`](docs/commands/transcribe-daemon.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]"`.
+- **[`transcribe-daemon`](docs/commands/transcribe-daemon.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]" -p 3.13`.
 
 ## Quick Start
 
@@ -59,11 +59,15 @@ If you already have AI services running (or plan to use OpenAI), simply install:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Using pip
 pip install agent-cli
 ```
+
+> [!NOTE]
+> The `-p 3.13` flag is required because some dependencies (like `onnxruntime`) don't support Python 3.14 yet.
+> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then use it:
 ```bash
@@ -98,12 +102,12 @@ agent-cli autocorrect "this has an eror"
 
 > [!NOTE]
 > `agent-cli` uses `sounddevice` for real-time microphone/voice features.
-> On Linux only, you need to install the system-level PortAudio library  (`sudo apt install portaudio19-dev` / your distro's equivalent on Linux) **before** you run `uv tool install agent-cli`.
+> On Linux only, you need to install the system-level PortAudio library  (`sudo apt install portaudio19-dev` / your distro's equivalent on Linux) **before** you run `uv tool install agent-cli -p 3.13`.
 > On Windows and macOS, this is handled automatically.
 
 ```bash
 # 1. Install agent-cli
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # 2. Install all required services
 agent-cli install-services
@@ -184,7 +188,7 @@ If you already have AI services set up or plan to use cloud services (OpenAI/Gem
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Using pip
 pip install agent-cli
@@ -748,7 +752,7 @@ the `[defaults]` section of your configuration file.
 
 **Installation:** Requires the `vad` extra:
 ```bash
-uv tool install "agent-cli[vad]"
+uv tool install "agent-cli[vad]" -p 3.13
 ```
 
 **How to Use It:**

--- a/agent_cli/dev/skill/SKILL.md
+++ b/agent_cli/dev/skill/SKILL.md
@@ -13,10 +13,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Or run directly without installing
-uvx agent-cli dev new <branch-name> --agent --prompt "..."
+uvx --python 3.13 agent-cli dev new <branch-name> --agent --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/docs/commands/transcribe-daemon.md
+++ b/docs/commands/transcribe-daemon.md
@@ -32,7 +32,7 @@ Saving MP3 files requires FFmpeg; if it's not available, audio saving is disable
 Requires the `vad` extra:
 
 ```bash
-uv tool install "agent-cli[vad]"
+uv tool install "agent-cli[vad]" -p 3.13
 # or
 pip install "agent-cli[vad]"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,11 +22,15 @@ If you already have AI services set up or plan to use cloud services (OpenAI/Gem
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Using pip
 pip install agent-cli
 ```
+
+> [!NOTE]
+> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
+> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 ### Option 2: Full Local Setup
 
@@ -49,7 +53,7 @@ For a complete local setup with all AI services:
 
     ```bash
     # 1. Install agent-cli
-    uv tool install agent-cli
+    uv tool install agent-cli -p 3.13
 
     # 2. Install all required services
     agent-cli install-services

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,11 +74,15 @@ If you already have AI services running (or plan to use OpenAI):
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Using pip
 pip install agent-cli
 ```
+
+> [!NOTE]
+> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
+> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then use it:
 
@@ -90,7 +94,7 @@ agent-cli autocorrect "this has an eror"
 
 ```bash
 # 1. Install agent-cli
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # 2. Install all required services
 agent-cli install-services

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -42,7 +42,7 @@ Universal Docker setup that works on any platform with Docker support.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli
+   uv tool install agent-cli -p 3.13
    # or: pip install agent-cli
    ```
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -85,11 +85,15 @@ Once services are running, install the agent-cli package:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Using pip
 pip install agent-cli
 ```
+
+> [!NOTE]
+> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
+> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then test with:
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -41,7 +41,7 @@ Native Linux setup with full NVIDIA GPU acceleration for optimal performance.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli
+   uv tool install agent-cli -p 3.13
    ```
 
 4. **Test the setup:**

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -33,7 +33,7 @@ Native macOS setup with full Metal GPU acceleration for optimal performance.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli
+   uv tool install agent-cli -p 3.13
    # or: pip install agent-cli
    ```
 

--- a/docs/installation/nixos.md
+++ b/docs/installation/nixos.md
@@ -112,7 +112,7 @@ If you have an NVIDIA GPU, also add:
 3. **Install agent-cli:**
 
    ```bash
-   nix-shell -p portaudio pkg-config gcc python3 --run "uv tool install --upgrade agent-cli"
+   nix-shell -p portaudio pkg-config gcc python3 --run "uv tool install --upgrade agent-cli -p 3.13"
    # or add to your configuration:
    # environment.systemPackages = with pkgs; [ agent-cli ];
    ```

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -32,7 +32,7 @@ The fastest way to get started - no local services needed:
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # Install agent-cli
-uv tool install agent-cli
+uv tool install agent-cli -p 3.13
 
 # Use with cloud providers (requires API keys)
 $env:OPENAI_API_KEY = "sk-..."
@@ -93,7 +93,7 @@ If you prefer manual setup:
 3. **Install agent-cli:**
 
    ```powershell
-   uv tool install agent-cli
+   uv tool install agent-cli -p 3.13
    ```
 
 4. **Run services individually:**


### PR DESCRIPTION
## Summary
- Add `-p 3.13` flag to all `uv tool install` commands in documentation
- Add notes explaining why the flag is needed

## Problem
`uv tool install` doesn't respect `requires-python` upper bounds. When uv picks Python 3.14 by default, it installs an older version of agent-cli (that was compatible with 3.14) instead of using Python 3.13 with the latest version.

See: https://github.com/astral-sh/uv/issues/8206

## Files updated
- README.md
- docs/installation/*.md
- docs/getting-started.md
- docs/index.md
- docs/commands/transcribe-daemon.md
- Skill files (.claude/, .claude-plugin/, agent_cli/dev/skill/)