### PR TITLE
fix(docker): copy source and install project in whisper/tts Dockerfiles

### DIFF
--- a/docker/transcription-proxy.Dockerfile
+++ b/docker/transcription-proxy.Dockerfile
@@ -20,10 +20,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
-RUN uv sync --frozen --no-dev --extra server
+COPY scripts ./scripts
+RUN uv sync --frozen --no-dev --no-editable --extra server
 
 # =============================================================================
 # Runtime stage - minimal image

--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -22,10 +22,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
-RUN uv sync --frozen --no-dev --extra server --extra kokoro && \
+COPY scripts ./scripts
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra kokoro && \
     /app/.venv/bin/python -m spacy download en_core_web_sm
 
 # =============================================================================
@@ -41,10 +42,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
-RUN uv sync --frozen --no-dev --extra server --extra piper
+COPY scripts ./scripts
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra piper
 
 # =============================================================================
 # CUDA target: GPU-accelerated with Kokoro TTS

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -22,10 +22,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
-RUN uv sync --frozen --no-dev --extra server --extra faster-whisper
+COPY scripts ./scripts
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra faster-whisper
 
 # =============================================================================
 # CUDA target: GPU-accelerated with faster-whisper


### PR DESCRIPTION
## Summary

The previous commit (2f569361) broke Docker builds by using `--no-install-project` without copying source code. Containers failed with `agent-cli: not found`.

## Root Cause

The Dockerfiles were missing several required files:
1. **README.md** - Referenced in pyproject.toml, required for build
2. **.git directory** - Required by versioningit for version detection from tags
3. **scripts directory** - `agent_cli/scripts` is a symlink to `../scripts`
4. **--no-editable flag** - Editable installs create .pth files pointing to source, which isn't in runtime image

## Fix

All three Dockerfiles now use a uniform multi-stage build:

```dockerfile
# Builder stage
COPY pyproject.toml uv.lock README.md ./
COPY .git ./.git
COPY agent_cli ./agent_cli
COPY scripts ./scripts
RUN uv sync --frozen --no-dev --no-editable --extra server [--extra ...]
```

Key changes:
- Copy README.md (required by pyproject.toml)
- Copy .git directory (required by versioningit)
- Copy scripts directory (fixes symlink)
- Use `--no-editable` (avoids .pth file issues)
- Install git in builder stage (required by versioningit)

## Test Plan

### Build & verify `agent-cli --version`
- [x] transcription-proxy
- [x] whisper CPU
- [x] tts CPU
- [ ] whisper CUDA
- [ ] tts CUDA

### Deploy & verify services start
- [ ] Deploy to production
- [ ] Verify health endpoints respond