### PR TITLE
docs: Improve install-services and start-services help messages

### DIFF
--- a/agent_cli/install/services.py
+++ b/agent_cli/install/services.py
@@ -18,15 +18,32 @@ from agent_cli.install.common import (
 
 @app.command("install-services", rich_help_panel="Installation")
 def install_services() -> None:
-    """Install all required services (Ollama, Whisper, Piper, OpenWakeWord).
+    """Install all required AI services for local voice and LLM processing.
 
-    This command installs:
-    - Ollama (local LLM server)
-    - Wyoming Faster Whisper (speech-to-text)
-    - Wyoming Piper (text-to-speech)
-    - Wyoming OpenWakeWord (wake word detection)
+    **What gets installed:**
 
-    The appropriate installation method is used based on your operating system.
+    - **Ollama**: Local LLM server (preloads `gemma3:4b` model)
+    - **Whisper**: Speech-to-text (MLX on Apple Silicon, faster-whisper on Linux)
+    - **Piper**: Text-to-speech via Wyoming protocol
+    - **OpenWakeWord**: Wake word detection via Wyoming protocol
+
+    Also installs: `uv` (Python package manager), `zellij` (terminal multiplexer)
+
+    **Prerequisites:**
+
+    - macOS: Homebrew must be installed
+    - Linux: PortAudio dev libraries (`sudo apt install portaudio19-dev` on Ubuntu)
+
+    **Next steps after installation:**
+
+    1. `agent-cli start-services` - Start all services in a Zellij session
+    2. `agent-cli install-hotkeys` - Set up system hotkeys for voice commands
+
+    **Platform notes:**
+
+    - Apple Silicon: Uses MLX Whisper (installed as launchd service)
+    - Intel Mac: Uses Linux-style faster-whisper setup
+    - Linux: GPU acceleration requires NVIDIA drivers and CUDA
     """
     script_name = get_platform_script("setup-macos.sh", "setup-linux.sh")
 
@@ -46,19 +63,26 @@ def start_services(
     attach: bool = typer.Option(
         True,  # noqa: FBT003
         "--attach/--no-attach",
-        help="Attach to Zellij session after starting",
+        help="Attach to Zellij session. Use `--no-attach` to start in background.",
     ),
 ) -> None:
-    """Start all agent-cli services in a Zellij session.
+    """Start all agent-cli services in a Zellij terminal multiplexer session.
 
-    This starts:
-    - Ollama (LLM server)
-    - Wyoming Faster Whisper (speech-to-text)
-    - Wyoming Piper (text-to-speech)
-    - Wyoming OpenWakeWord (wake word detection)
+    **Services started:**
 
-    Services run in a Zellij terminal multiplexer session named 'agent-cli'.
-    Use Ctrl-Q to quit or Ctrl-O d to detach from the session.
+    - **Ollama**: Local LLM server for chat and voice editing
+    - **Whisper**: Speech-to-text transcription
+    - **Piper**: Text-to-speech synthesis
+    - **OpenWakeWord**: "Hey Jarvis" wake word detection
+
+    **Session management:**
+
+    - Services run in a Zellij session named `agent-cli`
+    - Press `Ctrl-Q` to quit all services
+    - Press `Ctrl-O d` to detach (services keep running)
+    - Reattach with: `zellij attach agent-cli`
+
+    **Prerequisite:** Run `agent-cli install-services` first to install the services.
     """
     try:
         script_path = get_script_path("start-all-services.sh")

--- a/docs/commands/start-services.md
+++ b/docs/commands/start-services.md
@@ -35,7 +35,7 @@ Services run inside a Zellij session named `agent-cli`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--attach/--no-attach` | `true` | Attach to Zellij session after starting |
+| `--attach/--no-attach` | `true` | Attach to Zellij session. Use `--no-attach` to start in background. |
 
 
 <!-- OUTPUT:END -->


### PR DESCRIPTION
## Summary

Improve the help messages for `install-services` and `start-services` commands to be more informative for AI coding agents and users.

**Changes:**

- `install-services`: Document prerequisites, installed services, platform differences, and next steps
- `start-services`: Add session management instructions, improve option descriptions, cross-reference install-services

## Test plan

- [x] All 909 tests pass
- [x] Pre-commit hooks pass
- [x] Documentation regenerated
- [x] Help output verified