### PR TITLE
ci(docker): Fix version detection and disk space issues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
-          sudo docker system prune -af
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
           df -h
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to checkout for proper git tag detection (fixes version showing 0.0.0)
- Add disk cleanup step for multi-target builds (frees ~20GB for TTS CUDA)

## Changes
- Remove .NET SDK (~8GB) and Android SDK (~12GB) before Docker builds