### PR TITLE
feat(whisper): add streaming transcription support to faster-whisper backend

### DIFF
--- a/agent_cli/server/whisper/backends/base.py
+++ b/agent_cli/server/whisper/backends/base.py
@@ -6,7 +6,18 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
+
+
+@dataclass
+class TranscriptionSegment:
+    """A single segment from streaming transcription."""
+
+    text: str
+    start: float
+    end: float
+    segment_id: int
 
 
 @dataclass
@@ -92,6 +103,39 @@ class WhisperBackend(Protocol):
 
         Returns:
             TranscriptionResult with text and metadata.
+
+        """
+        ...
+
+    @property
+    def supports_streaming(self) -> bool:
+        """Check if this backend supports streaming transcription."""
+        ...
+
+    def transcribe_stream(
+        self,
+        audio: bytes,
+        *,
+        source_filename: str | None = None,
+        language: str | None = None,
+        task: Literal["transcribe", "translate"] = "transcribe",
+        initial_prompt: str | None = None,
+        temperature: float = 0.0,
+        vad_filter: bool = True,
+    ) -> AsyncIterator[TranscriptionSegment]:
+        """Stream transcription segments as they are processed.
+
+        Args:
+            audio: Audio data as bytes (WAV format, 16kHz, 16-bit, mono)
+            source_filename: Optional filename to help detect audio format.
+            language: Language code or None for auto-detection
+            task: "transcribe" or "translate" (to English)
+            initial_prompt: Optional prompt to guide transcription
+            temperature: Sampling temperature
+            vad_filter: Whether to use VAD filtering
+
+        Yields:
+            TranscriptionSegment for each processed segment.
 
         """
         ...

--- a/agent_cli/server/whisper/backends/mlx.py
+++ b/agent_cli/server/whisper/backends/mlx.py
@@ -19,9 +19,12 @@ from agent_cli.server.whisper.backends.base import (
     BackendConfig,
     InvalidAudioError,
     TranscriptionResult,
+    TranscriptionSegment,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     import numpy as np
     from numpy.typing import NDArray
 
@@ -268,3 +271,25 @@ class MLXWhisperBackend:
                 for i, seg in enumerate(segments)
             ],
         )
+
+    @property
+    def supports_streaming(self) -> bool:
+        """MLX Whisper backend does not support streaming transcription."""
+        return False
+
+    async def transcribe_stream(
+        self,
+        audio: bytes,  # noqa: ARG002
+        *,
+        source_filename: str | None = None,  # noqa: ARG002
+        language: str | None = None,  # noqa: ARG002
+        task: Literal["transcribe", "translate"] = "transcribe",  # noqa: ARG002
+        initial_prompt: str | None = None,  # noqa: ARG002
+        temperature: float = 0.0,  # noqa: ARG002
+        vad_filter: bool = True,  # noqa: ARG002
+    ) -> AsyncIterator[TranscriptionSegment]:
+        """Streaming not supported for MLX Whisper backend."""
+        msg = "Streaming transcription is not supported by MLX Whisper backend"
+        raise NotImplementedError(msg)
+        # yield is needed to make this an async generator, but it's unreachable
+        yield  # type: ignore[misc]  # pragma: no cover


### PR DESCRIPTION
## Summary

- Add `transcribe_stream` method to `FasterWhisperBackend` that yields `TranscriptionSegment` objects as segments are processed
- Uses `multiprocessing.Manager().Queue()` for IPC, following the same pattern as Kokoro TTS streaming
- Add `TranscriptionSegment` dataclass and streaming interface to `WhisperBackend` protocol
- Add stub implementation to `MLXWhisperBackend` (returns `supports_streaming=False`)

## Test plan

- [x] All existing tests pass (913 tests)
- [x] Pre-commit checks pass (ruff, mypy, etc.)
- [ ] Manual testing with actual audio files to verify streaming works end-to-end