### PR TITLE
Fix speaker identity follow-up issues

### DIFF
--- a/agent_cli/core/speaker_identity.py
+++ b/agent_cli/core/speaker_identity.py
@@ -611,14 +611,24 @@ def _enroll_assignment(
         raise ValueError(msg)
 
     source_profile = _find_profile(store, source_label)
-    should_rename_source = source_profile is not None and source_profile.get("anonymous")
+    renamed_source_profile = (
+        source_profile if source_profile is not None and source_profile.get("anonymous") else None
+    )
+    if renamed_source_profile is not None:
+        target_profile = _find_profile(store, name)
+        if target_profile is not None and target_profile is not renamed_source_profile:
+            renamed_source_profile = merge_speaker_profiles(
+                store,
+                str(renamed_source_profile["id"]),
+                name,
+            )
     for label in labels:
-        if should_rename_source:
+        if renamed_source_profile is not None:
             _add_named_embedding(
                 store,
                 name,
                 embeddings[label],
-                source_profile=source_profile,
+                source_profile=renamed_source_profile,
             )
         else:
             _add_named_embedding(store, name, embeddings[label])
@@ -653,6 +663,9 @@ def resolve_speaker_identities(
 ) -> dict[str, str]:
     """Resolve current diarization labels to persistent speaker names."""
     assignments = parse_speaker_assignments(enroll_speakers)
+    if not assignments and not identify_speakers and not remember_unknown_speakers:
+        return {}
+
     path = (profiles_file or DEFAULT_SPEAKER_PROFILES_FILE).expanduser()
     store = load_speaker_profile_store(path, embedding_model=embedding_model)
     if not _speaker_identities_need_embeddings(

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,18 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
+
+
+def _toml_path(path: str | Path) -> str:
+    return json.dumps(str(path))
+
+
+def test_toml_path_escapes_windows_backslashes() -> None:
+    windows_path = r"C:\Users\Bas\AppData\Local\agent-cli\speaker-profiles.json"
+
+    data = tomllib.loads(f"speaker-profiles-file = {_toml_path(windows_path)}")
+
+    assert data["speaker-profiles-file"] == windows_path
 
 
 def _write_profile_store(path: Path) -> None:
@@ -116,10 +129,10 @@ def test_speakers_list_uses_configured_profile_file(tmp_path: Path) -> None:
     config_file.write_text(
         f"""
 [defaults]
-speaker-profiles-file = "{default_profiles_file}"
+speaker-profiles-file = {_toml_path(default_profiles_file)}
 
 [speakers]
-speaker-profiles-file = "{profiles_file}"
+speaker-profiles-file = {_toml_path(profiles_file)}
 """,
         encoding="utf-8",
     )
@@ -145,7 +158,7 @@ def test_speakers_list_auto_loads_configured_profile_file(
     config_file.write_text(
         f"""
 [defaults]
-speaker-profiles-file = "{profiles_file}"
+speaker-profiles-file = {_toml_path(profiles_file)}
 """,
         encoding="utf-8",
     )

--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -128,6 +128,76 @@ def test_resolve_speaker_identities_enrolls_named_profile(tmp_path: Path) -> Non
     assert store["profiles"][0]["embeddings"] == [[1.0, 0.0]]
 
 
+def test_resolve_speaker_identities_disabled_skips_invalid_profile_file(
+    tmp_path: Path,
+) -> None:
+    profiles_file = tmp_path / "speaker-profiles.json"
+    profiles_file.write_text("{not valid json", encoding="utf-8")
+    segments = [DiarizedSegment(speaker="SPEAKER_00", start=0.0, end=2.0)]
+
+    with patch("agent_cli.core.speaker_identity.extract_speaker_embeddings") as mock_extract:
+        label_map = resolve_speaker_identities(
+            audio_path=tmp_path / "audio.wav",
+            segments=segments,
+            hf_token="token",  # noqa: S106
+            profiles_file=profiles_file,
+            identify_speakers=False,
+        )
+
+    assert label_map == {}
+    mock_extract.assert_not_called()
+
+
+def test_resolve_speaker_identities_merges_unknown_enrollment_into_existing_name(
+    tmp_path: Path,
+) -> None:
+    profiles_file = tmp_path / "speaker-profiles.json"
+    profiles_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "embedding_model": "pyannote/wespeaker-voxceleb-resnet34-LM",
+                "next_unknown_id": 2,
+                "profiles": [
+                    {
+                        "id": "alice",
+                        "name": "Alice",
+                        "anonymous": False,
+                        "embeddings": [[1.0, 0.0]],
+                    },
+                    {
+                        "id": "UNKNOWN_001",
+                        "name": None,
+                        "anonymous": True,
+                        "embeddings": [[0.0, 1.0]],
+                    },
+                ],
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    segments = [DiarizedSegment(speaker="SPEAKER_00", start=0.0, end=2.0)]
+
+    with patch(
+        "agent_cli.core.speaker_identity.extract_speaker_embeddings",
+        return_value={"SPEAKER_00": [0.0, 1.0]},
+    ):
+        label_map = resolve_speaker_identities(
+            audio_path=tmp_path / "audio.wav",
+            segments=segments,
+            hf_token="token",  # noqa: S106
+            profiles_file=profiles_file,
+            enroll_speakers="UNKNOWN_001=Alice",
+        )
+
+    assert label_map == {"SPEAKER_00": "Alice"}
+    store = load_speaker_profile_store(profiles_file)
+    assert [profile["name"] for profile in store["profiles"]] == ["Alice"]
+    assert store["profiles"][0]["id"] == "alice"
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]
+
+
 def test_resolve_speaker_identities_enrolls_before_remembering_unknowns(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Escape generated TOML path values in speaker CLI tests so Windows backslashes remain valid TOML strings.
- Skip speaker profile store loading when speaker identification is explicitly disabled and no enrollment/remembering action is requested.
- Merge remembered anonymous profiles into an existing named profile during enrollment instead of creating duplicate speaker names.

## Verification
- uv run ruff check agent_cli/agents/speakers.py tests/agents/test_speakers.py agent_cli/core/speaker_identity.py tests/test_speaker_identity.py
- uv run pytest tests/agents/test_speakers.py tests/test_speaker_identity.py
- commit hook: ruff, ruff format, mypy, jscpd, pylint duplicate-code

Note: a direct `uv run mypy ...` invocation uses the project-wide config here and fails on unrelated missing optional dependency stubs; the commit hook scoped mypy check passes.