### PR TITLE
docs(transcribe-proxy): Document cleanup parameter for disabling LLM post-processing

### DIFF
--- a/docs/commands/server/transcribe-proxy.md
+++ b/docs/commands/server/transcribe-proxy.md
@@ -89,13 +89,18 @@ This skips the LLM step entirely, reducing latency and removing the LLM dependen
 ```json
 {
   "raw_transcript": "the original transcription",
-  "cleaned_transcript": "The cleaned transcription." | null,
+  "cleaned_transcript": "The cleaned transcription.",
   "success": true,
   "error": null
 }
 ```
 
-When `cleanup=false`, the `cleaned_transcript` field will be `null`.
+| Field | Type | Description |
+|-------|------|-------------|
+| `raw_transcript` | string | The raw transcription from the ASR provider |
+| `cleaned_transcript` | string or null | The LLM-cleaned transcript, or `null` if `cleanup=false` |
+| `success` | boolean | Whether the transcription succeeded |
+| `error` | string or null | Error message if something went wrong |
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
Document the `cleanup` parameter for the `/transcribe` endpoint, which allows disabling LLM post-processing on a per-request basis.

## Changes
- Added documentation for `/transcribe` endpoint request parameters
- Documented `cleanup=false` option with curl example
- Documented response format

## Use Case
Some deployments only need transcription without cleanup/post-processing:
- Simple speech-to-text for note-taking
- Environments without LLM infrastructure
- Reduced latency when cleanup isn't needed

The `cleanup=false` parameter already exists - this PR just documents it properly.

Closes #336