### PR TITLE
fix(install): don't pin to exact version when installing extras

### DIFF
--- a/agent_cli/install/extras.py
+++ b/agent_cli/install/extras.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import sys
 import tomllib
-from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import Annotated
 
@@ -62,9 +61,8 @@ def _get_current_uv_tool_extras() -> list[str]:
 
 def _install_via_uv_tool(extras: list[str], *, quiet: bool = False) -> bool:
     """Reinstall agent-cli via uv tool with the specified extras."""
-    current_version = get_version("agent-cli").split("+")[0]  # Strip local version
     extras_str = ",".join(extras)
-    package_spec = f"agent-cli[{extras_str}]=={current_version}"
+    package_spec = f"agent-cli[{extras_str}]"
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     cmd = ["uv", "tool", "install", package_spec, "--force", "--python", python_version]
     if quiet:


### PR DESCRIPTION
## Summary
- Removes the exact version constraint (`==`) when reinstalling agent-cli via `uv tool` to add extras
- This allows `uv tool upgrade agent-cli` to work normally instead of showing the "pinned to exact version" hint

## Test plan
- [x] All existing tests pass
- [x] Pre-commit checks pass