### PR TITLE
fix(docs): add both plugin install steps to install-skill help

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -1779,7 +1779,9 @@ def install_skill(
     - Works when you ask to "work on multiple features" or "parallelize tasks"
 
     **Alternative:** Install globally via Claude Code plugin marketplace:
-    `claude plugin marketplace add basnijholt/agent-cli`
+
+    1. `claude plugin marketplace add basnijholt/agent-cli`
+    2. `claude plugin install agent-cli-dev@agent-cli`
     """
     # Use current repo root (works in worktrees too)
     repo_root = _get_current_repo_root()


### PR DESCRIPTION
## Summary
- Updates `dev install-skill -h` to show both required steps for installing via Claude Code plugin marketplace
- Previously only showed the first step (`claude plugin marketplace add`)
- Now shows both steps in numbered format

## Test plan
- [x] Run `ag dev install-skill -h` and verify both steps are shown