### PR TITLE
fix(docker): Use uv to install Python in CUDA images

### DIFF
--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -71,8 +71,7 @@ WORKDIR /app
 
 COPY --from=builder-cuda /app/.venv /app/.venv
 
-# Fix venv python symlink to use uv-installed Python
-RUN ln -sf $(find /opt/python -name "python3.13" -type f | head -1) /app/.venv/bin/python && \
+RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     mkdir -p /home/tts/.cache && chown -R tts:tts /home/tts
 
@@ -106,11 +105,16 @@ ENTRYPOINT ["sh", "-c", "agent-cli server tts \
 # =============================================================================
 # CPU target: CPU-only with Piper TTS
 # =============================================================================
-FROM python:3.13-slim AS cpu
+FROM debian:bookworm-slim AS cpu
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+RUN uv python install 3.13
 
 RUN groupadd -g 1000 tts && useradd -m -u 1000 -g tts tts
 
@@ -118,7 +122,8 @@ WORKDIR /app
 
 COPY --from=builder-cpu /app/.venv /app/.venv
 
-RUN ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
+RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
+    ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     mkdir -p /home/tts/.cache && chown -R tts:tts /home/tts
 
 USER tts
@@ -135,7 +140,7 @@ ENV TTS_HOST=0.0.0.0 \
     TTS_DEVICE=cpu
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:${TTS_PORT}/health')" || exit 1
+    CMD /app/.venv/bin/python -c "import urllib.request; urllib.request.urlopen('http://localhost:${TTS_PORT}/health')" || exit 1
 
 ENTRYPOINT ["sh", "-c", "agent-cli server tts \
     --host ${TTS_HOST} \

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -48,8 +48,7 @@ WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
 
-# Fix venv python symlink to use uv-installed Python
-RUN ln -sf $(find /opt/python -name "python3.13" -type f | head -1) /app/.venv/bin/python && \
+RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     mkdir -p /home/whisper/.cache && chown -R whisper:whisper /home/whisper
 
@@ -81,13 +80,16 @@ ENTRYPOINT ["sh", "-c", "agent-cli server whisper \
 # =============================================================================
 # CPU target: CPU-only with faster-whisper
 # =============================================================================
-FROM python:3.13-slim AS cpu
+FROM debian:bookworm-slim AS cpu
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ffmpeg \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV UV_PYTHON_INSTALL_DIR=/opt/python
+RUN uv python install 3.13
 
 RUN groupadd -g 1000 whisper && useradd -m -u 1000 -g whisper whisper
 
@@ -95,7 +97,8 @@ WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
 
-RUN ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
+RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
+    ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     mkdir -p /home/whisper/.cache && chown -R whisper:whisper /home/whisper
 
 USER whisper
@@ -111,7 +114,7 @@ ENV WHISPER_HOST=0.0.0.0 \
     WHISPER_DEVICE=cpu
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:${WHISPER_PORT}/health')" || exit 1
+    CMD /app/.venv/bin/python -c "import urllib.request; urllib.request.urlopen('http://localhost:${WHISPER_PORT}/health')" || exit 1
 
 ENTRYPOINT ["sh", "-c", "agent-cli server whisper \
     --host ${WHISPER_HOST} \


### PR DESCRIPTION
## Summary
- Fix CUDA Docker images failing to build due to Python 3.13 not available on Ubuntu 22.04
- Use `uv python install 3.13` for Python installation in all runtime stages (CUDA and CPU)
- Use `debian:bookworm-slim` for CPU stages for consistency
- Fix venv symlink to use uv-installed Python (via `uv python find 3.13`)
- Install Python to `/opt/python` so it's accessible by non-root container users

## Changes
- All runtime stages now use `uv` to install Python
- Removed ugly `find /opt/python ...` command, replaced with `uv python find 3.13`
- Healthchecks use `/app/.venv/bin/python` instead of `python3`

## Test Plan
- [x] Build and test transcription-proxy locally
- [x] Build and test whisper:cpu locally
- [x] Build and test tts:cpu locally
- [ ] CI builds CUDA images (will test on merge + release)