### PR TITLE
Improve speaker review and clean segment selection

### DIFF
--- a/agent_cli/agents/speakers.py
+++ b/agent_cli/agents/speakers.py
@@ -960,6 +960,25 @@ def _print_no_review_summary(
             console.print(f"[dim]  {label}[/dim]")
 
 
+def _write_review_snippet_or_warn(
+    *,
+    audio_path: Path,
+    segment: DiarizedSegment,
+    output_dir: Path,
+    seconds: float,
+) -> Path | None:
+    try:
+        return _write_speaker_snippet(
+            audio_path=audio_path,
+            segment=segment,
+            output_dir=output_dir,
+            seconds=seconds,
+        )
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+        console.print(f"[yellow]Could not create snippet for {segment.speaker}: {exc}[/yellow]")
+        return None
+
+
 def _review_unknown_speakers(
     *,
     audio_path: Path,
@@ -968,11 +987,11 @@ def _review_unknown_speakers(
     matches: dict[str, SpeakerMatch],
     store: dict[str, Any],
     review_state: dict[str, Any],
-    speaker_match_threshold: float,
     snippet_seconds: float,
     player: str | None,
-) -> tuple[bool, list[dict[str, Any]]]:
+) -> tuple[bool, list[dict[str, Any]], bool]:
     changed = False
+    completed = True
     records: list[dict[str, Any]] = []
     with TemporaryDirectory(prefix="agent-cli-speakers-") as temp_dir:
         snippet_dir = Path(temp_dir)
@@ -994,7 +1013,7 @@ def _review_unknown_speakers(
                 review_state,
                 source_profile_id=source_profile_id,
                 embedding=embedding,
-                threshold=speaker_match_threshold,
+                threshold=REVIEW_SKIPPED_EMBEDDING_NEAR_DUPLICATE_THRESHOLD,
             )
             if skipped_entry is not None:
                 skipped_prior.append(review_label)
@@ -1031,15 +1050,14 @@ def _review_unknown_speakers(
                     match=match,
                 )
                 continue
-            try:
-                snippet_path = _write_speaker_snippet(
-                    audio_path=audio_path,
-                    segment=segment,
-                    output_dir=snippet_dir,
-                    seconds=snippet_seconds,
-                )
-            except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
-                console.print(f"[yellow]Could not create snippet for {label}: {exc}[/yellow]")
+            snippet_path = _write_review_snippet_or_warn(
+                audio_path=audio_path,
+                segment=segment,
+                output_dir=snippet_dir,
+                seconds=snippet_seconds,
+            )
+            if snippet_path is None:
+                completed = False
                 continue
             reviewed_count += 1
             try:
@@ -1068,14 +1086,14 @@ def _review_unknown_speakers(
                 changed = result.changed or changed
             except typer.Exit as exc:
                 raise _ReviewInterruptedError(changed, records) from exc
-        if reviewed_count == 0:
+        if reviewed_count == 0 and completed:
             _print_no_review_summary(
                 skipped_named=skipped_named,
                 skipped_prior=skipped_prior,
                 skipped_short=skipped_short,
                 skipped_no_embedding=skipped_no_embedding,
             )
-    return changed, records
+    return changed, records, completed
 
 
 def _review_audio_targets(
@@ -1125,14 +1143,13 @@ def _review_audio_targets(
         )
 
         try:
-            audio_changed, records = _review_unknown_speakers(
+            audio_changed, records, audio_completed = _review_unknown_speakers(
                 audio_path=audio_path,
                 segments=segments,
                 embeddings=embeddings,
                 matches=matches,
                 store=store,
                 review_state=review_state,
-                speaker_match_threshold=speaker_match_threshold,
                 snippet_seconds=snippet_seconds,
                 player=player,
             )
@@ -1141,6 +1158,11 @@ def _review_audio_targets(
             interrupted = True
             _save_review_state(review_state_path, review_state)
             break
+
+        if not audio_completed:
+            _save_review_state(review_state_path, review_state)
+            changed = audio_changed or changed
+            continue
 
         _record_audio_review(review_state, audio_path, records)
         _save_review_state(review_state_path, review_state)

--- a/agent_cli/agents/speakers.py
+++ b/agent_cli/agents/speakers.py
@@ -1137,17 +1137,15 @@ def _review_audio_targets(
                 player=player,
             )
         except _ReviewInterruptedError as exc:
-            audio_changed = exc.changed
-            records = exc.records
+            changed = exc.changed or changed
             interrupted = True
+            _save_review_state(review_state_path, review_state)
+            break
 
         _record_audio_review(review_state, audio_path, records)
         _save_review_state(review_state_path, review_state)
         reviewed_audio_count += 1
         changed = audio_changed or changed
-
-        if interrupted:
-            break
 
     return changed, reviewed_audio_count, skipped_audio_count, interrupted
 

--- a/agent_cli/agents/speakers.py
+++ b/agent_cli/agents/speakers.py
@@ -68,7 +68,6 @@ SPEAKER_PROFILES_FILE_OPTION: Path = typer.Option(
     "--speaker-profiles-file",
     help="JSON file storing persistent speaker voice embeddings.",
 )
-REVIEW_OUTPUT_DIR = Path.home() / ".cache" / "agent-cli" / "speaker-review"
 DEFAULT_REVIEW_TRANSCRIPTION_LOG = Path.home() / ".config" / "agent-cli" / "transcriptions.jsonl"
 DEFAULT_REVIEW_STATE_FILE = Path.home() / ".config" / "agent-cli" / "speaker-review-state.json"
 REVIEW_SKIPPED_EMBEDDING_NEAR_DUPLICATE_THRESHOLD = 0.98
@@ -78,11 +77,6 @@ REVIEW_TRANSCRIPTION_LOG_OPTION: Path = typer.Option(
     DEFAULT_REVIEW_TRANSCRIPTION_LOG,
     "--transcription-log",
     help="Path to the transcribe-live JSONL log for --last-session.",
-)
-REVIEW_OUTPUT_DIR_OPTION: Path = typer.Option(
-    REVIEW_OUTPUT_DIR,
-    "--output-dir",
-    help="Directory for combined live-session audio and temporary snippets.",
 )
 REVIEW_STATE_FILE_OPTION: Path = typer.Option(
     DEFAULT_REVIEW_STATE_FILE,
@@ -205,58 +199,15 @@ def _all_live_review_audio_targets(
     return [segment.audio_file for segment in reversed(segments) if segment.audio_file.exists()]
 
 
-def _combine_live_review_session(
-    *,
-    last_session: int,
-    transcription_log: Path,
-    output_dir: Path,
-    session_gap: float,
-) -> Path:
-    """Combine a transcribe-live session into one reviewable WAV file."""
-    from agent_cli.agents.diarize_live_session import (  # noqa: PLC0415
-        combine_segments,
-        load_segments,
-        select_recent_session,
-        session_basename,
-        write_ffconcat_manifest,
-    )
-
-    log_path = transcription_log.expanduser()
-    if not log_path.exists():
-        msg = f"Transcription log not found: {log_path}"
-        raise FileNotFoundError(msg)
-    selected = select_recent_session(
-        load_segments(log_path),
-        index=last_session,
-        max_gap_seconds=session_gap,
-    )
-    missing = [segment.audio_file for segment in selected if not segment.audio_file.exists()]
-    if missing:
-        missing_list = "\n".join(str(path) for path in missing)
-        msg = f"Selected audio files are missing:\n{missing_list}"
-        raise FileNotFoundError(msg)
-
-    output_dir = output_dir.expanduser()
-    output_dir.mkdir(parents=True, exist_ok=True)
-    basename = session_basename(selected)
-    manifest_path = output_dir / f"{basename}.ffconcat"
-    combined_audio = output_dir / f"{basename}.wav"
-    write_ffconcat_manifest(selected, manifest_path)
-    combine_segments(manifest_path, combined_audio)
-    return combined_audio
-
-
 def _resolve_review_audio_targets(
     *,
     from_file: Path | None,
     last_recording: int | None,
     last_session: int | None,
     transcription_log: Path,
-    output_dir: Path,
     session_gap: float,
 ) -> list[Path]:
     """Resolve the audio files that should be reviewed, newest first."""
-    del output_dir
     _validate_single_review_source(
         from_file=from_file,
         last_recording=last_recording,
@@ -296,27 +247,6 @@ def _resolve_review_audio_targets(
         msg = "Recording #1 not found."
         raise FileNotFoundError(msg)
     return [recording]
-
-
-def _resolve_review_audio_source(
-    *,
-    from_file: Path | None,
-    last_recording: int | None,
-    last_session: int | None,
-    transcription_log: Path,
-    output_dir: Path,
-    session_gap: float,
-) -> Path:
-    """Resolve the audio file that should be reviewed."""
-    targets = _resolve_review_audio_targets(
-        from_file=from_file,
-        last_recording=last_recording,
-        last_session=last_session,
-        transcription_log=transcription_log,
-        output_dir=output_dir,
-        session_gap=session_gap,
-    )
-    return targets[0]
 
 
 def _new_review_state() -> dict[str, Any]:
@@ -1375,7 +1305,6 @@ def review_speakers(
         ),
     ] = 300.0,
     transcription_log: Path = REVIEW_TRANSCRIPTION_LOG_OPTION,
-    output_dir: Path = REVIEW_OUTPUT_DIR_OPTION,
     hf_token: str | None = opts.HF_TOKEN,
     speakers: Annotated[
         int | None,
@@ -1434,7 +1363,6 @@ def review_speakers(
             last_recording=last_recording,
             last_session=last_session,
             transcription_log=transcription_log,
-            output_dir=output_dir,
             session_gap=session_gap,
         )
     except (FileNotFoundError, RuntimeError, ValueError) as exc:

--- a/agent_cli/agents/speakers.py
+++ b/agent_cli/agents/speakers.py
@@ -8,6 +8,10 @@ import shlex
 import shutil
 import subprocess
 import sys
+import warnings
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Annotated, Any
@@ -19,7 +23,12 @@ from rich.table import Table
 from agent_cli import opts
 from agent_cli.cli import app
 from agent_cli.core.deps import requires_extras
-from agent_cli.core.diarization import DiarizedSegment, SpeakerDiarizer
+from agent_cli.core.diarization import (
+    DEFAULT_CLEAN_SPEAKER_NEIGHBOR_GAP_SECONDS,
+    DiarizedSegment,
+    SpeakerDiarizer,
+    best_clean_speaker_segment,
+)
 from agent_cli.core.process import set_process_title
 from agent_cli.core.speaker_identity import (
     DEFAULT_SPEAKER_PROFILES_FILE,
@@ -61,6 +70,10 @@ SPEAKER_PROFILES_FILE_OPTION: Path = typer.Option(
 )
 REVIEW_OUTPUT_DIR = Path.home() / ".cache" / "agent-cli" / "speaker-review"
 DEFAULT_REVIEW_TRANSCRIPTION_LOG = Path.home() / ".config" / "agent-cli" / "transcriptions.jsonl"
+DEFAULT_REVIEW_STATE_FILE = Path.home() / ".config" / "agent-cli" / "speaker-review-state.json"
+REVIEW_SKIPPED_EMBEDDING_NEAR_DUPLICATE_THRESHOLD = 0.98
+REVIEW_MIN_PROMPT_SEGMENT_SECONDS = 2.0
+REVIEW_SNIPPET_NEIGHBOR_GAP_SECONDS = DEFAULT_CLEAN_SPEAKER_NEIGHBOR_GAP_SECONDS
 REVIEW_TRANSCRIPTION_LOG_OPTION: Path = typer.Option(
     DEFAULT_REVIEW_TRANSCRIPTION_LOG,
     "--transcription-log",
@@ -71,6 +84,49 @@ REVIEW_OUTPUT_DIR_OPTION: Path = typer.Option(
     "--output-dir",
     help="Directory for combined live-session audio and temporary snippets.",
 )
+REVIEW_STATE_FILE_OPTION: Path = typer.Option(
+    DEFAULT_REVIEW_STATE_FILE,
+    "--review-state-file",
+    help="JSON cache tracking which audio files have already been speaker-reviewed.",
+)
+
+
+@dataclass(frozen=True)
+class _SpeakerReviewResult:
+    changed: bool
+    action: str
+    target_profile_id: str | None = None
+    target_display_name: str | None = None
+
+
+class _ReviewInterruptedError(Exception):
+    """Review was quit after zero or more profile changes."""
+
+    def __init__(self, changed: bool, records: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.changed = changed
+        self.records = records
+
+
+@contextmanager
+def _suppress_speaker_review_warnings() -> Any:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="torchcodec is not installed correctly.*",
+            category=UserWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="Mean of empty slice.*",
+            category=RuntimeWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="invalid value encountered in divide.*",
+            category=RuntimeWarning,
+        )
+        yield
 
 
 @speakers_app.callback()
@@ -102,6 +158,51 @@ def _validate_single_review_source(
     if selected > 1:
         msg = "Use only one of --from-file, --last-recording, or --last-session."
         raise ValueError(msg)
+
+
+def _load_live_segments(log_path: Path) -> list[Any]:
+    from agent_cli.agents.diarize_live_session import load_segments  # noqa: PLC0415
+
+    expanded = log_path.expanduser()
+    if not expanded.exists():
+        msg = f"Transcription log not found: {expanded}"
+        raise FileNotFoundError(msg)
+    return load_segments(expanded)
+
+
+def _select_recent_live_session_audio(
+    *,
+    last_session: int,
+    transcription_log: Path,
+    session_gap: float,
+) -> list[Path]:
+    from agent_cli.agents.diarize_live_session import select_recent_session  # noqa: PLC0415
+
+    if last_session < 1:
+        msg = "--last-session must be 1 or greater."
+        raise ValueError(msg)
+    selected = select_recent_session(
+        _load_live_segments(transcription_log),
+        index=last_session,
+        max_gap_seconds=session_gap,
+    )
+    missing = [segment.audio_file for segment in selected if not segment.audio_file.exists()]
+    if missing:
+        missing_list = "\n".join(str(path) for path in missing)
+        msg = f"Selected audio files are missing:\n{missing_list}"
+        raise FileNotFoundError(msg)
+    return [segment.audio_file for segment in reversed(selected)]
+
+
+def _all_live_review_audio_targets(
+    *,
+    transcription_log: Path,
+) -> list[Path]:
+    try:
+        segments = _load_live_segments(transcription_log)
+    except FileNotFoundError:
+        return []
+    return [segment.audio_file for segment in reversed(segments) if segment.audio_file.exists()]
 
 
 def _combine_live_review_session(
@@ -145,7 +246,7 @@ def _combine_live_review_session(
     return combined_audio
 
 
-def _resolve_review_audio_source(
+def _resolve_review_audio_targets(
     *,
     from_file: Path | None,
     last_recording: int | None,
@@ -153,8 +254,9 @@ def _resolve_review_audio_source(
     transcription_log: Path,
     output_dir: Path,
     session_gap: float,
-) -> Path:
-    """Resolve the audio file that should be reviewed."""
+) -> list[Path]:
+    """Resolve the audio files that should be reviewed, newest first."""
+    del output_dir
     _validate_single_review_source(
         from_file=from_file,
         last_recording=last_recording,
@@ -166,28 +268,243 @@ def _resolve_review_audio_source(
         if not path.exists():
             msg = f"File not found: {path}"
             raise FileNotFoundError(msg)
-        return path
+        return [path]
 
     if last_session is not None:
-        if last_session < 1:
-            msg = "--last-session must be 1 or greater."
-            raise ValueError(msg)
-        return _combine_live_review_session(
+        return _select_recent_live_session_audio(
             last_session=last_session,
             transcription_log=transcription_log,
-            output_dir=output_dir,
             session_gap=session_gap,
         )
 
-    recording_index = 1 if last_recording is None else last_recording
-    if recording_index < 1:
-        msg = "--last-recording must be 1 or greater."
-        raise ValueError(msg)
-    recording = get_last_recording(recording_index)
+    if last_recording is not None:
+        if last_recording < 1:
+            msg = "--last-recording must be 1 or greater."
+            raise ValueError(msg)
+        recording = get_last_recording(last_recording)
+        if recording is None:
+            msg = f"Recording #{last_recording} not found."
+            raise FileNotFoundError(msg)
+        return [recording]
+
+    live_targets = _all_live_review_audio_targets(transcription_log=transcription_log)
+    if live_targets:
+        return live_targets
+
+    recording = get_last_recording(1)
     if recording is None:
-        msg = f"Recording #{recording_index} not found."
+        msg = "Recording #1 not found."
         raise FileNotFoundError(msg)
-    return recording
+    return [recording]
+
+
+def _resolve_review_audio_source(
+    *,
+    from_file: Path | None,
+    last_recording: int | None,
+    last_session: int | None,
+    transcription_log: Path,
+    output_dir: Path,
+    session_gap: float,
+) -> Path:
+    """Resolve the audio file that should be reviewed."""
+    targets = _resolve_review_audio_targets(
+        from_file=from_file,
+        last_recording=last_recording,
+        last_session=last_session,
+        transcription_log=transcription_log,
+        output_dir=output_dir,
+        session_gap=session_gap,
+    )
+    return targets[0]
+
+
+def _new_review_state() -> dict[str, Any]:
+    return {"version": 1, "audio_files": {}, "skipped_speakers": []}
+
+
+def _load_review_state(path: Path) -> dict[str, Any]:
+    path = path.expanduser()
+    if not path.exists():
+        return _new_review_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        msg = f"Invalid speaker review state file {path}: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"Invalid speaker review state file {path}: expected a JSON object."
+        raise TypeError(msg)
+    audio_files = data.get("audio_files")
+    if not isinstance(audio_files, dict):
+        data["audio_files"] = {}
+    skipped_speakers = data.get("skipped_speakers")
+    if not isinstance(skipped_speakers, list):
+        data["skipped_speakers"] = []
+    data.setdefault("version", 1)
+    return data
+
+
+def _save_review_state(path: Path, state: dict[str, Any]) -> None:
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _audio_review_key(audio_path: Path) -> str:
+    return str(audio_path.expanduser().resolve(strict=False))
+
+
+def _audio_review_metadata(audio_path: Path) -> dict[str, Any]:
+    stat = audio_path.expanduser().stat()
+    return {
+        "path": _audio_review_key(audio_path),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _audio_review_is_cached(
+    state: dict[str, Any],
+    audio_path: Path,
+) -> bool:
+    audio_files = state.get("audio_files", {})
+    if not isinstance(audio_files, dict):
+        return False
+    entry = audio_files.get(_audio_review_key(audio_path))
+    if not isinstance(entry, dict):
+        return False
+    try:
+        metadata = _audio_review_metadata(audio_path)
+    except OSError:
+        return False
+    return entry.get("size") == metadata["size"] and entry.get("mtime_ns") == metadata["mtime_ns"]
+
+
+def _review_record_from_result(
+    *,
+    diarized_label: str,
+    review_label: str,
+    match: SpeakerMatch | None,
+    result: _SpeakerReviewResult,
+) -> dict[str, Any]:
+    return {
+        "diarized_label": diarized_label,
+        "review_label": review_label,
+        "profile_id": match.profile_id if match is not None else None,
+        "display_name": match.display_name if match is not None else None,
+        "similarity": match.similarity if match is not None else None,
+        "action": result.action,
+        "target_profile_id": result.target_profile_id,
+        "target_display_name": result.target_display_name,
+        "reviewed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _record_audio_review(
+    state: dict[str, Any],
+    audio_path: Path,
+    records: list[dict[str, Any]],
+) -> None:
+    audio_files = state.setdefault("audio_files", {})
+    if not isinstance(audio_files, dict):
+        audio_files = {}
+        state["audio_files"] = audio_files
+    metadata = _audio_review_metadata(audio_path)
+    audio_files[metadata["path"]] = {
+        **metadata,
+        "reviewed_at": datetime.now(UTC).isoformat(),
+        "speakers": records,
+    }
+
+
+def _review_cosine_similarity(left: list[float], right: list[float]) -> float:
+    if len(left) != len(right) or not left or not right:
+        return -1.0
+    return sum(a * b for a, b in zip(left, right, strict=True))
+
+
+def _source_review_profile_id(
+    store: dict[str, Any],
+    match: SpeakerMatch | None,
+) -> str | None:
+    profile = _matched_profile(store, match)
+    if profile is not None and bool(profile.get("anonymous")):
+        return str(profile["id"])
+    return None
+
+
+def _skipped_speaker_entries(review_state: dict[str, Any]) -> list[dict[str, Any]]:
+    skipped_speakers = review_state.setdefault("skipped_speakers", [])
+    if not isinstance(skipped_speakers, list):
+        skipped_speakers = []
+        review_state["skipped_speakers"] = skipped_speakers
+    return skipped_speakers
+
+
+def _matching_skipped_speaker(
+    review_state: dict[str, Any],
+    *,
+    source_profile_id: str | None,
+    embedding: list[float] | None,
+    threshold: float,
+) -> dict[str, Any] | None:
+    for entry in _skipped_speaker_entries(review_state):
+        if not isinstance(entry, dict):
+            continue
+        if source_profile_id is not None and entry.get("profile_id") == source_profile_id:
+            return entry
+        entry_embeddings = entry.get("embeddings", [])
+        if embedding is None or not isinstance(entry_embeddings, list):
+            continue
+        for entry_embedding in entry_embeddings:
+            if not isinstance(entry_embedding, list):
+                continue
+            similarity = _review_cosine_similarity(embedding, entry_embedding)
+            if similarity >= threshold:
+                return entry
+    return None
+
+
+def _record_skipped_speaker(
+    review_state: dict[str, Any],
+    *,
+    review_label: str,
+    source_profile_id: str | None,
+    embedding: list[float] | None,
+) -> None:
+    entries = _skipped_speaker_entries(review_state)
+    entry = _matching_skipped_speaker(
+        review_state,
+        source_profile_id=source_profile_id,
+        embedding=embedding,
+        threshold=REVIEW_SKIPPED_EMBEDDING_NEAR_DUPLICATE_THRESHOLD,
+    )
+    now = datetime.now(UTC).isoformat()
+    if entry is None:
+        entry = {
+            "id": source_profile_id or f"skipped_{len(entries) + 1:04d}",
+            "profile_id": source_profile_id,
+            "label": review_label,
+            "embeddings": [],
+            "created_at": now,
+        }
+        entries.append(entry)
+    entry["label"] = review_label
+    entry["updated_at"] = now
+    if embedding is None:
+        return
+    embeddings = entry.setdefault("embeddings", [])
+    if not isinstance(embeddings, list):
+        embeddings = []
+        entry["embeddings"] = embeddings
+    for existing in embeddings:
+        if isinstance(existing, list) and (
+            _review_cosine_similarity(embedding, existing)
+            >= REVIEW_SKIPPED_EMBEDDING_NEAR_DUPLICATE_THRESHOLD
+        ):
+            return
+    embeddings.append(embedding)
 
 
 def _speaker_labels_by_first_turn(segments: list[DiarizedSegment]) -> list[str]:
@@ -195,20 +512,6 @@ def _speaker_labels_by_first_turn(segments: list[DiarizedSegment]) -> list[str]:
     for segment in segments:
         first_seen.setdefault(segment.speaker, segment.start)
     return [label for label, _ in sorted(first_seen.items(), key=lambda item: item[1])]
-
-
-def _best_segment_for_speaker(
-    segments: list[DiarizedSegment],
-    speaker: str,
-) -> DiarizedSegment | None:
-    candidates = [
-        segment
-        for segment in segments
-        if segment.speaker == speaker and segment.end > segment.start
-    ]
-    if not candidates:
-        return None
-    return max(candidates, key=lambda segment: segment.end - segment.start)
 
 
 def _write_speaker_snippet(
@@ -310,7 +613,7 @@ def _stop_audio_playback(
 def _review_choice_prompt() -> str:
     return (
         typer.prompt(
-            "Action [p] replay, [m] merge, [n] new, [s] skip, [q] quit",
+            "Choose action",
             default="s",
         )
         .strip()
@@ -323,6 +626,7 @@ def _print_review_speaker_intro(
     label: str,
     embedding: list[float] | None,
     match: SpeakerMatch | None,
+    source_profile_id: str | None,
 ) -> None:
     console.print(f"\n[bold]Speaker:[/bold] [cyan]{label}[/cyan]")
     if match is not None:
@@ -331,10 +635,73 @@ def _print_review_speaker_intro(
             f"[bold]{match.display_name}[/bold] "
             f"([cyan]{match.profile_id}[/cyan], {match.similarity:.2f})",
         )
+    else:
+        console.print("[dim]Closest profile:[/dim] none")
     if embedding is None:
         console.print(
             "[yellow]No embedding was available for this speaker; only skip/replay works.[/yellow]"
         )
+        console.print(
+            "[dim]Actions:[/dim] "
+            "[bold]p[/bold]=replay, "
+            "[bold]s[/bold]=skip, "
+            "[bold]q[/bold]=save and quit",
+        )
+    else:
+        name_action = "name this unknown speaker" if source_profile_id else "create a new profile"
+        console.print(
+            "[dim]Actions:[/dim] "
+            "[bold]p[/bold]=replay, "
+            "[bold]m[/bold]=merge into an existing named profile, "
+            f"[bold]n[/bold]={name_action}, "
+            "[bold]s[/bold]=skip, "
+            "[bold]q[/bold]=save and quit",
+        )
+
+
+def _matched_profile(
+    store: dict[str, Any],
+    match: SpeakerMatch | None,
+) -> dict[str, Any] | None:
+    if match is None:
+        return None
+    profiles = store.get("profiles", [])
+    if not isinstance(profiles, list):
+        return None
+    for profile in profiles:
+        if isinstance(profile, dict) and str(profile.get("id")) == match.profile_id:
+            return profile
+    return None
+
+
+def _is_named_review_match(
+    *,
+    store: dict[str, Any],
+    match: SpeakerMatch | None,
+) -> bool:
+    profile = _matched_profile(store, match)
+    return profile is not None and not bool(profile.get("anonymous"))
+
+
+def _is_anonymous_review_match(
+    *,
+    store: dict[str, Any],
+    match: SpeakerMatch | None,
+) -> bool:
+    profile = _matched_profile(store, match)
+    return profile is not None and bool(profile.get("anonymous"))
+
+
+def _review_label(
+    *,
+    diarized_label: str,
+    store: dict[str, Any],
+    match: SpeakerMatch | None,
+) -> str:
+    profile = _matched_profile(store, match)
+    if profile is not None and bool(profile.get("anonymous")):
+        return str(profile.get("id"))
+    return diarized_label
 
 
 def _start_review_snippet(
@@ -349,43 +716,127 @@ def _start_review_snippet(
         return None
 
 
+def _named_profile_options(
+    store: dict[str, Any],
+    *,
+    exclude_profile_id: str | None = None,
+) -> list[dict[str, Any]]:
+    profiles = store.get("profiles", [])
+    if not isinstance(profiles, list):
+        return []
+    return [
+        profile
+        for profile in profiles
+        if isinstance(profile, dict)
+        and not bool(profile.get("anonymous"))
+        and str(profile.get("id")) != exclude_profile_id
+    ]
+
+
+def _print_merge_target_options(
+    store: dict[str, Any],
+    *,
+    exclude_profile_id: str | None,
+) -> list[dict[str, Any]]:
+    options = _named_profile_options(store, exclude_profile_id=exclude_profile_id)
+    if not options:
+        console.print(
+            "[yellow]No named profiles are available to merge into. Use new/name.[/yellow]"
+        )
+        return []
+    console.print("[dim]Merge targets:[/dim]")
+    for index, profile in enumerate(options, start=1):
+        summary = summarize_speaker_profile(profile)
+        console.print(
+            f"  [bold]{index}[/bold]. [bold]{summary['display_name']}[/bold] "
+            f"([cyan]{summary['id']}[/cyan])",
+        )
+    return options
+
+
+def _resolve_merge_target_choice(
+    choice: str,
+    options: list[dict[str, Any]],
+) -> str | None:
+    clean_choice = choice.strip()
+    if clean_choice.isdecimal():
+        index = int(clean_choice)
+        if 1 <= index <= len(options):
+            return str(options[index - 1]["id"])
+    for profile in options:
+        summary = summarize_speaker_profile(profile)
+        if clean_choice.casefold() in {
+            str(summary["id"]).casefold(),
+            str(summary["display_name"]).casefold(),
+        }:
+            return str(summary["id"])
+    console.print("[yellow]Choose one of the listed profile numbers.[/yellow]")
+    return None
+
+
+def _prompt_merge_target(
+    store: dict[str, Any],
+    *,
+    exclude_profile_id: str | None,
+) -> str | None:
+    options = _print_merge_target_options(store, exclude_profile_id=exclude_profile_id)
+    if not options:
+        return None
+    default = "1" if len(options) == 1 else None
+    target = typer.prompt("Merge into profile number", default=default).strip()
+    return _resolve_merge_target_choice(target, options)
+
+
 def _merge_review_speaker(
     *,
     label: str,
     embedding: list[float],
-    match: SpeakerMatch | None,
+    source_profile_id: str | None,
     store: dict[str, Any],
-) -> bool:
-    if match is not None:
-        target = typer.prompt("Target profile id/name", default=match.display_name).strip()
-    else:
-        target = typer.prompt("Target profile id/name").strip()
+) -> dict[str, Any] | None:
+    target = _prompt_merge_target(store, exclude_profile_id=source_profile_id)
+    if target is None:
+        return None
     try:
-        profile = add_speaker_embedding_to_profile(store, target, embedding)
+        if source_profile_id is not None:
+            profile = merge_speaker_profiles(store, source_profile_id, target)
+        else:
+            profile = add_speaker_embedding_to_profile(store, target, embedding)
     except ValueError as exc:
         console.print(f"[yellow]{exc}[/yellow]")
-        return False
+        return None
     summary = summarize_speaker_profile(profile)
     console.print(
         f"[green]Merged current speaker {label} into {summary['display_name']}.[/green]",
     )
-    return True
+    return summary
 
 
 def _create_review_speaker(
     *,
+    label: str,
     embedding: list[float],
+    source_profile_id: str | None,
     store: dict[str, Any],
-) -> bool:
-    name = typer.prompt("New speaker name").strip()
+) -> dict[str, Any] | None:
+    prompt = "Speaker name" if source_profile_id is not None else "New speaker name"
+    name = typer.prompt(prompt).strip()
     try:
-        profile = create_speaker_profile_from_embedding(store, name, embedding)
+        if source_profile_id is not None:
+            profile = rename_speaker_profile(store, source_profile_id, name)
+        else:
+            profile = create_speaker_profile_from_embedding(store, name, embedding)
     except ValueError as exc:
         console.print(f"[yellow]{exc}[/yellow]")
-        return False
+        return None
     summary = summarize_speaker_profile(profile)
-    console.print(f"[green]Created speaker profile {summary['display_name']}.[/green]")
-    return True
+    if source_profile_id is not None:
+        console.print(
+            f"[green]Named speaker {label} as {summary['display_name']}.[/green]",
+        )
+    else:
+        console.print(f"[green]Created speaker profile {summary['display_name']}.[/green]")
+    return summary
 
 
 def _review_speaker(
@@ -396,40 +847,337 @@ def _review_speaker(
     match: SpeakerMatch | None,
     store: dict[str, Any],
     player: str | None,
-) -> bool:
+) -> _SpeakerReviewResult:
     """Interactively review one diarized speaker label."""
-    changed = False
+    source_profile = _matched_profile(store, match)
+    source_profile_id = (
+        str(source_profile["id"])
+        if source_profile is not None and bool(source_profile.get("anonymous"))
+        else None
+    )
+    play_requested = True
     while True:
-        _print_review_speaker_intro(label=label, embedding=embedding, match=match)
-        playback_process = _start_review_snippet(snippet_path, player=player)
+        _print_review_speaker_intro(
+            label=label,
+            embedding=embedding,
+            match=match,
+            source_profile_id=source_profile_id,
+        )
+        playback_process = (
+            _start_review_snippet(snippet_path, player=player) if play_requested else None
+        )
+        play_requested = False
 
         try:
             choice = _review_choice_prompt()
         finally:
             _stop_audio_playback(playback_process)
         if choice in {"p", "play", "replay"}:
+            play_requested = True
             continue
         if choice in {"s", "skip", ""}:
             console.print(f"[dim]Skipped {label}.[/dim]")
-            return changed
+            return _SpeakerReviewResult(changed=False, action="skipped")
         if choice in {"q", "quit"}:
             raise typer.Exit(0)
         if embedding is None:
-            console.print("[yellow]Choose skip or replay; this speaker has no embedding.[/yellow]")
+            console.print("[yellow]Choose p, s, or q; this speaker has no embedding.[/yellow]")
             continue
         if choice in {"m", "merge"}:
-            changed = _merge_review_speaker(
-                label=label, embedding=embedding, match=match, store=store
+            summary = _merge_review_speaker(
+                label=label,
+                embedding=embedding,
+                source_profile_id=source_profile_id,
+                store=store,
             )
-            if changed:
-                return True
+            if summary is not None:
+                return _SpeakerReviewResult(
+                    changed=True,
+                    action="merged",
+                    target_profile_id=str(summary["id"]),
+                    target_display_name=str(summary["display_name"]),
+                )
             continue
         if choice in {"n", "new", "name"}:
-            changed = _create_review_speaker(embedding=embedding, store=store)
-            if changed:
-                return True
+            summary = _create_review_speaker(
+                label=label,
+                embedding=embedding,
+                source_profile_id=source_profile_id,
+                store=store,
+            )
+            if summary is not None:
+                return _SpeakerReviewResult(
+                    changed=True,
+                    action="named" if source_profile_id is not None else "created",
+                    target_profile_id=str(summary["id"]),
+                    target_display_name=str(summary["display_name"]),
+                )
             continue
-        console.print("[yellow]Unknown choice. Use p, m, n, s, or q.[/yellow]")
+        if embedding is None:
+            console.print("[yellow]Unknown choice. Use p, s, or q.[/yellow]")
+        else:
+            console.print("[yellow]Unknown choice. Use p, m, n, s, or q.[/yellow]")
+
+
+def _append_review_record(
+    records: list[dict[str, Any]],
+    *,
+    diarized_label: str,
+    review_label: str,
+    match: SpeakerMatch | None,
+    result: _SpeakerReviewResult,
+) -> None:
+    records.append(
+        _review_record_from_result(
+            diarized_label=diarized_label,
+            review_label=review_label,
+            match=match,
+            result=result,
+        ),
+    )
+
+
+def _append_cached_skip_record(
+    records: list[dict[str, Any]],
+    *,
+    diarized_label: str,
+    review_label: str,
+    match: SpeakerMatch | None,
+    skipped_entry: dict[str, Any],
+) -> None:
+    _append_review_record(
+        records,
+        diarized_label=diarized_label,
+        review_label=review_label,
+        match=match,
+        result=_SpeakerReviewResult(
+            changed=False,
+            action="skipped_cached",
+            target_profile_id=str(skipped_entry.get("id")),
+            target_display_name=str(skipped_entry.get("label")),
+        ),
+    )
+
+
+def _append_short_skip_record(
+    records: list[dict[str, Any]],
+    *,
+    diarized_label: str,
+    review_label: str,
+    match: SpeakerMatch | None,
+) -> None:
+    _append_review_record(
+        records,
+        diarized_label=diarized_label,
+        review_label=review_label,
+        match=match,
+        result=_SpeakerReviewResult(changed=False, action="skipped_short"),
+    )
+
+
+def _print_no_review_summary(
+    *,
+    skipped_named: list[tuple[str, SpeakerMatch]],
+    skipped_prior: list[str],
+    skipped_short: list[str],
+) -> None:
+    console.print("[dim]No unknown speakers found in this audio.[/dim]")
+    if skipped_named:
+        console.print("[dim]Skipped named speaker matches:[/dim]")
+        for label, match in skipped_named:
+            console.print(
+                f"[dim]  {label} -> {match.display_name} "
+                f"({match.profile_id}, {match.similarity:.2f})[/dim]",
+            )
+    if skipped_prior:
+        console.print("[dim]Skipped previously skipped speakers:[/dim]")
+        for label in skipped_prior:
+            console.print(f"[dim]  {label}[/dim]")
+    if skipped_short:
+        console.print("[dim]Skipped short speaker fragments:[/dim]")
+        for label in skipped_short:
+            console.print(f"[dim]  {label} (<{REVIEW_MIN_PROMPT_SEGMENT_SECONDS:.0f}s)[/dim]")
+
+
+def _review_unknown_speakers(
+    *,
+    audio_path: Path,
+    segments: list[DiarizedSegment],
+    embeddings: dict[str, list[float]],
+    matches: dict[str, SpeakerMatch],
+    store: dict[str, Any],
+    review_state: dict[str, Any],
+    speaker_match_threshold: float,
+    snippet_seconds: float,
+    player: str | None,
+) -> tuple[bool, list[dict[str, Any]]]:
+    changed = False
+    records: list[dict[str, Any]] = []
+    with TemporaryDirectory(prefix="agent-cli-speakers-") as temp_dir:
+        snippet_dir = Path(temp_dir)
+        reviewed_count = 0
+        skipped_named: list[tuple[str, SpeakerMatch]] = []
+        skipped_prior: list[str] = []
+        skipped_short: list[str] = []
+        for label in _speaker_labels_by_first_turn(segments):
+            match = matches.get(label)
+            if _is_named_review_match(store=store, match=match):
+                assert match is not None
+                skipped_named.append((label, match))
+                continue
+            embedding = embeddings.get(label)
+            source_profile_id = _source_review_profile_id(store, match)
+            review_label = _review_label(diarized_label=label, store=store, match=match)
+            skipped_entry = _matching_skipped_speaker(
+                review_state,
+                source_profile_id=source_profile_id,
+                embedding=embedding,
+                threshold=speaker_match_threshold,
+            )
+            if skipped_entry is not None:
+                skipped_prior.append(review_label)
+                _append_cached_skip_record(
+                    records,
+                    diarized_label=label,
+                    review_label=review_label,
+                    match=match,
+                    skipped_entry=skipped_entry,
+                )
+                continue
+            segment = best_clean_speaker_segment(
+                segments,
+                label,
+                neighbor_gap_seconds=REVIEW_SNIPPET_NEIGHBOR_GAP_SECONDS,
+            )
+            if segment is None:
+                continue
+            if segment.end - segment.start < REVIEW_MIN_PROMPT_SEGMENT_SECONDS:
+                skipped_short.append(review_label)
+                _append_short_skip_record(
+                    records,
+                    diarized_label=label,
+                    review_label=review_label,
+                    match=match,
+                )
+                continue
+            try:
+                snippet_path = _write_speaker_snippet(
+                    audio_path=audio_path,
+                    segment=segment,
+                    output_dir=snippet_dir,
+                    seconds=snippet_seconds,
+                )
+            except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+                console.print(f"[yellow]Could not create snippet for {label}: {exc}[/yellow]")
+                continue
+            reviewed_count += 1
+            try:
+                result = _review_speaker(
+                    label=review_label,
+                    snippet_path=snippet_path,
+                    embedding=embeddings.get(label),
+                    match=match,
+                    store=store,
+                    player=player,
+                )
+                _append_review_record(
+                    records,
+                    diarized_label=label,
+                    review_label=review_label,
+                    match=match,
+                    result=result,
+                )
+                if result.action == "skipped":
+                    _record_skipped_speaker(
+                        review_state,
+                        review_label=review_label,
+                        source_profile_id=source_profile_id,
+                        embedding=embedding,
+                    )
+                changed = result.changed or changed
+            except typer.Exit as exc:
+                raise _ReviewInterruptedError(changed, records) from exc
+        if reviewed_count == 0:
+            _print_no_review_summary(
+                skipped_named=skipped_named,
+                skipped_prior=skipped_prior,
+                skipped_short=skipped_short,
+            )
+    return changed, records
+
+
+def _review_audio_targets(
+    *,
+    audio_targets: list[Path],
+    review_state: dict[str, Any],
+    store: dict[str, Any],
+    diarizer: SpeakerDiarizer,
+    hf_token: str,
+    speaker_match_threshold: float,
+    snippet_seconds: float,
+    player: str | None,
+    force_review: bool,
+    review_state_path: Path,
+) -> tuple[bool, int, int, bool]:
+    changed = False
+    reviewed_audio_count = 0
+    skipped_audio_count = 0
+    interrupted = False
+
+    for audio_path in audio_targets:
+        if not force_review and _audio_review_is_cached(review_state, audio_path):
+            skipped_audio_count += 1
+            continue
+
+        console.print(f"[blue]Running diarization on {audio_path}...[/blue]")
+        with _suppress_speaker_review_warnings():
+            segments = diarizer.diarize(audio_path)
+        if not segments:
+            console.print("[yellow]Diarization returned no speaker segments.[/yellow]")
+            _record_audio_review(review_state, audio_path, [])
+            _save_review_state(review_state_path, review_state)
+            reviewed_audio_count += 1
+            continue
+
+        with _suppress_speaker_review_warnings():
+            embeddings = extract_speaker_embeddings(
+                audio_path=audio_path,
+                segments=segments,
+                hf_token=hf_token,
+                device=diarizer.device,
+            )
+        matches = match_speaker_profiles(
+            embeddings,
+            store,
+            threshold=speaker_match_threshold,
+        )
+
+        try:
+            audio_changed, records = _review_unknown_speakers(
+                audio_path=audio_path,
+                segments=segments,
+                embeddings=embeddings,
+                matches=matches,
+                store=store,
+                review_state=review_state,
+                speaker_match_threshold=speaker_match_threshold,
+                snippet_seconds=snippet_seconds,
+                player=player,
+            )
+        except _ReviewInterruptedError as exc:
+            audio_changed = exc.changed
+            records = exc.records
+            interrupted = True
+
+        _record_audio_review(review_state, audio_path, records)
+        _save_review_state(review_state_path, review_state)
+        reviewed_audio_count += 1
+        changed = audio_changed or changed
+
+        if interrupted:
+            break
+
+    return changed, reviewed_audio_count, skipped_audio_count, interrupted
 
 
 @speakers_app.command("list")
@@ -605,14 +1353,18 @@ def review_speakers(
         int | None,
         typer.Option(
             "--last-recording",
-            help="Review the Nth most recent saved transcribe recording (default: 1).",
+            help="Review the Nth most recent saved transcribe recording.",
         ),
     ] = None,
     last_session: Annotated[
         int | None,
         typer.Option(
             "--last-session",
-            help="Review the Nth most recent inferred transcribe-live session.",
+            "--last-live-session",
+            help=(
+                "Review the Nth most recent inferred transcribe-live session "
+                "(default source when available)."
+            ),
         ),
     ] = None,
     session_gap: Annotated[
@@ -651,6 +1403,14 @@ def review_speakers(
             help="Audio player command to use for snippets (default: afplay, ffplay, aplay, or paplay).",
         ),
     ] = None,
+    review_state_file: Path = REVIEW_STATE_FILE_OPTION,
+    force_review: Annotated[
+        bool,
+        typer.Option(
+            "--force-review",
+            help="Review audio even if it is already present in the speaker review cache.",
+        ),
+    ] = False,
     _config_file: str | None = opts.CONFIG_FILE,
 ) -> None:
     """Interactively review diarized speakers by listening to snippets."""
@@ -669,7 +1429,7 @@ def review_speakers(
         raise typer.Exit(1)
 
     try:
-        audio_path = _resolve_review_audio_source(
+        audio_targets = _resolve_review_audio_targets(
             from_file=from_file,
             last_recording=last_recording,
             last_session=last_session,
@@ -681,68 +1441,51 @@ def review_speakers(
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc
 
-    diarizer = SpeakerDiarizer(
-        hf_token=hf_token,
-        min_speakers=speakers if speakers is not None else min_speakers,
-        max_speakers=speakers if speakers is not None else max_speakers,
-    )
-    console.print(f"[blue]Running diarization on {audio_path}...[/blue]")
-    segments = diarizer.diarize(audio_path)
-    if not segments:
-        console.print("[red]Diarization returned no speaker segments.[/red]")
-        raise typer.Exit(1)
+    try:
+        review_state_path = review_state_file.expanduser()
+        review_state = _load_review_state(review_state_path)
+    except (TypeError, ValueError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    with _suppress_speaker_review_warnings():
+        diarizer = SpeakerDiarizer(
+            hf_token=hf_token,
+            min_speakers=speakers if speakers is not None else min_speakers,
+            max_speakers=speakers if speakers is not None else max_speakers,
+        )
 
     profiles_path = speaker_profiles_file.expanduser()
     store = _load_store_or_exit(profiles_path)
-    embeddings = extract_speaker_embeddings(
-        audio_path=audio_path,
-        segments=segments,
+    changed, reviewed_audio_count, skipped_audio_count, interrupted = _review_audio_targets(
+        audio_targets=audio_targets,
+        review_state=review_state,
+        store=store,
+        diarizer=diarizer,
         hf_token=hf_token,
-        device=diarizer.device,
-    )
-    matches = match_speaker_profiles(
-        embeddings,
-        store,
-        threshold=speaker_match_threshold,
+        speaker_match_threshold=speaker_match_threshold,
+        snippet_seconds=snippet_seconds,
+        player=player,
+        force_review=force_review,
+        review_state_path=review_state_path,
     )
 
-    changed = False
-    try:
-        with TemporaryDirectory(prefix="agent-cli-speakers-") as temp_dir:
-            snippet_dir = Path(temp_dir)
-            for label in _speaker_labels_by_first_turn(segments):
-                segment = _best_segment_for_speaker(segments, label)
-                if segment is None:
-                    continue
-                try:
-                    snippet_path = _write_speaker_snippet(
-                        audio_path=audio_path,
-                        segment=segment,
-                        output_dir=snippet_dir,
-                        seconds=snippet_seconds,
-                    )
-                except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
-                    console.print(f"[yellow]Could not create snippet for {label}: {exc}[/yellow]")
-                    continue
-                changed = (
-                    _review_speaker(
-                        label=label,
-                        snippet_path=snippet_path,
-                        embedding=embeddings.get(label),
-                        match=matches.get(label),
-                        store=store,
-                        player=player,
-                    )
-                    or changed
-                )
-    except typer.Exit:
-        if changed:
-            save_speaker_profile_store(profiles_path, store)
-            console.print(f"[green]Saved speaker profiles to {profiles_path}.[/green]")
-        raise
+    _save_review_state(review_state_path, review_state)
 
     if changed:
         save_speaker_profile_store(profiles_path, store)
         console.print(f"[green]Saved speaker profiles to {profiles_path}.[/green]")
-    else:
+    if reviewed_audio_count:
+        console.print(f"[green]Saved speaker review state to {review_state_path}.[/green]")
+    if interrupted:
+        raise typer.Exit(0)
+
+    if skipped_audio_count:
+        console.print(f"[dim]Skipped {skipped_audio_count} already reviewed audio file(s).[/dim]")
+
+    if changed:
+        return
+    if reviewed_audio_count:
         console.print("[dim]No speaker profile changes made.[/dim]")
+    else:
+        console.print("[dim]No unreviewed audio files found.[/dim]")

--- a/agent_cli/agents/speakers.py
+++ b/agent_cli/agents/speakers.py
@@ -558,6 +558,7 @@ def _print_review_speaker_intro(
     match: SpeakerMatch | None,
     source_profile_id: str | None,
 ) -> None:
+    can_update_profile = embedding is not None or source_profile_id is not None
     console.print(f"\n[bold]Speaker:[/bold] [cyan]{label}[/cyan]")
     if match is not None:
         console.print(
@@ -567,7 +568,7 @@ def _print_review_speaker_intro(
         )
     else:
         console.print("[dim]Closest profile:[/dim] none")
-    if embedding is None:
+    if not can_update_profile:
         console.print(
             "[yellow]No embedding was available for this speaker; only skip/replay works.[/yellow]"
         )
@@ -720,7 +721,7 @@ def _prompt_merge_target(
 def _merge_review_speaker(
     *,
     label: str,
-    embedding: list[float],
+    embedding: list[float] | None,
     source_profile_id: str | None,
     store: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -731,6 +732,9 @@ def _merge_review_speaker(
         if source_profile_id is not None:
             profile = merge_speaker_profiles(store, source_profile_id, target)
         else:
+            if embedding is None:
+                console.print("[yellow]Cannot merge this speaker without an embedding.[/yellow]")
+                return None
             profile = add_speaker_embedding_to_profile(store, target, embedding)
     except ValueError as exc:
         console.print(f"[yellow]{exc}[/yellow]")
@@ -745,7 +749,7 @@ def _merge_review_speaker(
 def _create_review_speaker(
     *,
     label: str,
-    embedding: list[float],
+    embedding: list[float] | None,
     source_profile_id: str | None,
     store: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -755,6 +759,11 @@ def _create_review_speaker(
         if source_profile_id is not None:
             profile = rename_speaker_profile(store, source_profile_id, name)
         else:
+            if embedding is None:
+                console.print(
+                    "[yellow]Cannot create a speaker profile without an embedding.[/yellow]"
+                )
+                return None
             profile = create_speaker_profile_from_embedding(store, name, embedding)
     except ValueError as exc:
         console.print(f"[yellow]{exc}[/yellow]")
@@ -787,6 +796,7 @@ def _review_speaker(
     )
     play_requested = True
     while True:
+        can_update_profile = embedding is not None or source_profile_id is not None
         _print_review_speaker_intro(
             label=label,
             embedding=embedding,
@@ -810,7 +820,7 @@ def _review_speaker(
             return _SpeakerReviewResult(changed=False, action="skipped")
         if choice in {"q", "quit"}:
             raise typer.Exit(0)
-        if embedding is None:
+        if not can_update_profile:
             console.print("[yellow]Choose p, s, or q; this speaker has no embedding.[/yellow]")
             continue
         if choice in {"m", "merge"}:
@@ -843,7 +853,7 @@ def _review_speaker(
                     target_display_name=str(summary["display_name"]),
                 )
             continue
-        if embedding is None:
+        if not can_update_profile:
             console.print("[yellow]Unknown choice. Use p, s, or q.[/yellow]")
         else:
             console.print("[yellow]Unknown choice. Use p, m, n, s, or q.[/yellow]")
@@ -905,13 +915,30 @@ def _append_short_skip_record(
     )
 
 
+def _append_no_embedding_skip_record(
+    records: list[dict[str, Any]],
+    *,
+    diarized_label: str,
+    review_label: str,
+    match: SpeakerMatch | None,
+) -> None:
+    _append_review_record(
+        records,
+        diarized_label=diarized_label,
+        review_label=review_label,
+        match=match,
+        result=_SpeakerReviewResult(changed=False, action="skipped_no_embedding"),
+    )
+
+
 def _print_no_review_summary(
     *,
     skipped_named: list[tuple[str, SpeakerMatch]],
     skipped_prior: list[str],
     skipped_short: list[str],
+    skipped_no_embedding: list[str],
 ) -> None:
-    console.print("[dim]No unknown speakers found in this audio.[/dim]")
+    console.print("[dim]No reviewable unknown speakers found in this audio.[/dim]")
     if skipped_named:
         console.print("[dim]Skipped named speaker matches:[/dim]")
         for label, match in skipped_named:
@@ -927,6 +954,10 @@ def _print_no_review_summary(
         console.print("[dim]Skipped short speaker fragments:[/dim]")
         for label in skipped_short:
             console.print(f"[dim]  {label} (<{REVIEW_MIN_PROMPT_SEGMENT_SECONDS:.0f}s)[/dim]")
+    if skipped_no_embedding:
+        console.print("[dim]Skipped speakers without embeddings:[/dim]")
+        for label in skipped_no_embedding:
+            console.print(f"[dim]  {label}[/dim]")
 
 
 def _review_unknown_speakers(
@@ -949,6 +980,7 @@ def _review_unknown_speakers(
         skipped_named: list[tuple[str, SpeakerMatch]] = []
         skipped_prior: list[str] = []
         skipped_short: list[str] = []
+        skipped_no_embedding: list[str] = []
         for label in _speaker_labels_by_first_turn(segments):
             match = matches.get(label)
             if _is_named_review_match(store=store, match=match):
@@ -984,6 +1016,15 @@ def _review_unknown_speakers(
             if segment.end - segment.start < REVIEW_MIN_PROMPT_SEGMENT_SECONDS:
                 skipped_short.append(review_label)
                 _append_short_skip_record(
+                    records,
+                    diarized_label=label,
+                    review_label=review_label,
+                    match=match,
+                )
+                continue
+            if embedding is None and source_profile_id is None:
+                skipped_no_embedding.append(review_label)
+                _append_no_embedding_skip_record(
                     records,
                     diarized_label=label,
                     review_label=review_label,
@@ -1032,6 +1073,7 @@ def _review_unknown_speakers(
                 skipped_named=skipped_named,
                 skipped_prior=skipped_prior,
                 skipped_short=skipped_short,
+                skipped_no_embedding=skipped_no_embedding,
             )
     return changed, records
 

--- a/agent_cli/core/diarization.py
+++ b/agent_cli/core/diarization.py
@@ -72,11 +72,11 @@ def _load_audio_for_diarization(audio_path: Path) -> tuple[torch.Tensor, int]:
 
     pcm_data = convert_audio_to_wyoming_format(audio_path.read_bytes(), audio_path.name)
     try:
-        pcm_tensor = torch.frombuffer(pcm_data, dtype=torch.int16)
+        pcm_tensor = torch.frombuffer(bytearray(pcm_data), dtype=torch.int16)
     except (AttributeError, TypeError):
         import numpy as np  # noqa: PLC0415
 
-        pcm_tensor = torch.from_numpy(np.frombuffer(pcm_data, dtype=np.int16))
+        pcm_tensor = torch.from_numpy(np.frombuffer(pcm_data, dtype=np.int16).copy())
     waveform = pcm_tensor.float().div(32768.0).unsqueeze(0)
     return normalize_waveform(waveform, constants.AUDIO_RATE)
 
@@ -112,6 +112,7 @@ _ABBREVIATIONS = {
 }
 _INITIALISM_RE = re.compile(r"(?:[A-Za-z]\.){2,}$")
 _SINGLE_INITIAL_LEN = 2
+DEFAULT_CLEAN_SPEAKER_NEIGHBOR_GAP_SECONDS = 0.35
 
 
 class SpeakerDiarizer:
@@ -188,6 +189,132 @@ class SpeakerDiarizer:
         segments.sort(key=lambda segment: (segment.start, segment.end))
 
         return segments
+
+
+def speaker_segment_neighbor_gap(
+    segment: DiarizedSegment,
+    segments: list[DiarizedSegment],
+) -> float:
+    """Return the nearest gap to another speaker, or -1 for overlap."""
+    nearest_gap = float("inf")
+    for other in segments:
+        if other is segment or other.speaker == segment.speaker:
+            continue
+        if other.end <= segment.start:
+            nearest_gap = min(nearest_gap, segment.start - other.end)
+        elif other.start >= segment.end:
+            nearest_gap = min(nearest_gap, other.start - segment.end)
+        else:
+            return -1.0
+    return nearest_gap
+
+
+def _speaker_segment_clean_score(
+    segment: DiarizedSegment,
+    segments: list[DiarizedSegment],
+    *,
+    neighbor_gap_seconds: float,
+) -> tuple[int, float, float]:
+    duration = segment.end - segment.start
+    neighbor_gap = speaker_segment_neighbor_gap(segment, segments)
+    clean = int(neighbor_gap >= neighbor_gap_seconds)
+    return clean, min(neighbor_gap, neighbor_gap_seconds), duration
+
+
+def select_clean_speaker_segments(
+    segments: list[DiarizedSegment],
+    speaker: str,
+    *,
+    min_duration_seconds: float = 0.0,
+    max_total_seconds: float | None = None,
+    neighbor_gap_seconds: float = DEFAULT_CLEAN_SPEAKER_NEIGHBOR_GAP_SECONDS,
+    fallback_to_unclean: bool = True,
+) -> list[DiarizedSegment]:
+    """Select representative single-speaker regions for review or embeddings.
+
+    Prefer turns with no overlap and at least ``neighbor_gap_seconds`` of separation
+    from other speakers. When requested, fall back to unclean turns only when no
+    clean turns exist.
+    """
+    candidates = [
+        segment
+        for segment in segments
+        if segment.speaker == speaker
+        and segment.end > segment.start
+        and segment.end - segment.start >= min_duration_seconds
+    ]
+    if not candidates:
+        return []
+
+    clean_candidates = [
+        segment
+        for segment in candidates
+        if speaker_segment_neighbor_gap(segment, segments) >= neighbor_gap_seconds
+    ]
+    pool = clean_candidates or (candidates if fallback_to_unclean else [])
+    if not pool:
+        return []
+
+    selected: list[DiarizedSegment] = []
+    total_seconds = 0.0
+    for segment in sorted(
+        pool,
+        key=lambda item: _speaker_segment_clean_score(
+            item,
+            segments,
+            neighbor_gap_seconds=neighbor_gap_seconds,
+        ),
+        reverse=True,
+    ):
+        duration = segment.end - segment.start
+        if max_total_seconds is not None and total_seconds >= max_total_seconds:
+            break
+        if max_total_seconds is not None and total_seconds + duration > max_total_seconds:
+            remaining = max_total_seconds - total_seconds
+            if remaining < min_duration_seconds:
+                continue
+            clipped_segment = DiarizedSegment(
+                speaker=segment.speaker,
+                start=segment.start,
+                end=segment.start + remaining,
+                text=segment.text,
+            )
+            duration = remaining
+            selected.append(clipped_segment)
+        else:
+            selected.append(segment)
+        total_seconds += duration
+
+    return sorted(selected, key=lambda segment: (segment.start, segment.end))
+
+
+def best_clean_speaker_segment(
+    segments: list[DiarizedSegment],
+    speaker: str,
+    *,
+    min_duration_seconds: float = 0.0,
+    neighbor_gap_seconds: float = DEFAULT_CLEAN_SPEAKER_NEIGHBOR_GAP_SECONDS,
+    fallback_to_unclean: bool = True,
+) -> DiarizedSegment | None:
+    """Return the best representative segment for one speaker."""
+    selected = select_clean_speaker_segments(
+        segments,
+        speaker,
+        min_duration_seconds=min_duration_seconds,
+        max_total_seconds=None,
+        neighbor_gap_seconds=neighbor_gap_seconds,
+        fallback_to_unclean=fallback_to_unclean,
+    )
+    if not selected:
+        return None
+    return max(
+        selected,
+        key=lambda item: _speaker_segment_clean_score(
+            item,
+            segments,
+            neighbor_gap_seconds=neighbor_gap_seconds,
+        ),
+    )
 
 
 def _split_into_sentences(text: str) -> list[str]:

--- a/agent_cli/core/speaker_identity.py
+++ b/agent_cli/core/speaker_identity.py
@@ -15,6 +15,7 @@ from agent_cli.core.diarization import (
     _check_pyannote_installed,
     _get_torch_device,
     _load_audio_for_diarization,
+    select_clean_speaker_segments,
 )
 
 if TYPE_CHECKING:
@@ -25,6 +26,7 @@ DEFAULT_SPEAKER_PROFILES_FILE = Path.home() / ".config" / "agent-cli" / "speaker
 DEFAULT_SPEAKER_EMBEDDING_MODEL = "pyannote/wespeaker-voxceleb-resnet34-LM"
 DEFAULT_SPEAKER_MATCH_THRESHOLD = 0.70
 MAX_PROFILE_EMBEDDINGS = 20
+SPEAKER_EMBEDDING_NEAR_DUPLICATE_THRESHOLD = 0.98
 MIN_SPEAKER_EMBEDDING_SECONDS = 1.0
 MAX_SPEAKER_EMBEDDING_SECONDS = 120.0
 _ASSIGNMENT_SPLIT_RE = re.compile(r"\s*[,;]\s*")
@@ -206,7 +208,11 @@ def _normalize_embedding(values: Any) -> list[float]:
         msg = "Speaker embedding output is empty or scalar; expected a vector."
         raise RuntimeError(msg)
     if embedding.ndim > 1:
-        embedding = embedding.reshape(-1, embedding.shape[-1]).mean(axis=0)
+        reshaped = embedding.reshape(-1, embedding.shape[-1])
+        if reshaped.shape[0] == 0:
+            msg = "Speaker embedding output is empty; expected at least one vector."
+            raise RuntimeError(msg)
+        embedding = reshaped.mean(axis=0)
     if not np.all(np.isfinite(embedding)):
         msg = "Speaker embedding output contains non-finite values."
         raise RuntimeError(msg)
@@ -276,14 +282,52 @@ def match_speaker_profiles(
     return matches
 
 
-def _append_embedding(profile: dict[str, Any], embedding: list[float]) -> None:
-    embeddings = profile.setdefault("embeddings", [])
+def _compatible_profile_embeddings(
+    embeddings: Any,
+    embedding: list[float],
+) -> list[list[float]]:
     if not isinstance(embeddings, list):
-        embeddings = []
+        return []
+    return [
+        stored
+        for stored in embeddings
+        if isinstance(stored, list) and len(stored) == len(embedding)
+    ]
+
+
+def _most_redundant_embedding_index(embeddings: list[list[float]]) -> int:
+    if len(embeddings) <= 1:
+        return 0
+    nearest_similarities: list[float] = []
+    for index, embedding in enumerate(embeddings):
+        nearest_similarities.append(
+            max(
+                _cosine_similarity(embedding, other)
+                for other_index, other in enumerate(embeddings)
+                if other_index != index
+            ),
+        )
+    return max(range(len(nearest_similarities)), key=nearest_similarities.__getitem__)
+
+
+def _append_embedding(profile: dict[str, Any], embedding: list[float]) -> bool:
+    raw_embeddings = profile.setdefault("embeddings", [])
+    embeddings = _compatible_profile_embeddings(raw_embeddings, embedding)
+    if not isinstance(raw_embeddings, list) or len(embeddings) != len(raw_embeddings):
         profile["embeddings"] = embeddings
+
+    if any(
+        _cosine_similarity(embedding, stored) >= SPEAKER_EMBEDDING_NEAR_DUPLICATE_THRESHOLD
+        for stored in embeddings
+    ):
+        return False
+
     embeddings.append(embedding)
-    del embeddings[:-MAX_PROFILE_EMBEDDINGS]
+    if len(embeddings) > MAX_PROFILE_EMBEDDINGS:
+        del embeddings[_most_redundant_embedding_index(embeddings)]
+    profile["embeddings"] = embeddings
     profile["updated_at"] = _now()
+    return True
 
 
 def _add_named_embedding(
@@ -433,22 +477,29 @@ def _speaker_waveforms(
     sample_totals: dict[str, int] = {}
     total_samples = waveform.shape[-1]
 
-    for segment in sorted(segments, key=lambda item: (item.speaker, item.start, item.end)):
-        if segment.end <= segment.start:
-            continue
-        current_total = sample_totals.get(segment.speaker, 0)
-        if current_total >= max_samples:
-            continue
-        start = max(0, int(segment.start * sample_rate))
-        end = min(total_samples, int(segment.end * sample_rate))
-        if end <= start:
-            continue
-        chunk = waveform[:, start:end]
-        remaining = max_samples - current_total
-        if chunk.shape[-1] > remaining:
-            chunk = chunk[:, :remaining]
-        by_speaker.setdefault(segment.speaker, []).append(chunk)
-        sample_totals[segment.speaker] = current_total + chunk.shape[-1]
+    speakers = sorted({segment.speaker for segment in segments})
+    for speaker in speakers:
+        selected_segments = select_clean_speaker_segments(
+            segments,
+            speaker,
+            min_duration_seconds=MIN_SPEAKER_EMBEDDING_SECONDS,
+            max_total_seconds=MAX_SPEAKER_EMBEDDING_SECONDS,
+            fallback_to_unclean=False,
+        )
+        for segment in selected_segments:
+            current_total = sample_totals.get(segment.speaker, 0)
+            if current_total >= max_samples:
+                continue
+            start = max(0, int(segment.start * sample_rate))
+            end = min(total_samples, int(segment.end * sample_rate))
+            if end <= start:
+                continue
+            chunk = waveform[:, start:end]
+            remaining = max_samples - current_total
+            if chunk.shape[-1] > remaining:
+                chunk = chunk[:, :remaining]
+            by_speaker.setdefault(segment.speaker, []).append(chunk)
+            sample_totals[segment.speaker] = current_total + chunk.shape[-1]
 
     return {
         speaker: torch.cat(chunks, dim=1)

--- a/docs/commands/speakers.md
+++ b/docs/commands/speakers.md
@@ -163,7 +163,7 @@ agent-cli speakers list --json
 |--------|---------|-------------|
 | `--from-file` | - | Review speakers from an existing audio file. |
 | `--last-recording` | - | Review the Nth most recent saved transcribe recording. |
-| `--last-session`, `--last-live-session` | - | Review the Nth most recent inferred transcribe-live session (default source when available). |
+| `--last-live-session` | - | Review the Nth most recent inferred transcribe-live session (default source when available). |
 | `--session-gap` | `300.0` | Maximum seconds between transcribe-live chunks in one session. |
 | `--transcription-log` | `/home/runner/.config/agent-cli/transcriptions.jsonl` | Path to the transcribe-live JSONL log for --last-session. |
 | `--output-dir` | `/home/runner/.cache/agent-cli/speaker-review` | Directory for combined live-session audio and temporary snippets. |

--- a/docs/commands/speakers.md
+++ b/docs/commands/speakers.md
@@ -20,9 +20,9 @@ Speaker profiles are stored voice embeddings created by `transcribe --diarize` o
 
 Use `speakers list` to see the stable profile IDs, `speakers rename` to give an
 unknown profile a human name, `speakers merge` to fold duplicate profiles for
-the same person together, and `speakers review` to listen to diarized snippets
-and decide interactively whether each voice should be merged into an existing
-profile or saved as a new named profile.
+the same person together, and `speakers review` to listen to snippets for
+unknown voices and decide interactively whether each one should be merged into
+an existing profile or named.
 
 ## Examples
 
@@ -39,11 +39,14 @@ agent-cli speakers rename UNKNOWN_001 Alice
 # Merge a duplicate unknown profile into Alice
 agent-cli speakers merge UNKNOWN_002 Alice
 
-# Listen to snippets from the last saved recording and update profiles
-agent-cli speakers review --last-recording 1
+# Walk backward through unreviewed transcribe-live audio files and update profiles
+agent-cli speakers review
 
-# Review a continuous transcribe-live session
-agent-cli speakers review --last-session 2
+# Review a specific transcribe-live session
+agent-cli speakers review --last-live-session 2
+
+# Review a saved transcribe recording instead
+agent-cli speakers review --last-recording 1
 
 # JSON output for scripts
 agent-cli speakers list --json
@@ -55,7 +58,9 @@ agent-cli speakers list --json
 - Stored profile IDs such as `UNKNOWN_001` are stable across runs.
 - Renaming a profile preserves its embeddings and changes the display name used by future diarization matches.
 - Merging moves embeddings from the source profile into the target profile and removes the source profile.
-- Review appends the current recording's speaker embedding to an existing profile when you choose merge.
+- Review skips already named speaker matches and resolves unknown profiles by naming or merging them.
+- Review keeps a separate `speaker-review-state.json` cache so already reviewed audio files are skipped on later runs. Use `--force-review` to bypass it.
+- Speaker profiles keep a bounded, diverse set of embeddings and skip near-duplicate observations.
 - `speakers list --json` shows profile metadata only; it does not print embedding vectors.
 
 ## Rename Arguments
@@ -157,8 +162,8 @@ agent-cli speakers list --json
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--from-file` | - | Review speakers from an existing audio file. |
-| `--last-recording` | - | Review the Nth most recent saved transcribe recording (default: 1). |
-| `--last-session` | - | Review the Nth most recent inferred transcribe-live session. |
+| `--last-recording` | - | Review the Nth most recent saved transcribe recording. |
+| `--last-session`, `--last-live-session` | - | Review the Nth most recent inferred transcribe-live session (default source when available). |
 | `--session-gap` | `300.0` | Maximum seconds between transcribe-live chunks in one session. |
 | `--transcription-log` | `/home/runner/.config/agent-cli/transcriptions.jsonl` | Path to the transcribe-live JSONL log for --last-session. |
 | `--output-dir` | `/home/runner/.cache/agent-cli/speaker-review` | Directory for combined live-session audio and temporary snippets. |
@@ -166,6 +171,8 @@ agent-cli speakers list --json
 | `--speaker-profiles-file` | `/home/runner/.config/agent-cli/speaker-profiles.json` | JSON file storing persistent speaker voice embeddings. |
 | `--snippet-seconds` | `6.0` | Maximum seconds to play for each speaker snippet. |
 | `--player` | - | Audio player command to use for snippets (default: afplay, ffplay, aplay, or paplay). |
+| `--review-state-file` | `/home/runner/.config/agent-cli/speaker-review-state.json` | JSON cache tracking which audio files have already been speaker-reviewed. |
+| `--force-review` | `false` | Review audio even if it is already present in the speaker review cache. |
 
 ### Diarization
 

--- a/docs/commands/speakers.md
+++ b/docs/commands/speakers.md
@@ -166,7 +166,6 @@ agent-cli speakers list --json
 | `--last-live-session` | - | Review the Nth most recent inferred transcribe-live session (default source when available). |
 | `--session-gap` | `300.0` | Maximum seconds between transcribe-live chunks in one session. |
 | `--transcription-log` | `/home/runner/.config/agent-cli/transcriptions.jsonl` | Path to the transcribe-live JSONL log for --last-session. |
-| `--output-dir` | `/home/runner/.cache/agent-cli/speaker-review` | Directory for combined live-session audio and temporary snippets. |
 | `--speakers` | - | Known number of speakers. Sets both --min-speakers and --max-speakers. |
 | `--speaker-profiles-file` | `/home/runner/.config/agent-cli/speaker-profiles.json` | JSON file storing persistent speaker voice embeddings. |
 | `--snippet-seconds` | `6.0` | Maximum seconds to play for each speaker snippet. |

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -930,6 +930,56 @@ def test_review_audio_targets_remembers_skipped_speaker_across_audio(
     assert saved_state["audio_files"][second_key]["speakers"][0]["action"] == "skipped_cached"
 
 
+def test_review_audio_targets_does_not_cache_interrupted_audio(
+    tmp_path: Path,
+) -> None:
+    audio_file = tmp_path / "recording.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    snippet_file = tmp_path / "snippet.wav"
+    audio_file.write_bytes(b"audio")
+    snippet_file.write_bytes(b"snippet")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [
+        DiarizedSegment("SPEAKER_00", 0.0, 3.0),
+        DiarizedSegment("SPEAKER_01", 4.0, 7.0),
+    ]
+
+    with (
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={
+                "SPEAKER_00": [1.0, 0.0],
+                "SPEAKER_01": [0.0, 1.0],
+            },
+        ),
+        patch("agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file),
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+        patch("agent_cli.agents.speakers._review_choice_prompt", side_effect=["s", "q"]),
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[audio_file],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 0
+    assert skipped_count == 0
+    assert interrupted is True
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert saved_state["audio_files"] == {}
+    assert saved_state["skipped_speakers"][0]["embeddings"] == [[1.0, 0.0]]
+
+
 def test_review_audio_targets_auto_skips_short_fragments(tmp_path: Path) -> None:
     audio_file = tmp_path / "short.wav"
     state_file = tmp_path / "speaker-review-state.json"

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -971,6 +971,48 @@ def test_review_audio_targets_auto_skips_short_fragments(tmp_path: Path) -> None
     assert saved_state["audio_files"][audio_key]["speakers"][0]["action"] == "skipped_short"
 
 
+def test_review_audio_targets_auto_skips_speakers_without_embeddings(
+    tmp_path: Path,
+) -> None:
+    audio_file = tmp_path / "recording.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    audio_file.write_bytes(b"audio")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 3.0)]
+
+    with (
+        patch("agent_cli.agents.speakers.extract_speaker_embeddings", return_value={}),
+        patch("agent_cli.agents.speakers._write_speaker_snippet") as write_snippet,
+        patch("agent_cli.agents.speakers._review_choice_prompt") as prompt,
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[audio_file],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 1
+    assert skipped_count == 0
+    assert interrupted is False
+    write_snippet.assert_not_called()
+    prompt.assert_not_called()
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    audio_key = speakers_module._audio_review_key(audio_file)
+    assert saved_state["audio_files"][audio_key]["speakers"][0]["action"] == (
+        "skipped_no_embedding"
+    )
+
+
 def test_review_speaker_prompts_while_snippet_is_playing(tmp_path: Path) -> None:
     snippet_file = tmp_path / "snippet.wav"
     snippet_file.write_bytes(b"snippet")

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 import agent_cli.config as config_module
 from agent_cli.agents import speakers as speakers_module
 from agent_cli.cli import app
-from agent_cli.core.diarization import DiarizedSegment
+from agent_cli.core.diarization import DiarizedSegment, best_clean_speaker_segment
 from agent_cli.core.speaker_identity import DEFAULT_SPEAKER_EMBEDDING_MODEL
 
 if TYPE_CHECKING:
@@ -283,7 +283,7 @@ def test_speakers_merge_moves_embeddings_and_removes_duplicate(tmp_path: Path) -
     assert "UNKNOWN_002" in result.stdout
     store = json.loads(profiles_file.read_text(encoding="utf-8"))
     assert [profile["id"] for profile in store["profiles"]] == ["john"]
-    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0]]
 
 
 def test_speakers_merge_json_outputs_target_profile(tmp_path: Path) -> None:
@@ -308,7 +308,7 @@ def test_speakers_merge_json_outputs_target_profile(tmp_path: Path) -> None:
     assert data["merged_source"] == "UNKNOWN_002"
     assert data["profile"]["id"] == "john"
     assert data["profile"]["name"] == "John"
-    assert data["profile"]["embedding_count"] == 2
+    assert data["profile"]["embedding_count"] == 1
 
 
 def test_speakers_merge_self_exits_nonzero(tmp_path: Path) -> None:
@@ -331,7 +331,20 @@ def test_speakers_merge_self_exits_nonzero(tmp_path: Path) -> None:
     assert "itself" in result.stdout
 
 
-def test_speakers_review_merges_current_speaker_into_existing_profile(tmp_path: Path) -> None:
+def test_best_review_segment_prefers_isolated_turn() -> None:
+    overlapping_long = DiarizedSegment("SPEAKER_00", 0.0, 5.0)
+    other_speaker = DiarizedSegment("SPEAKER_01", 2.0, 3.0)
+    isolated_short = DiarizedSegment("SPEAKER_00", 8.0, 10.0)
+
+    segment = best_clean_speaker_segment(
+        [overlapping_long, other_speaker, isolated_short],
+        "SPEAKER_00",
+    )
+
+    assert segment == isolated_short
+
+
+def test_speakers_review_creates_profile_for_unmatched_speaker_labels(tmp_path: Path) -> None:
     profiles_file = tmp_path / "speaker-profiles.json"
     audio_file = tmp_path / "recording.wav"
     snippet_file = tmp_path / "snippet.wav"
@@ -364,7 +377,7 @@ def test_speakers_review_merges_current_speaker_into_existing_profile(tmp_path: 
         patch("agent_cli.agents.speakers.SpeakerDiarizer", return_value=diarizer),
         patch(
             "agent_cli.agents.speakers.extract_speaker_embeddings",
-            return_value={"SPEAKER_00": [0.99, 0.01]},
+            return_value={"SPEAKER_00": [0.0, 1.0]},
         ),
         patch("agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file),
         patch("agent_cli.agents.speakers._start_audio_playback"),
@@ -381,16 +394,19 @@ def test_speakers_review_merges_current_speaker_into_existing_profile(tmp_path: 
                 "--hf-token",
                 "token",
             ],
-            input="m\n\n",
+            input="n\nAlice\n",
         )
 
     assert result.exit_code == 0
-    assert "Merged current speaker SPEAKER_00 into John" in result.stdout
+    assert "Speaker: SPEAKER_00" in result.stdout
+    assert "Closest profile: none" in result.stdout
+    assert "Created speaker profile Alice" in result.stdout
     store = json.loads(profiles_file.read_text(encoding="utf-8"))
-    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert [profile["name"] for profile in store["profiles"]] == ["John", "Alice"]
+    assert store["profiles"][1]["embeddings"] == [[0.0, 1.0]]
 
 
-def test_speakers_review_creates_new_named_profile(tmp_path: Path) -> None:
+def test_speakers_review_creates_profile_when_no_profiles_exist(tmp_path: Path) -> None:
     profiles_file = tmp_path / "speaker-profiles.json"
     audio_file = tmp_path / "recording.wav"
     snippet_file = tmp_path / "snippet.wav"
@@ -437,13 +453,15 @@ def test_speakers_review_creates_new_named_profile(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0
+    assert "Speaker: SPEAKER_00" in result.stdout
+    assert "Closest profile: none" in result.stdout
     assert "Created speaker profile Alice" in result.stdout
     store = json.loads(profiles_file.read_text(encoding="utf-8"))
     assert store["profiles"][0]["name"] == "Alice"
     assert store["profiles"][0]["embeddings"] == [[1.0, 0.0]]
 
 
-def test_speakers_review_saves_changes_before_quitting(tmp_path: Path) -> None:
+def test_speakers_review_prints_skipped_named_speaker_matches(tmp_path: Path) -> None:
     profiles_file = tmp_path / "speaker-profiles.json"
     audio_file = tmp_path / "recording.wav"
     snippet_file = tmp_path / "snippet.wav"
@@ -470,6 +488,74 @@ def test_speakers_review_saves_changes_before_quitting(tmp_path: Path) -> None:
     )
     diarizer = MagicMock()
     diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 2.0)]
+
+    with (
+        patch("agent_cli.agents.speakers.SpeakerDiarizer", return_value=diarizer),
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={"SPEAKER_00": [1.0, 0.0]},
+        ),
+        patch(
+            "agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file
+        ) as write_snippet,
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "speakers",
+                "review",
+                "--from-file",
+                str(audio_file),
+                "--speaker-profiles-file",
+                str(profiles_file),
+                "--review-state-file",
+                str(tmp_path / "speaker-review-state.json"),
+                "--hf-token",
+                "token",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Skipped named speaker matches:" in result.stdout
+    assert "SPEAKER_00 -> John (john, 1.00)" in result.stdout
+    write_snippet.assert_not_called()
+
+
+def test_speakers_review_saves_changes_before_quitting(tmp_path: Path) -> None:
+    profiles_file = tmp_path / "speaker-profiles.json"
+    audio_file = tmp_path / "recording.wav"
+    snippet_file = tmp_path / "snippet.wav"
+    audio_file.write_bytes(b"audio")
+    snippet_file.write_bytes(b"snippet")
+    profiles_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "embedding_model": DEFAULT_SPEAKER_EMBEDDING_MODEL,
+                "next_unknown_id": 1,
+                "profiles": [
+                    {
+                        "id": "john",
+                        "name": "John",
+                        "anonymous": False,
+                        "embeddings": [[1.0, 0.0]],
+                    },
+                    {
+                        "id": "UNKNOWN_001",
+                        "name": None,
+                        "anonymous": True,
+                        "embeddings": [[0.0, 1.0]],
+                    },
+                ],
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
     diarizer.diarize.return_value = [
         DiarizedSegment("SPEAKER_00", 0.0, 2.0),
         DiarizedSegment("SPEAKER_01", 2.0, 4.0),
@@ -480,8 +566,8 @@ def test_speakers_review_saves_changes_before_quitting(tmp_path: Path) -> None:
         patch(
             "agent_cli.agents.speakers.extract_speaker_embeddings",
             return_value={
-                "SPEAKER_00": [0.99, 0.01],
-                "SPEAKER_01": [0.0, 1.0],
+                "SPEAKER_00": [0.0, 1.0],
+                "SPEAKER_01": [0.5, 0.5],
             },
         ),
         patch("agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file),
@@ -505,7 +591,155 @@ def test_speakers_review_saves_changes_before_quitting(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "Saved speaker profiles" in result.stdout
     store = json.loads(profiles_file.read_text(encoding="utf-8"))
-    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert [profile["id"] for profile in store["profiles"]] == ["john"]
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0]]
+
+
+def test_speakers_review_skips_named_profile_matches(tmp_path: Path) -> None:
+    profiles_file = tmp_path / "speaker-profiles.json"
+    audio_file = tmp_path / "recording.wav"
+    snippet_file = tmp_path / "snippet.wav"
+    audio_file.write_bytes(b"audio")
+    snippet_file.write_bytes(b"snippet")
+    profiles_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "embedding_model": DEFAULT_SPEAKER_EMBEDDING_MODEL,
+                "next_unknown_id": 2,
+                "profiles": [
+                    {
+                        "id": "john",
+                        "name": "John",
+                        "anonymous": False,
+                        "embeddings": [[1.0, 0.0]],
+                    },
+                    {
+                        "id": "UNKNOWN_001",
+                        "name": None,
+                        "anonymous": True,
+                        "embeddings": [[0.0, 1.0]],
+                    },
+                ],
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [
+        DiarizedSegment("SPEAKER_00", 0.0, 2.0),
+        DiarizedSegment("SPEAKER_01", 2.0, 4.0),
+    ]
+
+    with (
+        patch("agent_cli.agents.speakers.SpeakerDiarizer", return_value=diarizer),
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={
+                "SPEAKER_00": [1.0, 0.0],
+                "SPEAKER_01": [0.0, 1.0],
+            },
+        ),
+        patch("agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file),
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "speakers",
+                "review",
+                "--from-file",
+                str(audio_file),
+                "--speaker-profiles-file",
+                str(profiles_file),
+                "--hf-token",
+                "token",
+            ],
+            input="n\nAlice\n",
+        )
+
+    assert result.exit_code == 0
+    assert "Speaker: UNKNOWN_001" in result.stdout
+    assert "Speaker: SPEAKER_00" not in result.stdout
+    assert "Named speaker UNKNOWN_001 as Alice" in result.stdout
+    store = json.loads(profiles_file.read_text(encoding="utf-8"))
+    assert len(store["profiles"]) == 2
+    assert store["profiles"][1]["id"] == "UNKNOWN_001"
+    assert store["profiles"][1]["name"] == "Alice"
+    assert store["profiles"][1]["anonymous"] is False
+    assert store["profiles"][1]["embeddings"] == [[0.0, 1.0]]
+
+
+def test_speakers_review_merges_anonymous_profile_into_named_profile(tmp_path: Path) -> None:
+    profiles_file = tmp_path / "speaker-profiles.json"
+    audio_file = tmp_path / "recording.wav"
+    snippet_file = tmp_path / "snippet.wav"
+    audio_file.write_bytes(b"audio")
+    snippet_file.write_bytes(b"snippet")
+    profiles_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "embedding_model": DEFAULT_SPEAKER_EMBEDDING_MODEL,
+                "next_unknown_id": 2,
+                "profiles": [
+                    {
+                        "id": "john",
+                        "name": "John",
+                        "anonymous": False,
+                        "embeddings": [[1.0, 0.0]],
+                    },
+                    {
+                        "id": "UNKNOWN_001",
+                        "name": None,
+                        "anonymous": True,
+                        "embeddings": [[0.0, 1.0]],
+                    },
+                ],
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 2.0)]
+
+    with (
+        patch("agent_cli.agents.speakers.SpeakerDiarizer", return_value=diarizer),
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={"SPEAKER_00": [0.0, 1.0]},
+        ),
+        patch("agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file),
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "speakers",
+                "review",
+                "--from-file",
+                str(audio_file),
+                "--speaker-profiles-file",
+                str(profiles_file),
+                "--hf-token",
+                "token",
+            ],
+            input="m\n\n",
+        )
+
+    assert result.exit_code == 0
+    assert "Actions:" in result.stdout
+    assert "Merge targets:" in result.stdout
+    assert "1. John (john)" in result.stdout
+    assert "Merge into profile number [1]" in result.stdout
+    assert "Merged current speaker UNKNOWN_001 into John" in result.stdout
+    store = json.loads(profiles_file.read_text(encoding="utf-8"))
+    assert [profile["id"] for profile in store["profiles"]] == ["john"]
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0]]
 
 
 def test_resolve_review_audio_source_rejects_last_recording_zero(tmp_path: Path) -> None:
@@ -523,6 +757,221 @@ def test_resolve_review_audio_source_rejects_last_recording_zero(tmp_path: Path)
         )
 
     get_last_recording.assert_not_called()
+
+
+def test_resolve_review_audio_source_defaults_to_last_live_session(tmp_path: Path) -> None:
+    transcription_log = tmp_path / "transcriptions.jsonl"
+    audio_file = tmp_path / "live.wav"
+    audio_file.write_bytes(b"audio")
+    transcription_log.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-30T12:00:00+00:00",
+                "audio_file": str(audio_file),
+                "duration_seconds": 1.0,
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with patch("agent_cli.agents.speakers.get_last_recording") as get_last_recording:
+        result = speakers_module._resolve_review_audio_source(
+            from_file=None,
+            last_recording=None,
+            last_session=None,
+            transcription_log=transcription_log,
+            output_dir=tmp_path,
+            session_gap=300.0,
+        )
+
+    assert result == audio_file
+    get_last_recording.assert_not_called()
+
+
+def test_resolve_review_audio_targets_walks_live_files_newest_first(tmp_path: Path) -> None:
+    transcription_log = tmp_path / "transcriptions.jsonl"
+    older_audio = tmp_path / "older.wav"
+    newer_audio = tmp_path / "newer.wav"
+    older_audio.write_bytes(b"older")
+    newer_audio.write_bytes(b"newer")
+    entries = [
+        {
+            "timestamp": "2026-04-30T12:00:00+00:00",
+            "audio_file": str(older_audio),
+            "duration_seconds": 1.0,
+        },
+        {
+            "timestamp": "2026-04-30T12:01:00+00:00",
+            "audio_file": str(newer_audio),
+            "duration_seconds": 1.0,
+        },
+    ]
+    transcription_log.write_text(
+        "".join(json.dumps(entry) + "\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+    targets = speakers_module._resolve_review_audio_targets(
+        from_file=None,
+        last_recording=None,
+        last_session=None,
+        transcription_log=transcription_log,
+        output_dir=tmp_path,
+        session_gap=300.0,
+    )
+
+    assert targets == [newer_audio, older_audio]
+
+
+def test_review_audio_targets_skips_cached_audio(tmp_path: Path) -> None:
+    audio_file = tmp_path / "reviewed.wav"
+    audio_file.write_bytes(b"audio")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}}
+    speakers_module._record_audio_review(review_state, audio_file, [])
+    diarizer = MagicMock()
+    store: dict[str, object] = {"profiles": []}
+
+    changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+        audio_targets=[audio_file],
+        review_state=review_state,
+        store=store,
+        diarizer=diarizer,
+        hf_token="token",  # noqa: S106
+        speaker_match_threshold=0.7,
+        snippet_seconds=6.0,
+        player=None,
+        force_review=False,
+        review_state_path=tmp_path / "speaker-review-state.json",
+    )
+
+    assert changed is False
+    assert reviewed_count == 0
+    assert skipped_count == 1
+    assert interrupted is False
+    diarizer.diarize.assert_not_called()
+
+
+def test_review_audio_targets_saves_state_after_each_reviewed_audio(tmp_path: Path) -> None:
+    audio_file = tmp_path / "reviewed.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    audio_file.write_bytes(b"audio")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = []
+
+    changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+        audio_targets=[audio_file],
+        review_state=review_state,
+        store={"profiles": []},
+        diarizer=diarizer,
+        hf_token="token",  # noqa: S106
+        speaker_match_threshold=0.7,
+        snippet_seconds=6.0,
+        player=None,
+        force_review=False,
+        review_state_path=state_file,
+    )
+
+    assert changed is False
+    assert reviewed_count == 1
+    assert skipped_count == 0
+    assert interrupted is False
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert speakers_module._audio_review_key(audio_file) in saved_state["audio_files"]
+
+
+def test_review_audio_targets_remembers_skipped_speaker_across_audio(
+    tmp_path: Path,
+) -> None:
+    first_audio = tmp_path / "first.wav"
+    second_audio = tmp_path / "second.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    snippet_file = tmp_path / "snippet.wav"
+    first_audio.write_bytes(b"first")
+    second_audio.write_bytes(b"second")
+    snippet_file.write_bytes(b"snippet")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 3.0)]
+
+    with (
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={"SPEAKER_00": [1.0, 0.0]},
+        ),
+        patch(
+            "agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file
+        ) as write_snippet,
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+        patch("agent_cli.agents.speakers._review_choice_prompt", return_value="s") as prompt,
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[first_audio, second_audio],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 2
+    assert skipped_count == 0
+    assert interrupted is False
+    write_snippet.assert_called_once()
+    prompt.assert_called_once()
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert saved_state["skipped_speakers"][0]["embeddings"] == [[1.0, 0.0]]
+    second_key = speakers_module._audio_review_key(second_audio)
+    assert saved_state["audio_files"][second_key]["speakers"][0]["action"] == "skipped_cached"
+
+
+def test_review_audio_targets_auto_skips_short_fragments(tmp_path: Path) -> None:
+    audio_file = tmp_path / "short.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    audio_file.write_bytes(b"audio")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 1.5)]
+
+    with (
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={"SPEAKER_00": [1.0, 0.0]},
+        ),
+        patch("agent_cli.agents.speakers._write_speaker_snippet") as write_snippet,
+        patch("agent_cli.agents.speakers._review_choice_prompt") as prompt,
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[audio_file],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 1
+    assert skipped_count == 0
+    assert interrupted is False
+    write_snippet.assert_not_called()
+    prompt.assert_not_called()
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    audio_key = speakers_module._audio_review_key(audio_file)
+    assert saved_state["audio_files"][audio_key]["speakers"][0]["action"] == "skipped_short"
 
 
 def test_review_speaker_prompts_while_snippet_is_playing(tmp_path: Path) -> None:
@@ -544,7 +993,7 @@ def test_review_speaker_prompts_while_snippet_is_playing(tmp_path: Path) -> None
         patch("agent_cli.agents.speakers._start_audio_playback", side_effect=start_playback),
         patch("agent_cli.agents.speakers._review_choice_prompt", side_effect=prompt_choice),
     ):
-        changed = speakers_module._review_speaker(
+        result = speakers_module._review_speaker(
             label="SPEAKER_00",
             snippet_path=snippet_file,
             embedding=[1.0, 0.0],
@@ -553,7 +1002,35 @@ def test_review_speaker_prompts_while_snippet_is_playing(tmp_path: Path) -> None
             player=None,
         )
 
-    assert changed is False
+    assert result.changed is False
+    assert result.action == "skipped"
     assert events == ["start", "prompt"]
     playback_process.terminate.assert_called_once_with()
     playback_process.wait.assert_called_once_with(timeout=1.0)
+
+
+def test_review_speaker_without_embedding_does_not_replay_after_invalid_choice(
+    tmp_path: Path,
+) -> None:
+    snippet_file = tmp_path / "snippet.wav"
+    snippet_file.write_bytes(b"snippet")
+    playback_process = MagicMock()
+
+    with (
+        patch(
+            "agent_cli.agents.speakers._start_audio_playback", return_value=playback_process
+        ) as start,
+        patch("agent_cli.agents.speakers._review_choice_prompt", side_effect=["m", "s"]),
+    ):
+        result = speakers_module._review_speaker(
+            label="SPEAKER_00",
+            snippet_path=snippet_file,
+            embedding=None,
+            match=None,
+            store={"profiles": []},
+            player=None,
+        )
+
+    assert result.changed is False
+    assert result.action == "skipped"
+    start.assert_called_once_with(snippet_file, player=None)

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -742,24 +742,23 @@ def test_speakers_review_merges_anonymous_profile_into_named_profile(tmp_path: P
     assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0]]
 
 
-def test_resolve_review_audio_source_rejects_last_recording_zero(tmp_path: Path) -> None:
+def test_resolve_review_audio_targets_rejects_last_recording_zero(tmp_path: Path) -> None:
     with (
         patch("agent_cli.agents.speakers.get_last_recording") as get_last_recording,
         pytest.raises(ValueError, match="--last-recording must be 1 or greater"),
     ):
-        speakers_module._resolve_review_audio_source(
+        speakers_module._resolve_review_audio_targets(
             from_file=None,
             last_recording=0,
             last_session=None,
             transcription_log=tmp_path / "transcriptions.jsonl",
-            output_dir=tmp_path,
             session_gap=300.0,
         )
 
     get_last_recording.assert_not_called()
 
 
-def test_resolve_review_audio_source_defaults_to_last_live_session(tmp_path: Path) -> None:
+def test_resolve_review_audio_targets_defaults_to_last_live_session(tmp_path: Path) -> None:
     transcription_log = tmp_path / "transcriptions.jsonl"
     audio_file = tmp_path / "live.wav"
     audio_file.write_bytes(b"audio")
@@ -776,16 +775,15 @@ def test_resolve_review_audio_source_defaults_to_last_live_session(tmp_path: Pat
     )
 
     with patch("agent_cli.agents.speakers.get_last_recording") as get_last_recording:
-        result = speakers_module._resolve_review_audio_source(
+        targets = speakers_module._resolve_review_audio_targets(
             from_file=None,
             last_recording=None,
             last_session=None,
             transcription_log=transcription_log,
-            output_dir=tmp_path,
             session_gap=300.0,
         )
 
-    assert result == audio_file
+    assert targets == [audio_file]
     get_last_recording.assert_not_called()
 
 
@@ -817,7 +815,6 @@ def test_resolve_review_audio_targets_walks_live_files_newest_first(tmp_path: Pa
         last_recording=None,
         last_session=None,
         transcription_log=transcription_log,
-        output_dir=tmp_path,
         session_gap=300.0,
     )
 

--- a/tests/agents/test_speakers.py
+++ b/tests/agents/test_speakers.py
@@ -930,6 +930,59 @@ def test_review_audio_targets_remembers_skipped_speaker_across_audio(
     assert saved_state["audio_files"][second_key]["speakers"][0]["action"] == "skipped_cached"
 
 
+def test_review_audio_targets_does_not_auto_skip_loose_skipped_speaker_match(
+    tmp_path: Path,
+) -> None:
+    first_audio = tmp_path / "first.wav"
+    second_audio = tmp_path / "second.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    snippet_file = tmp_path / "snippet.wav"
+    first_audio.write_bytes(b"first")
+    second_audio.write_bytes(b"second")
+    snippet_file.write_bytes(b"snippet")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 3.0)]
+
+    with (
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            side_effect=[
+                {"SPEAKER_00": [1.0, 0.0]},
+                {"SPEAKER_00": [0.8, 0.6]},
+            ],
+        ),
+        patch(
+            "agent_cli.agents.speakers._write_speaker_snippet", return_value=snippet_file
+        ) as write_snippet,
+        patch("agent_cli.agents.speakers._start_audio_playback"),
+        patch("agent_cli.agents.speakers._review_choice_prompt", return_value="s") as prompt,
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[first_audio, second_audio],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 2
+    assert skipped_count == 0
+    assert interrupted is False
+    assert write_snippet.call_count == 2
+    assert prompt.call_count == 2
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    second_key = speakers_module._audio_review_key(second_audio)
+    assert saved_state["audio_files"][second_key]["speakers"][0]["action"] == "skipped"
+
+
 def test_review_audio_targets_does_not_cache_interrupted_audio(
     tmp_path: Path,
 ) -> None:
@@ -978,6 +1031,50 @@ def test_review_audio_targets_does_not_cache_interrupted_audio(
     saved_state = json.loads(state_file.read_text(encoding="utf-8"))
     assert saved_state["audio_files"] == {}
     assert saved_state["skipped_speakers"][0]["embeddings"] == [[1.0, 0.0]]
+
+
+def test_review_audio_targets_does_not_cache_audio_when_snippet_fails(
+    tmp_path: Path,
+) -> None:
+    audio_file = tmp_path / "recording.wav"
+    state_file = tmp_path / "speaker-review-state.json"
+    audio_file.write_bytes(b"audio")
+    review_state: dict[str, object] = {"version": 1, "audio_files": {}, "skipped_speakers": []}
+    diarizer = MagicMock()
+    diarizer.device = "cpu"
+    diarizer.diarize.return_value = [DiarizedSegment("SPEAKER_00", 0.0, 3.0)]
+
+    with (
+        patch(
+            "agent_cli.agents.speakers.extract_speaker_embeddings",
+            return_value={"SPEAKER_00": [1.0, 0.0]},
+        ),
+        patch(
+            "agent_cli.agents.speakers._write_speaker_snippet",
+            side_effect=RuntimeError("ffmpeg is required"),
+        ),
+        patch("agent_cli.agents.speakers._review_choice_prompt") as prompt,
+    ):
+        changed, reviewed_count, skipped_count, interrupted = speakers_module._review_audio_targets(
+            audio_targets=[audio_file],
+            review_state=review_state,
+            store={"profiles": []},
+            diarizer=diarizer,
+            hf_token="token",  # noqa: S106
+            speaker_match_threshold=0.7,
+            snippet_seconds=6.0,
+            player=None,
+            force_review=False,
+            review_state_path=state_file,
+        )
+
+    assert changed is False
+    assert reviewed_count == 0
+    assert skipped_count == 0
+    assert interrupted is False
+    prompt.assert_not_called()
+    saved_state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert saved_state["audio_files"] == {}
 
 
 def test_review_audio_targets_auto_skips_short_fragments(tmp_path: Path) -> None:

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -16,7 +16,9 @@ from agent_cli.core.diarization import (
     align_transcript_with_speakers,
     align_transcript_with_words,
     align_words_to_speakers,
+    best_clean_speaker_segment,
     format_diarized_output,
+    select_clean_speaker_segments,
 )
 
 if TYPE_CHECKING:
@@ -38,6 +40,38 @@ class TestDiarizedSegment:
         """Test that text defaults to empty string."""
         segment = DiarizedSegment(speaker="SPEAKER_01", start=1.0, end=3.0)
         assert segment.text == ""
+
+
+class TestCleanSpeakerSegments:
+    """Tests for clean speaker segment selection."""
+
+    def test_prefers_isolated_segment_over_longer_overlap(self):
+        """The representative segment prefers isolation over duration."""
+        overlapping_long = DiarizedSegment("SPEAKER_00", 0.0, 5.0)
+        other_speaker = DiarizedSegment("SPEAKER_01", 2.0, 3.0)
+        isolated_short = DiarizedSegment("SPEAKER_00", 8.0, 10.0)
+
+        segment = best_clean_speaker_segment(
+            [overlapping_long, other_speaker, isolated_short],
+            "SPEAKER_00",
+        )
+
+        assert segment == isolated_short
+
+    def test_can_reject_unclean_segments(self):
+        """Unclean segments can be rejected instead of used as fallback."""
+        segments = [
+            DiarizedSegment("SPEAKER_00", 0.0, 5.0),
+            DiarizedSegment("SPEAKER_01", 2.0, 3.0),
+        ]
+
+        selected = select_clean_speaker_segments(
+            segments,
+            "SPEAKER_00",
+            fallback_to_unclean=False,
+        )
+
+        assert selected == []
 
 
 class TestAlignTranscriptWithSpeakers:

--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -11,8 +11,10 @@ import pytest
 from agent_cli.core.diarization import DiarizedSegment
 from agent_cli.core.speaker_identity import (
     DEFAULT_SPEAKER_MATCH_THRESHOLD,
+    MAX_PROFILE_EMBEDDINGS,
     SpeakerMatch,
     _normalize_embedding,
+    _speaker_waveforms,
     add_speaker_embedding_to_profile,
     apply_speaker_label_map,
     create_speaker_profile_from_embedding,
@@ -106,6 +108,31 @@ def test_normalize_embedding_rejects_non_finite_values() -> None:
         _normalize_embedding([float("nan"), 1.0])
 
 
+def test_speaker_waveforms_uses_clean_non_overlapping_segments(tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"audio")
+    sample_rate = 10
+    waveform = torch.arange(120, dtype=torch.float32).unsqueeze(0)
+
+    with patch(
+        "agent_cli.core.speaker_identity._load_audio_for_diarization",
+        return_value=(waveform, sample_rate),
+    ):
+        waveforms, returned_sample_rate = _speaker_waveforms(
+            audio_file,
+            [
+                DiarizedSegment("SPEAKER_00", 0.0, 5.0),
+                DiarizedSegment("SPEAKER_01", 2.0, 3.0),
+                DiarizedSegment("SPEAKER_00", 8.0, 10.0),
+            ],
+        )
+
+    assert returned_sample_rate == sample_rate
+    assert set(waveforms) == {"SPEAKER_00"}
+    assert waveforms["SPEAKER_00"].tolist() == [list(range(80, 100))]
+
+
 def test_resolve_speaker_identities_enrolls_named_profile(tmp_path: Path) -> None:
     profiles_file = tmp_path / "speaker-profiles.json"
     segments = [DiarizedSegment(speaker="SPEAKER_00", start=0.0, end=2.0)]
@@ -195,7 +222,7 @@ def test_resolve_speaker_identities_merges_unknown_enrollment_into_existing_name
     store = load_speaker_profile_store(profiles_file)
     assert [profile["name"] for profile in store["profiles"]] == ["Alice"]
     assert store["profiles"][0]["id"] == "alice"
-    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.0, 1.0]]
 
 
 def test_resolve_speaker_identities_enrolls_before_remembering_unknowns(
@@ -303,7 +330,7 @@ def test_resolve_speaker_identities_refreshes_matched_profile_when_remembering(
     assert label_map == {"SPEAKER_00": "Alice"}
     store = load_speaker_profile_store(profiles_file)
     assert len(store["profiles"]) == 1
-    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert store["profiles"][0]["embeddings"] == [[1.0, 0.0]]
 
 
 def test_resolve_speaker_identities_remembers_unknown_profile(tmp_path: Path) -> None:
@@ -382,7 +409,7 @@ def test_merge_speaker_profiles_moves_embeddings_and_removes_source() -> None:
 
     assert profile["id"] == "john"
     assert profile["name"] == "John"
-    assert profile["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert profile["embeddings"] == [[1.0, 0.0]]
     assert [stored_profile["id"] for stored_profile in store["profiles"]] == ["john"]
 
 
@@ -397,7 +424,7 @@ def test_merge_speaker_profiles_rejects_self_merge() -> None:
         merge_speaker_profiles(store, "john", "John")
 
 
-def test_add_speaker_embedding_to_profile_appends_embedding() -> None:
+def test_add_speaker_embedding_to_profile_skips_near_duplicate_embedding() -> None:
     store = {
         "profiles": [
             {
@@ -412,7 +439,45 @@ def test_add_speaker_embedding_to_profile_appends_embedding() -> None:
     profile = add_speaker_embedding_to_profile(store, "John", [0.99, 0.01])
 
     assert profile["id"] == "john"
-    assert profile["embeddings"] == [[1.0, 0.0], [0.99, 0.01]]
+    assert profile["embeddings"] == [[1.0, 0.0]]
+
+
+def test_add_speaker_embedding_to_profile_appends_diverse_embedding() -> None:
+    store = {
+        "profiles": [
+            {
+                "id": "john",
+                "name": "John",
+                "anonymous": False,
+                "embeddings": [[1.0, 0.0]],
+            },
+        ],
+    }
+
+    profile = add_speaker_embedding_to_profile(store, "John", [0.7, 0.7])
+
+    assert profile["id"] == "john"
+    assert profile["embeddings"] == [[1.0, 0.0], [0.7, 0.7]]
+
+
+def test_add_speaker_embedding_to_profile_keeps_bounded_diverse_embeddings() -> None:
+    embeddings = [[1.0, 0.0] for _ in range(MAX_PROFILE_EMBEDDINGS)]
+    store = {
+        "profiles": [
+            {
+                "id": "john",
+                "name": "John",
+                "anonymous": False,
+                "embeddings": embeddings,
+            },
+        ],
+    }
+
+    profile = add_speaker_embedding_to_profile(store, "John", [0.0, 1.0])
+
+    assert len(profile["embeddings"]) == MAX_PROFILE_EMBEDDINGS
+    assert [0.0, 1.0] in profile["embeddings"]
+    assert profile["embeddings"].count([1.0, 0.0]) == MAX_PROFILE_EMBEDDINGS - 1
 
 
 def test_create_speaker_profile_from_embedding_rejects_duplicate_name() -> None:


### PR DESCRIPTION
## Summary
- make speaker review walk live audio with persistent review state and per-speaker skip cache
- review unmatched/anonymous speakers only, with clearer merge/name actions and no replay on invalid no-embedding choices
- centralize clean speaker segment selection and use it for both review snippets and speaker embeddings
- bound profile embeddings and skip near-duplicate vectors
- suppress noisy third-party review warnings and fix writable PCM conversion

## Tests
- uv run ruff check agent_cli/core/diarization.py agent_cli/core/speaker_identity.py agent_cli/agents/speakers.py tests/test_diarization.py tests/test_speaker_identity.py tests/agents/test_speakers.py
- uv run pytest tests/test_diarization.py tests/test_speaker_identity.py tests/agents/test_speakers.py
- pre-commit hook on commit