### PR TITLE
fix: depend on both typer and typer-slim to prevent namespace corruption

### DIFF
--- a/agent_cli/_requirements/audio.txt
+++ b/agent_cli/_requirements/audio.txt
@@ -11,7 +11,9 @@ certifi==2026.1.4
 cffi==2.0.0
     # via sounddevice
 click==8.3.1
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 dotenv==0.9.9
@@ -49,12 +51,17 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
+    #   typer
     #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 sounddevice==0.5.3
+    # via agent-cli
+typer==0.21.1
     # via agent-cli
 typer-slim==0.21.1
     # via agent-cli
@@ -63,6 +70,7 @@ typing-extensions==4.15.0
     #   anyio
     #   pydantic
     #   pydantic-core
+    #   typer
     #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2

--- a/agent_cli/_requirements/faster-whisper.txt
+++ b/agent_cli/_requirements/faster-whisper.txt
@@ -176,6 +176,7 @@ tqdm==4.67.1
     #   huggingface-hub
 typer==0.21.1
     # via
+    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1

--- a/agent_cli/_requirements/kokoro.txt
+++ b/agent_cli/_requirements/kokoro.txt
@@ -367,6 +367,7 @@ triton==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via torch
 typer==0.21.1
     # via
+    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1

--- a/agent_cli/_requirements/llm.txt
+++ b/agent_cli/_requirements/llm.txt
@@ -23,6 +23,7 @@ charset-normalizer==3.4.4
 click==8.3.1
     # via
     #   ddgs
+    #   typer
     #   typer-slim
 colorama==0.4.6
     # via
@@ -132,13 +133,16 @@ requests==2.32.5
 rich==14.2.0
     # via
     #   agent-cli
+    #   typer
     #   typer-slim
 rsa==4.9.1
     # via google-auth
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 sniffio==1.3.1
     # via
     #   google-genai
@@ -151,6 +155,8 @@ tiktoken==0.12.0
     # via pydantic-ai-slim
 tqdm==4.67.1
     # via openai
+typer==0.21.1
+    # via agent-cli
 typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
@@ -161,6 +167,7 @@ typing-extensions==4.15.0
     #   opentelemetry-api
     #   pydantic
     #   pydantic-core
+    #   typer
     #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2

--- a/agent_cli/_requirements/memory.txt
+++ b/agent_cli/_requirements/memory.txt
@@ -300,6 +300,7 @@ transformers==4.57.5
     # via agent-cli
 typer==0.21.1
     # via
+    #   agent-cli
     #   chromadb
     #   fastapi-cli
     #   fastapi-cloud-cli

--- a/agent_cli/_requirements/mlx-whisper.txt
+++ b/agent_cli/_requirements/mlx-whisper.txt
@@ -180,8 +180,9 @@ tqdm==4.67.1 ; platform_machine == 'arm64' and sys_platform == 'darwin'
     # via
     #   huggingface-hub
     #   mlx-whisper
-typer==0.21.1 ; platform_machine == 'arm64' and sys_platform == 'darwin'
+typer==0.21.1
     # via
+    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1

--- a/agent_cli/_requirements/piper.txt
+++ b/agent_cli/_requirements/piper.txt
@@ -140,6 +140,7 @@ sympy==1.14.0
     # via onnxruntime
 typer==0.21.1
     # via
+    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1

--- a/agent_cli/_requirements/rag.txt
+++ b/agent_cli/_requirements/rag.txt
@@ -343,6 +343,7 @@ transformers==4.57.5
     # via agent-cli
 typer==0.21.1
     # via
+    #   agent-cli
     #   chromadb
     #   fastapi-cli
     #   fastapi-cloud-cli

--- a/agent_cli/_requirements/server.txt
+++ b/agent_cli/_requirements/server.txt
@@ -118,6 +118,7 @@ starlette==0.50.0
     # via fastapi
 typer==0.21.1
     # via
+    #   agent-cli
     #   fastapi-cli
     #   fastapi-cloud-cli
 typer-slim==0.21.1

--- a/agent_cli/_requirements/speed.txt
+++ b/agent_cli/_requirements/speed.txt
@@ -11,7 +11,9 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
 click==8.3.1
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 dotenv==0.9.9
@@ -49,13 +51,18 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
+    #   typer
     #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 shellingham==1.5.4
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 termcolor==3.3.0
     # via fire
+typer==0.21.1
+    # via agent-cli
 typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
@@ -63,6 +70,7 @@ typing-extensions==4.15.0
     #   anyio
     #   pydantic
     #   pydantic-core
+    #   typer
     #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2

--- a/agent_cli/_requirements/vad.txt
+++ b/agent_cli/_requirements/vad.txt
@@ -9,7 +9,9 @@ certifi==2026.1.4
     #   httpcore
     #   httpx
 click==8.3.1
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 colorama==0.4.6 ; sys_platform == 'win32'
     # via click
 coloredlogs==15.0.1
@@ -112,13 +114,16 @@ python-dotenv==1.2.1
 rich==14.2.0
     # via
     #   agent-cli
+    #   typer
     #   typer-slim
 setproctitle==1.3.7
     # via agent-cli
 setuptools==80.9.0 ; python_full_version >= '3.12'
     # via torch
 shellingham==1.5.4
-    # via typer-slim
+    # via
+    #   typer
+    #   typer-slim
 silero-vad==6.2.0
     # via agent-cli
 sympy==1.14.0
@@ -133,6 +138,8 @@ torchaudio==2.9.1
     # via silero-vad
 triton==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via torch
+typer==0.21.1
+    # via agent-cli
 typer-slim==0.21.1
     # via agent-cli
 typing-extensions==4.15.0
@@ -141,6 +148,7 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   torch
+    #   typer
     #   typer-slim
     #   typing-inspection
 typing-inspection==0.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "pydantic",  # Required for config.py models
     "rich",
     "pyperclip",
-    "typer-slim[standard]",
+    "typer-slim[standard]",  # Depend on both typer and typer-slim to prevent
+    "typer",  # uv namespace corruption (astral-sh/uv#17645)
     "dotenv",
     "httpx",
     "psutil; sys_platform == 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ dependencies = [
     { name = "pyperclip" },
     { name = "rich" },
     { name = "setproctitle" },
+    { name = "typer" },
     { name = "typer-slim", extra = ["standard"] },
 ]
 
@@ -188,6 +189,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'kokoro'", specifier = ">=4.40.0" },
     { name = "transformers", marker = "extra == 'memory'", specifier = ">=4.30.0" },
     { name = "transformers", marker = "extra == 'rag'", specifier = ">=4.30.0" },
+    { name = "typer" },
     { name = "typer-slim", extras = ["standard"] },
     { name = "versioningit", marker = "extra == 'dev'" },
     { name = "watchfiles", marker = "extra == 'memory'", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary

Follow-up to #308. The previous fix (switching to `typer-slim[standard]`) didn't fully solve the issue because other packages in extras (like `fastapi-cli`) still depend on `typer`.

This fix adds both `typer` and `typer-slim` as dependencies. Since agent-cli always needs both, uv cannot uninstall either package, preventing the shared namespace files from being deleted.

Workaround for [astral-sh/uv#17645](https://github.com/astral-sh/uv/issues/17645).

## Test plan

Verified the fix works:
```bash
uv tool install agent-cli
uv tool install 'agent-cli[kokoro]' --force
uv tool install agent-cli --force
ag --version  # Now works!
```