### PR TITLE
fix: auto-recover faster-whisper after pool crashes

### DIFF
--- a/agent_cli/server/whisper/backends/faster_whisper.py
+++ b/agent_cli/server/whisper/backends/faster_whisper.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import tempfile
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from multiprocessing import get_context
 from pathlib import Path
@@ -209,12 +210,27 @@ class FasterWhisperBackend:
         }
 
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
-            self._executor,
-            _transcribe_in_subprocess,
-            audio,
-            kwargs,
-        )
+        try:
+            result = await loop.run_in_executor(
+                self._executor,
+                _transcribe_in_subprocess,
+                audio,
+                kwargs,
+            )
+        except BrokenProcessPool:
+            logger.warning(
+                "faster-whisper process pool died during transcription; "
+                "reloading model %s and retrying once",
+                self._config.model_name,
+            )
+            await self.unload()
+            await self.load()
+            result = await loop.run_in_executor(
+                self._executor,
+                _transcribe_in_subprocess,
+                audio,
+                kwargs,
+            )
 
         return TranscriptionResult(
             text=result["text"],

--- a/tests/test_faster_whisper_backend.py
+++ b/tests/test_faster_whisper_backend.py
@@ -1,0 +1,66 @@
+"""Tests for the faster-whisper backend."""
+
+from __future__ import annotations
+
+from concurrent.futures.process import BrokenProcessPool
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_cli.server.whisper.backends.base import BackendConfig
+from agent_cli.server.whisper.backends.faster_whisper import FasterWhisperBackend
+
+if TYPE_CHECKING:
+    from concurrent.futures import ProcessPoolExecutor
+
+
+@pytest.mark.asyncio
+async def test_faster_whisper_transcribe_recovers_from_broken_process_pool() -> None:
+    """Reload the backend and retry once when the process pool is broken."""
+    config = BackendConfig(model_name="tiny", device="cpu", compute_type="int8")
+    backend = FasterWhisperBackend(config)
+    initial_executor = cast("ProcessPoolExecutor", object())
+    backend._executor = initial_executor
+    backend._device = "cpu"
+
+    recovered_executor = cast("ProcessPoolExecutor", object())
+    fake_result = {
+        "text": "hello world",
+        "language": "en",
+        "language_probability": 0.99,
+        "duration": 1.25,
+        "segments": [],
+    }
+    executors_seen: list[object] = []
+
+    async def mock_run_in_executor(
+        executor: object, _func: object, *_args: object
+    ) -> dict[str, object]:
+        executors_seen.append(executor)
+        if len(executors_seen) == 1:
+            msg = "worker died"
+            raise BrokenProcessPool(msg)
+        return fake_result
+
+    async def fake_unload() -> None:
+        backend._executor = None
+        backend._device = None
+
+    async def fake_load() -> float:
+        backend._executor = recovered_executor
+        backend._device = "cpu"
+        return 0.1
+
+    with (
+        patch("asyncio.get_running_loop") as mock_loop,
+        patch.object(backend, "unload", new=AsyncMock(side_effect=fake_unload)) as unload_mock,
+        patch.object(backend, "load", new=AsyncMock(side_effect=fake_load)) as load_mock,
+    ):
+        mock_loop.return_value.run_in_executor = mock_run_in_executor
+        result = await backend.transcribe(b"fake audio bytes")
+
+    assert result.text == "hello world"
+    unload_mock.assert_awaited_once()
+    load_mock.assert_awaited_once()
+    assert executors_seen == [initial_executor, recovered_executor]


### PR DESCRIPTION
## Summary
- catch `BrokenProcessPool` in the faster-whisper backend and retry a transcription once after unloading and reloading the model worker
- keep the recovery logic local to the faster-whisper backend so the generic model manager behavior stays unchanged
- add a regression test covering the dead-pool recovery path

## Test Plan
- `ruff check agent_cli/server/whisper/backends/faster_whisper.py tests/test_faster_whisper_backend.py`
- `pytest tests/test_server_whisper.py tests/test_faster_whisper_backend.py -q`
- `git commit` pre-commit hooks (ruff, ruff format, mypy, jscpd, pylint duplicate-code)
