### PR TITLE
fix: make numpy an optional dependency

### DIFF
--- a/agent_cli/_extras.json
+++ b/agent_cli/_extras.json
@@ -1,5 +1,5 @@
 {
-  "audio": ["Audio recording/playback with Wyoming protocol", ["sounddevice", "wyoming"]],
+  "audio": ["Audio recording/playback with Wyoming protocol", ["numpy", "sounddevice", "wyoming"]],
   "llm": ["LLM framework (pydantic-ai)", ["pydantic_ai"]],
   "memory": ["Long-term memory proxy", ["chromadb", "yaml"]],
   "rag": ["RAG proxy (ChromaDB, embeddings)", ["chromadb"]],

--- a/agent_cli/_requirements/faster-whisper.txt
+++ b/agent_cli/_requirements/faster-whisper.txt
@@ -96,7 +96,6 @@ mpmath==1.3.0
     # via sympy
 numpy==2.3.5
     # via
-    #   agent-cli
     #   ctranslate2
     #   onnxruntime
 onnxruntime==1.20.1

--- a/agent_cli/_requirements/kokoro.txt
+++ b/agent_cli/_requirements/kokoro.txt
@@ -164,7 +164,6 @@ num2words==0.5.14
     # via misaki
 numpy==2.3.5
     # via
-    #   agent-cli
     #   blis
     #   kokoro
     #   soundfile

--- a/agent_cli/_requirements/llm.txt
+++ b/agent_cli/_requirements/llm.txt
@@ -85,8 +85,6 @@ markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-numpy==2.3.5
-    # via agent-cli
 openai==2.15.0
     # via pydantic-ai-slim
 opentelemetry-api==1.39.1

--- a/agent_cli/_requirements/memory.txt
+++ b/agent_cli/_requirements/memory.txt
@@ -132,7 +132,6 @@ mpmath==1.3.0
     # via sympy
 numpy==2.3.5
     # via
-    #   agent-cli
     #   chromadb
     #   onnxruntime
     #   transformers

--- a/agent_cli/_requirements/mlx-whisper.txt
+++ b/agent_cli/_requirements/mlx-whisper.txt
@@ -102,7 +102,6 @@ numba==0.63.1
     # via mlx-whisper
 numpy==2.3.5
     # via
-    #   agent-cli
     #   mlx-whisper
     #   numba
     #   scipy

--- a/agent_cli/_requirements/piper.txt
+++ b/agent_cli/_requirements/piper.txt
@@ -74,9 +74,7 @@ mdurl==0.1.2
 mpmath==1.3.0
     # via sympy
 numpy==2.3.5
-    # via
-    #   agent-cli
-    #   onnxruntime
+    # via onnxruntime
 onnxruntime==1.20.1
     # via piper-tts
 packaging==25.0

--- a/agent_cli/_requirements/rag.txt
+++ b/agent_cli/_requirements/rag.txt
@@ -160,7 +160,6 @@ mpmath==1.3.0
     # via sympy
 numpy==2.3.5
     # via
-    #   agent-cli
     #   chromadb
     #   magika
     #   onnxruntime

--- a/agent_cli/_requirements/server.txt
+++ b/agent_cli/_requirements/server.txt
@@ -65,8 +65,6 @@ markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-numpy==2.3.5
-    # via agent-cli
 psutil==7.2.1 ; sys_platform == 'win32'
     # via agent-cli
 pydantic==2.12.5

--- a/agent_cli/_requirements/speed.txt
+++ b/agent_cli/_requirements/speed.txt
@@ -33,9 +33,7 @@ markdown-it-py==4.0.0
 mdurl==0.1.2
     # via markdown-it-py
 numpy==2.3.5
-    # via
-    #   agent-cli
-    #   audiostretchy
+    # via audiostretchy
 psutil==7.2.1 ; sys_platform == 'win32'
     # via agent-cli
 pydantic==2.12.5

--- a/agent_cli/_requirements/vad.txt
+++ b/agent_cli/_requirements/vad.txt
@@ -47,9 +47,7 @@ mpmath==1.3.0
 networkx==3.6.1
     # via torch
 numpy==2.3.5
-    # via
-    #   agent-cli
-    #   onnxruntime
+    # via onnxruntime
 nvidia-cublas-cu12==12.8.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via
     #   nvidia-cudnn-cu12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dynamic = ["version"]
 authors = [{ name = "Bas Nijholt", email = "bas@nijho.lt" }]
 dependencies = [
     # Core dependencies that are always required
-    "numpy",
     "pydantic",  # Required for config.py models
     "rich",
     "pyperclip",
@@ -31,7 +30,7 @@ Homepage = "https://github.com/basnijholt/agent-cli"
 
 [project.optional-dependencies]
 # Provider extras (previously base dependencies, now optional)
-audio = ["sounddevice>=0.4.6", "wyoming>=1.5.2"]
+audio = ["numpy", "sounddevice>=0.4.6", "wyoming>=1.5.2"]
 llm = ["pydantic-ai-slim[openai,google,duckduckgo,vertexai]>=0.1.1"]
 
 # Feature extras

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,6 @@ source = { editable = "." }
 dependencies = [
     { name = "dotenv" },
     { name = "httpx" },
-    { name = "numpy" },
     { name = "psutil", marker = "sys_platform == 'win32'" },
     { name = "pydantic" },
     { name = "pyperclip" },
@@ -36,6 +35,7 @@ dependencies = [
 
 [package.optional-dependencies]
 audio = [
+    { name = "numpy" },
     { name = "sounddevice" },
     { name = "wyoming" },
 ]
@@ -155,7 +155,7 @@ requires-dist = [
     { name = "markitdown", extras = ["docx", "pdf", "pptx"], marker = "extra == 'rag'", specifier = ">=0.1.3" },
     { name = "mlx-whisper", marker = "extra == 'mlx-whisper'", specifier = ">=0.4.0" },
     { name = "notebook", marker = "extra == 'dev'" },
-    { name = "numpy" },
+    { name = "numpy", marker = "extra == 'audio'" },
     { name = "onnxruntime", marker = "extra == 'memory'", specifier = ">=1.17.0" },
     { name = "onnxruntime", marker = "extra == 'rag'", specifier = ">=1.17.0" },
     { name = "pip", marker = "extra == 'kokoro'" },


### PR DESCRIPTION
## Summary
- Move `numpy` from core dependencies to the `audio` extra
- Other extras that use numpy (vad, rag, memory, kokoro, mlx-whisper) already get it as a transitive dependency from their packages
- Updates `_extras.json` to check for numpy in the audio extra

## Test plan
- [x] All 893 tests pass
- [x] Pre-commit hooks pass
- [x] Verified minimal install has no numpy: `uv pip list | grep numpy` shows nothing
- [x] Verified error messages work: `ag transcribe --last-recording 1` shows audio extra install hint