### PR TITLE
fix(server): add wyoming to required extras for whisper and tts commands

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -186,7 +186,7 @@ def _check_whisper_deps(backend: str, *, download_only: bool = False) -> None:
 
 
 @app.command("whisper")
-@requires_extras("server", "faster-whisper|mlx-whisper")
+@requires_extras("server", "faster-whisper|mlx-whisper", "wyoming")
 def whisper_cmd(  # noqa: PLR0912, PLR0915
     model: Annotated[
         list[str] | None,
@@ -532,7 +532,7 @@ def transcribe_proxy_cmd(
 
 
 @app.command("tts")
-@requires_extras("server", "piper|kokoro")
+@requires_extras("server", "piper|kokoro", "wyoming")
 def tts_cmd(  # noqa: PLR0915
     model: Annotated[
         list[str] | None,


### PR DESCRIPTION
## Summary
- Add `wyoming` to `@requires_extras` for `whisper` and `tts` server commands
- Fixes Wyoming server being skipped after auto-install

## Details
The whisper and tts commands use Wyoming protocol but weren't including it in their required extras, causing:
```
WARNING  Wyoming not available, skipping Wyoming server
```

## Test plan
- [x] Pre-commit passes
- [ ] Run `ag server whisper` - should auto-install wyoming and start Wyoming server