### PR TITLE
docs(voice-edit): Improve help message with workflow and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1119,16 +1119,23 @@ uv tool install "agent-cli[vad]" -p 3.13
 
  Usage: agent-cli voice-edit [OPTIONS]
 
- Interact with clipboard text via a voice command using local or remote services.
+ Edit or query clipboard text using voice commands.
 
- Usage:
+ Workflow: Captures clipboard text → records your voice command → transcribes it → sends
+ both to an LLM → copies result back to clipboard.
 
-  • Run in foreground: agent-cli voice-edit --input-device-index 1
-  • Run in background: agent-cli voice-edit --input-device-index 1 &
-  • Check status: agent-cli voice-edit --status
-  • Stop background process: agent-cli voice-edit --stop
-  • List output devices: agent-cli voice-edit --list-output-devices
-  • Save TTS to file: agent-cli voice-edit --tts --save-file response.wav
+ Use this for hands-free text editing (e.g., "make this more formal") or asking questions
+ about clipboard content (e.g., "summarize this").
+
+ Typical hotkey integration: Run voice-edit & on keypress to start recording, then send
+ SIGINT (via --stop) on second keypress to process.
+
+ Examples:
+
+  • Basic usage: agent-cli voice-edit
+  • With TTS response: agent-cli voice-edit --tts
+  • Toggle on/off: agent-cli voice-edit --toggle
+  • List audio devices: agent-cli voice-edit --list-devices
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --help  -h        Show this message and exit.                                          │

--- a/agent_cli/agents/voice_edit.py
+++ b/agent_cli/agents/voice_edit.py
@@ -229,15 +229,23 @@ def voice_edit(
     config_file: str | None = opts.CONFIG_FILE,
     print_args: bool = opts.PRINT_ARGS,
 ) -> None:
-    """Interact with clipboard text via a voice command using local or remote services.
+    """Edit or query clipboard text using voice commands.
 
-    Usage:
-    - Run in foreground: agent-cli voice-edit --input-device-index 1
-    - Run in background: agent-cli voice-edit --input-device-index 1 &
-    - Check status: agent-cli voice-edit --status
-    - Stop background process: agent-cli voice-edit --stop
-    - List output devices: agent-cli voice-edit --list-output-devices
-    - Save TTS to file: agent-cli voice-edit --tts --save-file response.wav
+    **Workflow:** Captures clipboard text → records your voice command → transcribes
+    it → sends both to an LLM → copies result back to clipboard.
+
+    Use this for hands-free text editing (e.g., "make this more formal") or
+    asking questions about clipboard content (e.g., "summarize this").
+
+    **Typical hotkey integration:** Run `voice-edit &` on keypress to start
+    recording, then send SIGINT (via `--stop`) on second keypress to process.
+
+    **Examples:**
+
+    - Basic usage: `agent-cli voice-edit`
+    - With TTS response: `agent-cli voice-edit --tts`
+    - Toggle on/off: `agent-cli voice-edit --toggle`
+    - List audio devices: `agent-cli voice-edit --list-devices`
     """
     if print_args:
         print_command_line_args(locals())


### PR DESCRIPTION
## Summary

- Rewrote the `voice-edit` command docstring to be more informative
- Added step-by-step workflow explanation (clipboard → voice → LLM → clipboard)
- Included common use cases (text editing vs. querying)
- Added hotkey integration guidance
- Fixed incorrect example flags (`--list-output-devices` → `--list-devices`)
- Simplified examples to show most common usage patterns

## Before

```
Interact with clipboard text via a voice command using local or remote services.

Usage:
- Run in foreground: agent-cli voice-edit --input-device-index 1
- Run in background: agent-cli voice-edit --input-device-index 1 &
- Check status: agent-cli voice-edit --status
- Stop background process: agent-cli voice-edit --stop
- List output devices: agent-cli voice-edit --list-output-devices
- Save TTS to file: agent-cli voice-edit --tts --save-file response.wav
```

## After

```
Edit or query clipboard text using voice commands.

Workflow: Captures clipboard text → records your voice command → transcribes
it → sends both to an LLM → copies result back to clipboard.

Use this for hands-free text editing (e.g., "make this more formal") or
asking questions about clipboard content (e.g., "summarize this").

Typical hotkey integration: Run voice-edit & on keypress to start
recording, then send SIGINT (via --stop) on second keypress to process.

Examples:

- Basic usage: agent-cli voice-edit
- With TTS response: agent-cli voice-edit --tts
- Toggle on/off: agent-cli voice-edit --toggle
- List audio devices: agent-cli voice-edit --list-devices
```

## Test plan

- [x] Run `uv run agent-cli voice-edit --help` to verify improved output
- [x] Run `uv run python docs/run_markdown_code_runner.py` to regenerate docs
- [x] Run `pytest` - all 909 tests pass
- [x] Run `pre-commit run --all-files` - all hooks pass