### PR TITLE
fix(docs): correct plugin install syntax in README files

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -30,7 +30,7 @@ uvx --python 3.13 agent-cli dev new my-feature --agent --prompt "..."
 claude plugin marketplace add basnijholt/agent-cli
 
 # Then install
-claude plugin install agent-cli@agent-cli-dev
+claude plugin install agent-cli-dev@agent-cli
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ agent-cli dev install-skill
 
 # Option 2: Install via Claude Code plugin marketplace
 claude plugin marketplace add basnijholt/agent-cli
-claude plugin install agent-cli@agent-cli-dev
+claude plugin install agent-cli-dev@agent-cli
 ```
 
 Once installed, Claude Code can automatically use this skill when you ask to:


### PR DESCRIPTION
## Summary
- Fix the Claude Code plugin install command syntax in README.md and .claude-plugin/README.md
- The correct format is `plugin-name@marketplace-name`, not `marketplace-name@plugin-name`
- Changed `agent-cli@agent-cli-dev` → `agent-cli-dev@agent-cli`

## Test plan
- [x] Verify the corrected syntax works: `claude plugin install agent-cli-dev@agent-cli`