### PR TITLE
docs: Add transcribe-proxy environment variables documentation

### DIFF
--- a/docs/commands/server/transcribe-proxy.md
+++ b/docs/commands/server/transcribe-proxy.md
@@ -106,6 +106,30 @@ docker run -p 61337:61337 ghcr.io/basnijholt/agent-cli-transcribe-proxy:latest
 docker compose -f docker/docker-compose.yml --profile cpu up transcribe-proxy
 ```
 
+### Environment Variables
+
+Configure the proxy using environment variables (priority: env var > config file > default):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ASR_PROVIDER` | `wyoming` | ASR provider: `wyoming`, `openai`, `gemini` |
+| `ASR_WYOMING_IP` | `localhost` | Wyoming ASR server hostname/IP |
+| `ASR_WYOMING_PORT` | `10300` | Wyoming ASR server port |
+| `LLM_PROVIDER` | `ollama` | LLM provider: `ollama`, `openai`, `gemini` |
+| `OPENAI_API_KEY` | - | OpenAI API key (for OpenAI provider) |
+| `GEMINI_API_KEY` | - | Gemini API key (for Gemini provider) |
+
+Example with Wyoming ASR in Docker Compose:
+
+```bash
+docker run -p 61337:61337 \
+  -e ASR_WYOMING_IP=agent-cli-whisper \
+  -e ASR_WYOMING_PORT=10300 \
+  ghcr.io/basnijholt/agent-cli-transcribe-proxy:latest
+```
+
+### Custom Config File
+
 To use a custom config, mount it as a volume:
 
 ```bash

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -79,6 +79,10 @@ TTS_TTL=300                 # Seconds before unloading idle model
 
 # Transcription Proxy
 PROXY_PORT=61337            # Port for transcription proxy
+ASR_PROVIDER=wyoming        # ASR provider: wyoming, openai, gemini
+ASR_WYOMING_IP=whisper      # Wyoming server hostname (container name in compose)
+ASR_WYOMING_PORT=10300      # Wyoming server port
+LLM_PROVIDER=ollama         # LLM provider: ollama, openai, gemini
 ```
 
 ### GPU Support


### PR DESCRIPTION
## Summary

- Document new environment variables for transcribe-proxy Docker container
- Update `docs/commands/server/transcribe-proxy.md` with env var table and examples
- Update `docs/installation/docker.md` with proxy env vars in configuration section

Follows up on #328 which added env var support to the proxy.