### PR TITLE
fix: combine multiple missing extras into single error message

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -65,9 +65,9 @@ def _format_install_commands(extras: list[str]) -> list[str]:
     extras_args = " ".join(extras)
     return [
         "Install with:",
-        f'  uv tool install -p 3.13 "agent-cli[{combined}]"',
+        f'  [bold cyan]uv tool install -p 3.13 "agent-cli\\[{combined}]"[/bold cyan]',
         "  # or",
-        f"  agent-cli install-extras {extras_args}",
+        f"  [bold cyan]agent-cli install-extras {extras_args}[/bold cyan]",
     ]
 
 
@@ -83,9 +83,14 @@ def get_install_hint(extra: str) -> str:
         lines.extend(_format_extra_item(alt) for alt in alternatives)
         lines.append("")
         lines.append("Install one with:")
-        lines.extend(f'  uv tool install -p 3.13 "agent-cli[{alt}]"' for alt in alternatives)
+        lines.extend(
+            f'  [bold cyan]uv tool install -p 3.13 "agent-cli\\[{alt}]"[/bold cyan]'
+            for alt in alternatives
+        )
         lines.append("  # or")
-        lines.extend(f"  agent-cli install-extras {alt}" for alt in alternatives)
+        lines.extend(
+            f"  [bold cyan]agent-cli install-extras {alt}[/bold cyan]" for alt in alternatives
+        )
         return "\n".join(lines)
 
     desc, _ = EXTRAS.get(extra, ("", []))

--- a/agent_cli/core/utils.py
+++ b/agent_cli/core/utils.py
@@ -211,8 +211,8 @@ def print_output_panel(
 
 
 def print_error_message(message: str, suggestion: str | None = None) -> None:
-    """Prints an error message in a panel."""
-    error_text = Text(message)
+    """Prints an error message in a panel with rich markup support."""
+    error_text = Text.from_markup(message)
     if suggestion:
         error_text.append("\n\n")
         error_text.append(suggestion)

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -36,8 +36,9 @@ class TestRequiresExtrasDecorator:
         assert "requires one of:" in hint
         assert "'piper'" in hint
         assert "'kokoro'" in hint
-        assert "agent-cli[piper]" in hint
-        assert "agent-cli[kokoro]" in hint
+        # Brackets are escaped for rich markup (\\[)
+        assert "agent-cli\\[piper]" in hint
+        assert "agent-cli\\[kokoro]" in hint
 
 
 class TestExtrasMetadata:


### PR DESCRIPTION
## Summary
- Show all missing extras in one error box instead of separate boxes for each
- Include combined install command: `uv tool install -p 3.13 "agent-cli[audio,llm]"`
- Fix `-p` flag position in uv install commands (now before package name)
- DRY up install hint formatting with `_format_extra_item()` and `_format_install_commands()` helpers

## Before
```
╭─── Error ───╮
│ audio...    │
╰─────────────╯
╭─── Error ───╮
│ llm...      │
╰─────────────╯
```

## After
```
╭─────────────────────────────────── Error ────────────────────────────────────╮
│ This command requires the following extras:                                  │
│   - 'audio' (Audio recording/playback with Wyoming protocol)                 │
│   - 'llm' (LLM framework (pydantic-ai))                                      │
│                                                                              │
│ Install with:                                                                │
│   uv tool install -p 3.13 "agent-cli[audio,llm]"                             │
│   # or                                                                       │
│   agent-cli install-extras audio llm                                         │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Test plan
- [x] All 893 tests pass
- [x] Pre-commit hooks pass
- [x] Verified combined message in temp venv