### PR TITLE
docs: Improve help messages for start-services command

### DIFF
--- a/agent_cli/install/services.py
+++ b/agent_cli/install/services.py
@@ -46,19 +46,41 @@ def start_services(
     attach: bool = typer.Option(
         True,  # noqa: FBT003
         "--attach/--no-attach",
-        help="Attach to Zellij session after starting",
+        help=(
+            "Attach to the Zellij session after starting. "
+            "With `--no-attach`, services start in background and you can "
+            "reattach later with `zellij attach agent-cli`"
+        ),
     ),
 ) -> None:
     """Start all agent-cli services in a Zellij session.
 
-    This starts:
-    - Ollama (LLM server)
-    - Wyoming Faster Whisper (speech-to-text)
-    - Wyoming Piper (text-to-speech)
-    - Wyoming OpenWakeWord (wake word detection)
+    Starts these services, each in its own Zellij pane:
 
-    Services run in a Zellij terminal multiplexer session named 'agent-cli'.
-    Use Ctrl-Q to quit or Ctrl-O d to detach from the session.
+    • **Ollama** - LLM server (port 11434)
+    • **Wyoming Whisper** - Speech-to-text (port 10300)
+    • **Wyoming Piper** - Text-to-speech (port 10200)
+    • **Wyoming OpenWakeWord** - Wake word detection (port 10400)
+
+    Services run in a Zellij terminal multiplexer session named `agent-cli`.
+    If a session already exists, the command attaches to it instead of
+    starting new services.
+
+    **Keyboard shortcuts:**
+    • `Ctrl-O d` - Detach (keeps services running in background)
+    • `Ctrl-Q` - Quit (stops all services)
+    • `Alt + arrows` - Navigate between panes
+
+    **Examples:**
+
+    Start services and attach:
+        `agent-cli start-services`
+
+    Start in background (for scripts or automation):
+        `agent-cli start-services --no-attach`
+
+    Reattach to running services:
+        `zellij attach agent-cli`
     """
     try:
         script_path = get_script_path("start-all-services.sh")

--- a/docs/commands/start-services.md
+++ b/docs/commands/start-services.md
@@ -35,7 +35,7 @@ Services run inside a Zellij session named `agent-cli`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--attach/--no-attach` | `true` | Attach to Zellij session after starting |
+| `--attach/--no-attach` | `true` | Attach to the Zellij session after starting. With `--no-attach`, services start in background and you can reattach later with `zellij attach agent-cli` |
 
 
 <!-- OUTPUT:END -->


### PR DESCRIPTION
## Summary

- Add service ports (11434, 10300, 10200, 10400) to command docstring
- Explain session reuse behavior (attaches to existing session instead of starting duplicates)
- Add complete keyboard shortcuts section with formatting
- Add practical examples for common use cases
- Improve `--attach` option help text with `--no-attach` explanation
- Auto-regenerated documentation via markdown-code-runner

## Test plan

- [x] All 909 tests pass
- [x] Pre-commit hooks pass
- [x] Documentation regenerated
- [x] `uv run agent-cli start-services --help` output verified