### PR TITLE
docs: Fix transcribe-proxy env vars and document --prompt implies --agent

### DIFF
--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -61,7 +61,7 @@ agent-cli dev new [BRANCH] [OPTIONS]
 | `--with-editor` | Specific editor (cursor, vscode, zed, etc.) |
 | `--with-agent` | Specific agent (claude, codex, gemini, aider) |
 | `--agent-args` | Extra arguments to pass to the agent |
-| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree) |
+| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree). Implies `--agent`. |
 | `--prompt-file`, `-P` | Read initial prompt from a file (saved to `.claude/TASK.md` in worktree) |
 | `--direnv` | Generate .envrc file for direnv (auto-detects venv) |
 | `--setup/--no-setup` | Run automatic project setup (default: enabled) |
@@ -208,7 +208,7 @@ agent-cli dev agent NAME [--agent/-a AGENT] [--agent-args ARGS] [--prompt/-p PRO
 |--------|-------------|
 | `--agent`, `-a` | Specific agent (claude, codex, gemini, aider) |
 | `--agent-args` | Extra arguments to pass to the agent |
-| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree) |
+| `--prompt`, `-p` | Initial prompt to pass to the AI agent (saved to `.claude/TASK.md` in worktree). Implies `--agent`. |
 | `--prompt-file`, `-P` | Read initial prompt from a file (saved to `.claude/TASK.md` in worktree) |
 
 **Examples:**

--- a/docs/commands/server/transcribe-proxy.md
+++ b/docs/commands/server/transcribe-proxy.md
@@ -121,12 +121,17 @@ Configure the proxy using environment variables (priority: env var > config file
 | `ASR_PROVIDER` | `wyoming` | ASR provider: `wyoming`, `openai`, `gemini` |
 | `ASR_WYOMING_IP` | `localhost` | Wyoming ASR server hostname/IP |
 | `ASR_WYOMING_PORT` | `10300` | Wyoming ASR server port |
+| `ASR_OPENAI_MODEL` | `whisper-1` | OpenAI ASR model name |
+| `ASR_OPENAI_BASE_URL` | - | Custom OpenAI-compatible ASR endpoint |
+| `ASR_OPENAI_PROMPT` | - | Custom prompt to guide transcription |
+| `ASR_GEMINI_MODEL` | `gemini-3-flash-preview` | Gemini ASR model name |
 | `LLM_PROVIDER` | `ollama` | LLM provider: `ollama`, `openai`, `gemini` |
 | `LLM_OLLAMA_MODEL` | `gemma3:4b` | Ollama model name |
 | `LLM_OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
-| `LLM_OPENAI_MODEL` | `gpt-4.1-nano` | OpenAI model name |
+| `LLM_OPENAI_MODEL` | `gpt-5-mini` | OpenAI model name |
 | `LLM_GEMINI_MODEL` | `gemini-3-flash-preview` | Gemini model name |
 | `TTS_PROVIDER` | `wyoming` | TTS provider: `wyoming`, `openai`, `kokoro`, `gemini` |
+| `LOG_LEVEL` | `info` | Logging level: `debug`, `info`, `warning`, `error` |
 | `OPENAI_API_KEY` | - | OpenAI API key |
 | `OPENAI_BASE_URL` | - | Custom OpenAI-compatible API base URL |
 | `GEMINI_API_KEY` | - | Gemini API key |


### PR DESCRIPTION
## Summary

- Fix `LLM_OPENAI_MODEL` default in transcribe-proxy docs: `gpt-4.1-nano` → `gpt-5-mini` (matches `agent_cli/constants.py`)
- Add missing ASR environment variables to transcribe-proxy docs:
  - `ASR_OPENAI_MODEL` (default: `whisper-1`)
  - `ASR_OPENAI_BASE_URL`
  - `ASR_OPENAI_PROMPT`
  - `ASR_GEMINI_MODEL` (default: `gemini-3-flash-preview`)
- Add `LOG_LEVEL` to env vars table (aligns with docker-compose.yml)
- Document that `--prompt` implies `--agent` in dev command (feat added in #317)

## Test plan

- [x] Pre-commit checks pass
- [x] Verified defaults match `agent_cli/opts.py` and `agent_cli/constants.py`