### PR TITLE
fix(docker): use correct extras for TTS and Whisper Dockerfiles

### DIFF
--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /app
 # Install from lock file for reproducible builds
 COPY pyproject.toml uv.lock ./
 ENV UV_PYTHON=3.13
-RUN uv sync --frozen --no-dev --extra kokoro --no-install-project && \
+RUN uv sync --frozen --no-dev --extra server --extra kokoro --no-install-project && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     /app/.venv/bin/python -m spacy download en_core_web_sm
 
@@ -100,7 +100,7 @@ WORKDIR /app
 
 # Install from lock file for reproducible builds
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra piper --no-install-project && \
+RUN uv sync --frozen --no-dev --extra server --extra piper --no-install-project && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli
 
 # Create cache directory for models

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 # Install from lock file for reproducible builds
 COPY pyproject.toml uv.lock ./
 ENV UV_PYTHON=3.13
-RUN uv sync --frozen --no-dev --extra whisper --no-install-project && \
+RUN uv sync --frozen --no-dev --extra server --extra faster-whisper --no-install-project && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli
 
 # Create cache directory for models
@@ -92,7 +92,7 @@ WORKDIR /app
 
 # Install from lock file for reproducible builds
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra whisper --no-install-project && \
+RUN uv sync --frozen --no-dev --extra server --extra faster-whisper --no-install-project && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli
 
 # Create cache directory for models


### PR DESCRIPTION
## Summary
- TTS Dockerfile: `tts-kokoro` → `server,kokoro`, `tts` → `server,piper`
- Whisper Dockerfile: `whisper` → `server,faster-whisper`

The server commands require both the `server` extra and the backend-specific extra (per `@requires_extras` decorators).

## Test plan
- [ ] Docker workflow should pass after merge