### PR TITLE
fix: use quiet flag for uv tool install during auto-install

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -142,7 +142,7 @@ def _try_auto_install(missing: list[str]) -> bool:
     console.print(
         f"[yellow]Auto-installing missing extras: {', '.join(extras_to_install)}[/]",
     )
-    return install_extras_programmatic(extras_to_install)
+    return install_extras_programmatic(extras_to_install, quiet=True)
 
 
 def _check_and_install_extras(extras: tuple[str, ...]) -> list[str]:

--- a/agent_cli/install/extras.py
+++ b/agent_cli/install/extras.py
@@ -60,13 +60,15 @@ def _get_current_uv_tool_extras() -> list[str]:
     return []
 
 
-def _install_via_uv_tool(extras: list[str]) -> bool:
+def _install_via_uv_tool(extras: list[str], *, quiet: bool = False) -> bool:
     """Reinstall agent-cli via uv tool with the specified extras."""
     current_version = get_version("agent-cli").split("+")[0]  # Strip local version
     extras_str = ",".join(extras)
     package_spec = f"agent-cli[{extras_str}]=={current_version}"
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     cmd = ["uv", "tool", "install", package_spec, "--force", "--python", python_version]
+    if quiet:
+        cmd.append("-q")
     console.print(f"Running: [cyan]{' '.join(cmd)}[/]")
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
@@ -93,7 +95,7 @@ def _install_extras_impl(extras: list[str], *, quiet: bool = False) -> bool:
     if _is_uv_tool_install():
         current_extras = _get_current_uv_tool_extras()
         new_extras = sorted(set(current_extras) | set(extras))
-        return _install_via_uv_tool(new_extras)
+        return _install_via_uv_tool(new_extras, quiet=quiet)
 
     cmd = _install_cmd()
     for extra in extras:

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -141,7 +141,7 @@ class TestTryAutoInstall:
         ) as mock_install:
             result = _try_auto_install(["audio", "piper|kokoro"])
             assert result is True
-            mock_install.assert_called_once_with(["audio", "piper"])
+            mock_install.assert_called_once_with(["audio", "piper"], quiet=True)
 
     def test_returns_install_result(self) -> None:
         """Should return the result from install_extras_programmatic."""


### PR DESCRIPTION
## Summary
- Add `-q` flag to `uv tool install` command when auto-installing missing extras
- Reduces output noise during automatic dependency installation
- Explicit `install-extras` command still shows full output

## Test plan
- [x] Existing tests updated and passing
- [x] Pre-commit checks pass