### PR TITLE
fix(docker): Upgrade CUDA images to Ubuntu 24.04 for GLIBC 2.38+ compatibility

### DIFF
--- a/docker/tts.Dockerfile
+++ b/docker/tts.Dockerfile
@@ -65,15 +65,20 @@ RUN apt-get update && \
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 RUN uv python install 3.13
 
+# Delete pre-existing ubuntu user (UID 1000) and create tts user for uniformity with CPU target
+RUN userdel -r ubuntu && \
+    groupadd -g 1000 tts && \
+    useradd -m -u 1000 -g 1000 tts
+
 WORKDIR /app
 
 COPY --from=builder-cuda /app/.venv /app/.venv
 
 RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
-    mkdir -p /home/ubuntu/.cache && chown -R ubuntu:ubuntu /home/ubuntu
+    mkdir -p /home/tts/.cache && chown -R tts:tts /home/tts
 
-USER ubuntu
+USER tts
 
 EXPOSE 10200 10201
 

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -42,15 +42,20 @@ RUN apt-get update && \
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 RUN uv python install 3.13
 
+# Delete pre-existing ubuntu user (UID 1000) and create whisper user for uniformity with CPU target
+RUN userdel -r ubuntu && \
+    groupadd -g 1000 whisper && \
+    useradd -m -u 1000 -g 1000 whisper
+
 WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
 
 RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
-    mkdir -p /home/ubuntu/.cache && chown -R ubuntu:ubuntu /home/ubuntu
+    mkdir -p /home/whisper/.cache && chown -R whisper:whisper /home/whisper
 
-USER ubuntu
+USER whisper
 
 EXPOSE 10300 10301
 


### PR DESCRIPTION
## Summary

Fixes GLIBC compatibility issue in CUDA Docker images where `curated_tokenizers` (kokoro TTS dependency) requires GLIBC 2.38+.

**Changes:**
- Upgrade CUDA base image from Ubuntu 22.04 to Ubuntu 24.04 (`nvcr.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`)
- Switch from Docker Hub (`nvidia/cuda`) to NVIDIA Container Registry (`nvcr.io/nvidia/cuda`) to avoid rate limits
- Delete pre-existing `ubuntu` user (UID 1000) and create service-specific users (`whisper`/`tts`) for consistency with CPU targets

**Root cause:**
- Builder stage uses `python:3.13-slim` (Debian 12, GLIBC 2.36+)
- Old runtime used `nvidia/cuda:*-ubuntu22.04` (GLIBC 2.35)
- `curated_tokenizers` compiled against newer GLIBC failed at runtime

**Testing on PC (RTX 3090):**
- TTS CUDA: Builds, runs as `tts` user (UID 1000), produces valid MP3 audio
- Whisper CUDA: Builds, runs as `whisper` user (UID 1000), health check passes

## Test plan

- [x] Build TTS CUDA image
- [x] Test TTS API endpoint produces audio
- [x] Verify TTS runs as `tts` user (UID 1000)
- [x] Build Whisper CUDA image  
- [x] Verify Whisper runs as `whisper` user (UID 1000)
- [x] Verify GLIBC issue is resolved
- [ ] Deploy and verify in production