### PR TITLE
docs(transcribe-daemon): Improve help messages for AI agents and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,46 +826,76 @@ uv tool install "agent-cli[vad]" -p 3.13
 
  Usage: agent-cli transcribe-daemon [OPTIONS]
 
- Run a continuous transcription daemon with voice activity detection.
+ Continuous transcription daemon using Silero VAD for speech detection.
 
- This command runs indefinitely, capturing audio from your microphone, detecting speech
- segments using Silero VAD, transcribing them, and logging results with timestamps.
+ Unlike transcribe (single recording session), this daemon runs indefinitely and
+ automatically detects speech segments using Voice Activity Detection (VAD). Each
+ detected segment is transcribed and logged with timestamps.
 
- Examples: # Basic daemon agent-cli transcribe-daemon
+ How it works:
+
+  1 Listens continuously to microphone input
+  2 Silero VAD detects when you start/stop speaking
+  3 After --silence-threshold seconds of silence, the segment is finalized
+  4 Segment is transcribed (and optionally cleaned by LLM with --llm)
+  5 Results are appended to the JSONL log file
+  6 Audio is saved as MP3 if --save-audio is enabled (requires ffmpeg)
+
+ Use cases: Meeting transcription, note-taking, voice journaling, accessibility.
+
+ Examples:
 
 
-  # With role and custom silence threshold
+  agent-cli transcribe-daemon
   agent-cli transcribe-daemon --role meeting --silence-threshold 1.5
+  agent-cli transcribe-daemon --llm --clipboard --role notes
+  agent-cli transcribe-daemon --transcription-log ~/meeting.jsonl --no-save-audio
+  agent-cli transcribe-daemon --asr-provider openai --llm-provider gemini --llm
 
-  # With LLM cleanup
-  agent-cli transcribe-daemon --llm --role notes
 
-  # Custom log file and audio directory
-  agent-cli transcribe-daemon --transcription-log ~/meeting.jsonl --audio-dir ~/audio
+ Tips:
 
+  • Use --role to tag entries (e.g., speaker1, meeting, personal)
+  • Adjust --vad-threshold if detection is too sensitive (increase) or missing speech
+    (decrease)
+  • Use --stop to cleanly terminate a running daemon
+  • With --llm, transcripts are cleaned up (punctuation, filler words removed)
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --role               -r                     TEXT   Role name for logging (e.g.,        │
-│                                                    'meeting', 'notes', 'user').        │
+│ --role               -r                     TEXT   Label for log entries. Use to       │
+│                                                    distinguish speakers or contexts in │
+│                                                    logs.                               │
 │                                                    [default: user]                     │
-│ --silence-threshold  -s                     FLOAT  Seconds of silence to end a speech  │
-│                                                    segment.                            │
+│ --silence-threshold  -s                     FLOAT  Seconds of silence after speech to  │
+│                                                    finalize a segment. Increase for    │
+│                                                    slower speakers.                    │
 │                                                    [default: 1.0]                      │
-│ --min-segment        -m                     FLOAT  Minimum speech duration in seconds  │
-│                                                    to trigger a segment.               │
+│ --min-segment        -m                     FLOAT  Minimum seconds of speech required  │
+│                                                    before a segment is processed.      │
+│                                                    Filters brief sounds.               │
 │                                                    [default: 0.25]                     │
-│ --vad-threshold                             FLOAT  VAD speech detection threshold      │
-│                                                    (0.0-1.0). Higher = more aggressive │
-│                                                    filtering.                          │
+│ --vad-threshold                             FLOAT  Silero VAD confidence threshold     │
+│                                                    (0.0-1.0). Higher values require    │
+│                                                    clearer speech; lower values are    │
+│                                                    more sensitive to quiet/distant     │
+│                                                    voices.                             │
 │                                                    [default: 0.3]                      │
-│ --save-audio             --no-save-audio           Save audio segments as MP3 files.   │
+│ --save-audio             --no-save-audio           Save each speech segment as MP3.    │
+│                                                    Requires ffmpeg to be installed.    │
 │                                                    [default: save-audio]               │
-│ --audio-dir                                 PATH   Directory for MP3 files. Default:   │
-│                                                    ~/.config/agent-cli/audio           │
-│ --transcription-log  -t                     PATH   JSON Lines log file path. Default:  │
+│ --audio-dir                                 PATH   Base directory for MP3 files. Files │
+│                                                    are organized by date:              │
+│                                                    YYYY/MM/DD/HHMMSS_mmm.mp3. Default: │
+│                                                    ~/.config/agent-cli/audio.          │
+│ --transcription-log  -t                     PATH   JSONL file for transcript logging   │
+│                                                    (one JSON object per line with      │
+│                                                    timestamp, role, raw/processed      │
+│                                                    text, audio path). Default:         │
 │                                                    ~/.config/agent-cli/transcriptions… │
-│ --clipboard              --no-clipboard            Copy each transcription to          │
-│                                                    clipboard.                          │
+│ --clipboard              --no-clipboard            Copy each completed transcription   │
+│                                                    to clipboard (overwrites previous). │
+│                                                    Useful with --llm to get cleaned    │
+│                                                    text.                               │
 │                                                    [default: no-clipboard]             │
 │ --help               -h                            Show this message and exit.         │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/agent_cli/agents/transcribe_daemon.py
+++ b/agent_cli/agents/transcribe_daemon.py
@@ -296,45 +296,45 @@ def transcribe_daemon(  # noqa: PLR0912
         "user",
         "--role",
         "-r",
-        help="Role name for logging (e.g., 'meeting', 'notes', 'user').",
+        help="Label for log entries. Use to distinguish speakers or contexts in logs.",
     ),
     silence_threshold: float = typer.Option(
         1.0,
         "--silence-threshold",
         "-s",
-        help="Seconds of silence to end a speech segment.",
+        help="Seconds of silence after speech to finalize a segment. Increase for slower speakers.",
     ),
     min_segment: float = typer.Option(
         0.25,
         "--min-segment",
         "-m",
-        help="Minimum speech duration in seconds to trigger a segment.",
+        help="Minimum seconds of speech required before a segment is processed. Filters brief sounds.",
     ),
     vad_threshold: float = typer.Option(
         0.3,
         "--vad-threshold",
-        help="VAD speech detection threshold (0.0-1.0). Higher = more aggressive filtering.",
+        help="Silero VAD confidence threshold (0.0-1.0). Higher values require clearer speech; lower values are more sensitive to quiet/distant voices.",
     ),
     save_audio: bool = typer.Option(
         True,  # noqa: FBT003
         "--save-audio/--no-save-audio",
-        help="Save audio segments as MP3 files.",
+        help="Save each speech segment as MP3. Requires `ffmpeg` to be installed.",
     ),
     audio_dir: Path | None = typer.Option(  # noqa: B008
         None,
         "--audio-dir",
-        help="Directory for MP3 files. Default: ~/.config/agent-cli/audio",
+        help="Base directory for MP3 files. Files are organized by date: `YYYY/MM/DD/HHMMSS_mmm.mp3`. Default: `~/.config/agent-cli/audio`.",
     ),
     transcription_log: Path | None = typer.Option(  # noqa: B008
         None,
         "--transcription-log",
         "-t",
-        help="JSON Lines log file path. Default: ~/.config/agent-cli/transcriptions.jsonl",
+        help="JSONL file for transcript logging (one JSON object per line with timestamp, role, raw/processed text, audio path). Default: `~/.config/agent-cli/transcriptions.jsonl`.",
     ),
     clipboard: bool = typer.Option(
         False,  # noqa: FBT003
         "--clipboard/--no-clipboard",
-        help="Copy each transcription to clipboard.",
+        help="Copy each completed transcription to clipboard (overwrites previous). Useful with `--llm` to get cleaned text.",
     ),
     # --- Provider Selection ---
     asr_provider: str = opts.ASR_PROVIDER,
@@ -368,25 +368,37 @@ def transcribe_daemon(  # noqa: PLR0912
     config_file: str | None = opts.CONFIG_FILE,
     print_args: bool = opts.PRINT_ARGS,
 ) -> None:
-    """Run a continuous transcription daemon with voice activity detection.
+    """Continuous transcription daemon using Silero VAD for speech detection.
 
-    This command runs indefinitely, capturing audio from your microphone,
-    detecting speech segments using Silero VAD, transcribing them, and
-    logging results with timestamps.
+    Unlike `transcribe` (single recording session), this daemon runs indefinitely
+    and automatically detects speech segments using Voice Activity Detection (VAD).
+    Each detected segment is transcribed and logged with timestamps.
 
-    Examples:
-        # Basic daemon
+    **How it works:**
+
+    1. Listens continuously to microphone input
+    2. Silero VAD detects when you start/stop speaking
+    3. After `--silence-threshold` seconds of silence, the segment is finalized
+    4. Segment is transcribed (and optionally cleaned by LLM with `--llm`)
+    5. Results are appended to the JSONL log file
+    6. Audio is saved as MP3 if `--save-audio` is enabled (requires `ffmpeg`)
+
+    **Use cases:** Meeting transcription, note-taking, voice journaling, accessibility.
+
+    **Examples:**
+
         agent-cli transcribe-daemon
-
-        # With role and custom silence threshold
         agent-cli transcribe-daemon --role meeting --silence-threshold 1.5
+        agent-cli transcribe-daemon --llm --clipboard --role notes
+        agent-cli transcribe-daemon --transcription-log ~/meeting.jsonl --no-save-audio
+        agent-cli transcribe-daemon --asr-provider openai --llm-provider gemini --llm
 
-        # With LLM cleanup
-        agent-cli transcribe-daemon --llm --role notes
+    **Tips:**
 
-        # Custom log file and audio directory
-        agent-cli transcribe-daemon --transcription-log ~/meeting.jsonl --audio-dir ~/audio
-
+    - Use `--role` to tag entries (e.g., `speaker1`, `meeting`, `personal`)
+    - Adjust `--vad-threshold` if detection is too sensitive (increase) or missing speech (decrease)
+    - Use `--stop` to cleanly terminate a running daemon
+    - With `--llm`, transcripts are cleaned up (punctuation, filler words removed)
     """
     if print_args:
         print_command_line_args(locals())

--- a/docs/commands/transcribe-daemon.md
+++ b/docs/commands/transcribe-daemon.md
@@ -65,14 +65,14 @@ agent-cli transcribe-daemon --silence-threshold 1.5
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--role, -r` | `user` | Role name for logging (e.g., 'meeting', 'notes', 'user'). |
-| `--silence-threshold, -s` | `1.0` | Seconds of silence to end a speech segment. |
-| `--min-segment, -m` | `0.25` | Minimum speech duration in seconds to trigger a segment. |
-| `--vad-threshold` | `0.3` | VAD speech detection threshold (0.0-1.0). Higher = more aggressive filtering. |
-| `--save-audio/--no-save-audio` | `true` | Save audio segments as MP3 files. |
-| `--audio-dir` | - | Directory for MP3 files. Default: ~/.config/agent-cli/audio |
-| `--transcription-log, -t` | - | JSON Lines log file path. Default: ~/.config/agent-cli/transcriptions.jsonl |
-| `--clipboard/--no-clipboard` | `false` | Copy each transcription to clipboard. |
+| `--role, -r` | `user` | Label for log entries. Use to distinguish speakers or contexts in logs. |
+| `--silence-threshold, -s` | `1.0` | Seconds of silence after speech to finalize a segment. Increase for slower speakers. |
+| `--min-segment, -m` | `0.25` | Minimum seconds of speech required before a segment is processed. Filters brief sounds. |
+| `--vad-threshold` | `0.3` | Silero VAD confidence threshold (0.0-1.0). Higher values require clearer speech; lower values are more sensitive to quiet/distant voices. |
+| `--save-audio/--no-save-audio` | `true` | Save each speech segment as MP3. Requires `ffmpeg` to be installed. |
+| `--audio-dir` | - | Base directory for MP3 files. Files are organized by date: `YYYY/MM/DD/HHMMSS_mmm.mp3`. Default: `~/.config/agent-cli/audio`. |
+| `--transcription-log, -t` | - | JSONL file for transcript logging (one JSON object per line with timestamp, role, raw/processed text, audio path). Default: `~/.config/agent-cli/transcriptions.jsonl`. |
+| `--clipboard/--no-clipboard` | `false` | Copy each completed transcription to clipboard (overwrites previous). Useful with `--llm` to get cleaned text. |
 
 ### Provider Selection
 


### PR DESCRIPTION
## Summary

- Enhance `transcribe-daemon` help text to be more informative for AI coding agents and users
- Add comprehensive command description explaining VAD-based continuous transcription
- Document step-by-step workflow (listen -> detect -> transcribe -> log)
- Include use cases: meeting transcription, note-taking, voice journaling, accessibility
- Add practical examples showing common usage patterns
- Provide tips for adjusting VAD sensitivity and using `--llm`
- Improve individual option help text with more context and relationships

## Changes

**Main docstring improvements:**
- Explains how the daemon differs from regular `transcribe` command
- Step-by-step explanation of the VAD-based workflow
- Lists use cases to help users understand when to use this command
- Provides 5 practical examples
- Includes tips for common adjustments

**Option help text improvements:**
- `--role`: Clarifies it's for log entry tagging
- `--silence-threshold`: Explains relationship to speech finalization
- `--min-segment`: Describes filtering of brief sounds
- `--vad-threshold`: Explains sensitivity trade-offs clearly
- `--save-audio`: Notes ffmpeg requirement
- `--audio-dir`: Documents date-based file organization structure
- `--transcription-log`: Describes JSONL format and included fields
- `--clipboard`: Explains behavior with `--llm`

## Test plan

- [x] All 909 tests pass
- [x] Pre-commit hooks pass
- [x] Documentation regenerated
- [x] Help output verified to render correctly