### PR TITLE
fix(docker): Add audio extra to whisper and tts images for Wyoming support

### DIFF
--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -26,7 +26,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
 COPY scripts ./scripts
-RUN uv sync --frozen --no-dev --no-editable --extra server --extra kokoro && \
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra kokoro --extra audio && \
     /app/.venv/bin/python -m spacy download en_core_web_sm
 
 # =============================================================================
@@ -46,7 +46,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
 COPY scripts ./scripts
-RUN uv sync --frozen --no-dev --no-editable --extra server --extra piper
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra piper --extra audio
 
 # =============================================================================
 # CUDA target: GPU-accelerated with Kokoro TTS

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -26,7 +26,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY .git ./.git
 COPY agent_cli ./agent_cli
 COPY scripts ./scripts
-RUN uv sync --frozen --no-dev --no-editable --extra server --extra faster-whisper
+RUN uv sync --frozen --no-dev --no-editable --extra server --extra faster-whisper --extra audio
 
 # =============================================================================
 # CUDA target: GPU-accelerated with faster-whisper


### PR DESCRIPTION
## Summary
- Add `audio` extra to whisper Dockerfile (for Wyoming protocol support)
- Add `audio` extra to tts Dockerfile (both kokoro and piper targets)

The `wyoming` module is in the `audio` extra and is required for the Wyoming protocol server to start.

## Test plan
- [ ] Rebuild whisper image and verify Wyoming server starts (no more "Wyoming not available" warning)
- [ ] Rebuild tts image and verify Wyoming server starts