### PR TITLE
fix: escape brackets in Rich console output

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -176,6 +176,8 @@ def _info(msg: str) -> None:
     # Style commands (messages starting with "Running: ")
     if msg.startswith("Running: "):
         cmd = msg[9:]  # Remove "Running: " prefix
+        # Escape brackets to prevent Rich from interpreting them as markup
+        cmd = cmd.replace("[", r"\[")
         console.print(f"[dim]→[/dim] Running: [bold cyan]{cmd}[/bold cyan]")
     else:
         console.print(f"[dim]→[/dim] {msg}")

--- a/agent_cli/install/extras.py
+++ b/agent_cli/install/extras.py
@@ -68,7 +68,9 @@ def _install_via_uv_tool(extras: list[str], *, quiet: bool = False) -> bool:
     if quiet:
         cmd.append("-q")
     # Use stderr for status messages so they don't pollute stdout (e.g., for hotkey notifications)
-    err_console.print(f"Running: [cyan]{' '.join(cmd)}[/]")
+    # Escape brackets to prevent Rich from interpreting them as markup
+    cmd_str = " ".join(cmd).replace("[", r"\[")
+    err_console.print(f"Running: [cyan]{cmd_str}[/]")
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
 


### PR DESCRIPTION
## Summary
- Escape brackets in command output to prevent Rich from interpreting them as markup
- Fixes `agent-cli[extras]` being displayed as just `agent-cli`

## Files changed
- `agent_cli/install/extras.py` - auto-install command output
- `agent_cli/dev/cli.py` - dev command output

## Test plan
- [x] Pre-commit passes
- [ ] Run command that triggers auto-install, verify extras shown in output