### PR TITLE
fix: show full uv tool install command when installing extras

### DIFF
--- a/agent_cli/install/extras.py
+++ b/agent_cli/install/extras.py
@@ -66,8 +66,8 @@ def _install_via_uv_tool(extras: list[str]) -> bool:
     extras_str = ",".join(extras)
     package_spec = f"agent-cli[{extras_str}]=={current_version}"
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    console.print(f"Reinstalling via uv tool: [cyan]{package_spec}[/] (Python {python_version})")
     cmd = ["uv", "tool", "install", package_spec, "--force", "--python", python_version]
+    console.print(f"Running: [cyan]{' '.join(cmd)}[/]")
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
 


### PR DESCRIPTION
## Summary
Shows the actual `uv tool install ...` command being run instead of just "Reinstalling via uv tool: package-spec".

Before: `Reinstalling via uv tool: agent-cli[rag]==0.68.3 (Python 3.13)`
After: `Running: uv tool install agent-cli[rag]==0.68.3 --force --python 3.13`

## Test plan
- [ ] Run `agent-cli install-extras rag` on a uv tool installation and verify command is shown