### PR TITLE
fix: switch from typer to typer-slim to avoid namespace conflict

### DIFF
--- a/agent_cli/_requirements/audio.txt
+++ b/agent_cli/_requirements/audio.txt
@@ -11,7 +11,7 @@ certifi==2026.1.4
 cffi==2.0.0
     # via sounddevice
 click==8.3.1
-    # via typer
+    # via typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 dotenv==0.9.9
@@ -49,21 +49,21 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
-    #   typer
+    #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via typer-slim
 sounddevice==0.5.3
     # via agent-cli
-typer==0.21.1
+typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
     #   pydantic
     #   pydantic-core
-    #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/agent_cli/_requirements/faster-whisper.txt
+++ b/agent_cli/_requirements/faster-whisper.txt
@@ -23,6 +23,7 @@ click==8.3.1
     # via
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
@@ -146,6 +147,7 @@ rich==14.2.0
     #   agent-cli
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -159,7 +161,9 @@ setproctitle==1.3.7
 setuptools==80.9.0
     # via ctranslate2
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 starlette==0.50.0
     # via fastapi
 sympy==1.14.0
@@ -172,9 +176,10 @@ tqdm==4.67.1
     #   huggingface-hub
 typer==0.21.1
     # via
-    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -186,6 +191,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   starlette
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/kokoro.txt
+++ b/agent_cli/_requirements/kokoro.txt
@@ -291,6 +291,7 @@ rich==14.2.0
     #   agent-cli
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -315,7 +316,9 @@ setuptools==80.9.0
     #   thinc
     #   torch
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 six==1.17.0
     # via python-dateutil
 smart-open==7.5.0
@@ -364,11 +367,11 @@ triton==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via torch
 typer==0.21.1
     # via
-    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1
     # via
+    #   agent-cli
     #   spacy
     #   weasel
 typing-extensions==4.15.0

--- a/agent_cli/_requirements/llm.txt
+++ b/agent_cli/_requirements/llm.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.4.4
 click==8.3.1
     # via
     #   ddgs
-    #   typer
+    #   typer-slim
 colorama==0.4.6
     # via
     #   click
@@ -132,13 +132,13 @@ requests==2.32.5
 rich==14.2.0
     # via
     #   agent-cli
-    #   typer
+    #   typer-slim
 rsa==4.9.1
     # via google-auth
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via typer-slim
 sniffio==1.3.1
     # via
     #   google-genai
@@ -151,7 +151,7 @@ tiktoken==0.12.0
     # via pydantic-ai-slim
 tqdm==4.67.1
     # via openai
-typer==0.21.1
+typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
     # via
@@ -161,7 +161,7 @@ typing-extensions==4.15.0
     #   opentelemetry-api
     #   pydantic
     #   pydantic-core
-    #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/memory.txt
+++ b/agent_cli/_requirements/memory.txt
@@ -34,6 +34,7 @@ click==8.3.1
     # via
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 colorama==0.4.6 ; os_name == 'nt' or sys_platform == 'win32'
     # via
@@ -252,6 +253,7 @@ rich==14.2.0
     #   chromadb
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -271,7 +273,9 @@ sentry-sdk==2.49.0
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 six==1.17.0
     # via
     #   kubernetes
@@ -296,10 +300,11 @@ transformers==4.57.5
     # via agent-cli
 typer==0.21.1
     # via
-    #   agent-cli
     #   chromadb
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -318,6 +323,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   starlette
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/mlx-whisper.txt
+++ b/agent_cli/_requirements/mlx-whisper.txt
@@ -21,6 +21,7 @@ click==8.3.1
     # via
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
@@ -148,6 +149,7 @@ rich==14.2.0
     #   agent-cli
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1 ; platform_machine == 'arm64' and sys_platform == 'darwin'
     # via
     #   fastapi-cli
@@ -163,7 +165,9 @@ setproctitle==1.3.7
 setuptools==80.9.0 ; python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin'
     # via torch
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 starlette==0.50.0 ; platform_machine == 'arm64' and sys_platform == 'darwin'
     # via fastapi
 sympy==1.14.0 ; platform_machine == 'arm64' and sys_platform == 'darwin'
@@ -176,11 +180,12 @@ tqdm==4.67.1 ; platform_machine == 'arm64' and sys_platform == 'darwin'
     # via
     #   huggingface-hub
     #   mlx-whisper
-typer==0.21.1
+typer==0.21.1 ; platform_machine == 'arm64' and sys_platform == 'darwin'
     # via
-    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -193,6 +198,7 @@ typing-extensions==4.15.0
     #   starlette
     #   torch
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/piper.txt
+++ b/agent_cli/_requirements/piper.txt
@@ -18,6 +18,7 @@ click==8.3.1
     # via
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
@@ -118,6 +119,7 @@ rich==14.2.0
     #   agent-cli
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -129,16 +131,19 @@ sentry-sdk==2.49.0
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 starlette==0.50.0
     # via fastapi
 sympy==1.14.0
     # via onnxruntime
 typer==0.21.1
     # via
-    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -149,6 +154,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   starlette
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/rag.txt
+++ b/agent_cli/_requirements/rag.txt
@@ -44,6 +44,7 @@ click==8.3.1
     #   magika
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 cobble==0.1.4
     # via mammoth
@@ -292,6 +293,7 @@ rich==14.2.0
     #   chromadb
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -311,7 +313,9 @@ sentry-sdk==2.49.0
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 six==1.17.0
     # via
     #   kubernetes
@@ -339,10 +343,11 @@ transformers==4.57.5
     # via agent-cli
 typer==0.21.1
     # via
-    #   agent-cli
     #   chromadb
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -363,6 +368,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   starlette
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/server.txt
+++ b/agent_cli/_requirements/server.txt
@@ -18,6 +18,7 @@ click==8.3.1
     # via
     #   rich-toolkit
     #   typer
+    #   typer-slim
     #   uvicorn
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
@@ -98,6 +99,7 @@ rich==14.2.0
     #   agent-cli
     #   rich-toolkit
     #   typer
+    #   typer-slim
 rich-toolkit==0.17.1
     # via
     #   fastapi-cli
@@ -109,14 +111,17 @@ sentry-sdk==2.49.0
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via
+    #   typer
+    #   typer-slim
 starlette==0.50.0
     # via fastapi
 typer==0.21.1
     # via
-    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
+typer-slim==0.21.1
+    # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
@@ -127,6 +132,7 @@ typing-extensions==4.15.0
     #   rich-toolkit
     #   starlette
     #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/agent_cli/_requirements/speed.txt
+++ b/agent_cli/_requirements/speed.txt
@@ -11,7 +11,7 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
 click==8.3.1
-    # via typer
+    # via typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 dotenv==0.9.9
@@ -49,21 +49,21 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
-    #   typer
+    #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer
+    # via typer-slim
 termcolor==3.3.0
     # via fire
-typer==0.21.1
+typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
     # via
     #   anyio
     #   pydantic
     #   pydantic-core
-    #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/agent_cli/_requirements/vad.txt
+++ b/agent_cli/_requirements/vad.txt
@@ -9,7 +9,7 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
 click==8.3.1
-    # via typer
+    # via typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 coloredlogs==15.0.1
@@ -112,13 +112,13 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
-    #   typer
+    #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 setuptools==80.9.0 ; python_full_version >= '3.12'
     # via torch
 shellingham==1.5.4
-    # via typer
+    # via typer-slim
 silero-vad==6.2.0
     # via agent-cli
 sympy==1.14.0
@@ -133,7 +133,7 @@ torchaudio==2.9.1
     # via silero-vad
 triton==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via torch
-typer==0.21.1
+typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
     # via
@@ -141,7 +141,7 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   torch
-    #   typer
+    #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic",  # Required for config.py models
     "rich",
     "pyperclip",
-    "typer",
+    "typer-slim[standard]",
     "dotenv",
     "httpx",
     "psutil; sys_platform == 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ dependencies = [
     { name = "pyperclip" },
     { name = "rich" },
     { name = "setproctitle" },
-    { name = "typer" },
+    { name = "typer-slim", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
@@ -188,7 +188,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'kokoro'", specifier = ">=4.40.0" },
     { name = "transformers", marker = "extra == 'memory'", specifier = ">=4.30.0" },
     { name = "transformers", marker = "extra == 'rag'", specifier = ">=4.30.0" },
-    { name = "typer" },
+    { name = "typer-slim", extras = ["standard"] },
     { name = "versioningit", marker = "extra == 'dev'" },
     { name = "watchfiles", marker = "extra == 'memory'", specifier = ">=0.21.0" },
     { name = "watchfiles", marker = "extra == 'rag'", specifier = ">=0.21.0" },
@@ -5358,6 +5358,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Work around [astral-sh/uv#17645](https://github.com/astral-sh/uv/issues/17645) where `typer` and `typer-slim` both provide the same `typer/` namespace.

When extras bringing in `typer-slim` (via `spacy`) are installed then removed, uv deletes the shared files, breaking `typer`:

```bash
uv tool install agent-cli
uv tool install 'agent-cli[kokoro]' --force
uv tool install agent-cli --force
ag --version  # ModuleNotFoundError: No module named 'typer'
```

By depending on `typer-slim[standard]` instead of `typer`, we ensure only one package owns the namespace.

## Test plan

- [x] All tests pass
- [x] Pre-commit passes
- [x] `typer-slim[standard]` is functionally equivalent to `typer` (includes `rich` and `shellingham`)