### PR TITLE
fix(dev): use branch names for agent tabs

### DIFF
--- a/agent_cli/dev/launch.py
+++ b/agent_cli/dev/launch.py
@@ -268,7 +268,7 @@ def _tab_name_for_path(path: Path) -> tuple[Path | None, str]:
     repo_root = worktree.get_main_repo_root(path)
     branch = worktree.get_current_branch(path)
     repo_name = repo_root.name if repo_root else path.name
-    tab_name = f"{repo_name}@{branch}" if branch else repo_name
+    tab_name = branch or repo_name
     return repo_root, tab_name
 
 

--- a/tests/dev/test_launch.py
+++ b/tests/dev/test_launch.py
@@ -48,7 +48,7 @@ class TestLaunchAgent:
         mock_open.assert_called_once_with(
             tmp_path,
             "codex",
-            tab_name="repo@feature",
+            tab_name="feature",
             session_name="agent-cli-repo-1234",
         )
 
@@ -82,7 +82,7 @@ class TestLaunchAgent:
         mock_open.assert_called_once_with(
             tmp_path,
             "codex",
-            tab_name="repo.name@feature",
+            tab_name="feature",
             session_name=expected_session,
         )
 
@@ -114,7 +114,7 @@ class TestLaunchAgent:
         mock_open.assert_called_once_with(
             tmp_path,
             "codex",
-            tab_name="repo@feature",
+            tab_name="feature",
             session_name="shared-session",
         )
 
@@ -144,7 +144,7 @@ class TestLaunchAgent:
         mock_open.assert_called_once_with(
             tmp_path,
             "codex",
-            tab_name="repo@feature",
+            tab_name="feature",
             session_name="shared-session",
         )
 
@@ -190,7 +190,7 @@ class TestLaunchAgent:
         mock_open.assert_called_once_with(
             tmp_path,
             f"bash {shlex.quote(str(wrapper_script))}",
-            tab_name="repo@feature",
+            tab_name="feature",
             session_name="agent-cli-repo-1234",
         )
 
@@ -218,7 +218,7 @@ class TestLaunchAgent:
             result = launch_agent(tmp_path, agent, multiplexer_name="kitty")
 
         assert result is None
-        terminal.open_new_tab.assert_called_once_with(tmp_path, "codex", tab_name="repo@feature")
+        terminal.open_new_tab.assert_called_once_with(tmp_path, "codex", tab_name="feature")
         printed = "\n".join(call.args[0] for call in mock_print.call_args_list if call.args)
         assert "Started codex in new kitty tab" in printed
         assert "To start codex:" not in printed

--- a/tests/memory/test_engine.py
+++ b/tests/memory/test_engine.py
@@ -562,19 +562,10 @@ async def test_streaming_with_summarization_persists_facts_and_summaries(
         for line in body:
             yield line
 
-    async def fake_agent_run(_agent: Any, prompt_text: str, *_args: Any, **_kwargs: Any) -> Any:
-        class _Result:
-            def __init__(self, output: Any) -> None:
-                self.output = output
-
-        prompt_str = str(prompt_text)
-        if "New facts:" in prompt_str:
-            return _Result(SummaryOutput(summary="summary text"))
-        if "My cat is Luna" in prompt_str:
-            return _Result(["User has a cat named Luna."])
-        return _Result(SummaryOutput(summary="noop"))
-
     monkeypatch.setattr(engine._streaming, "stream_chat_sse", fake_stream_chat_sse)
+
+    async def fake_extract_salient_facts(*_args: Any, **_kwargs: Any) -> list[str]:
+        return ["User has a cat named Luna."]
 
     async def fake_reconcile(
         _collection: Any,
@@ -594,10 +585,12 @@ async def test_streaming_with_summarization_persists_facts_and_summaries(
         ]
         return entries, [], {}
 
-    monkeypatch.setattr(_ingest, "reconcile_facts", fake_reconcile)
-    import pydantic_ai  # noqa: PLC0415
+    async def fake_update_summary(*_args: Any, **_kwargs: Any) -> str:
+        return "summary text"
 
-    monkeypatch.setattr(pydantic_ai.Agent, "run", fake_agent_run)
+    monkeypatch.setattr(_ingest, "extract_salient_facts", fake_extract_salient_facts)
+    monkeypatch.setattr(_ingest, "reconcile_facts", fake_reconcile)
+    monkeypatch.setattr(_ingest, "update_summary", fake_update_summary)
 
     response = await engine.process_chat_request(
         request,


### PR DESCRIPTION
## Summary
- Use the current branch name as the terminal tab name for launched agents.
- Keep the existing repo/worktree-name fallback when no branch can be detected.
- Update launch tests to cover branch-only tab labels across tmux and non-tmux terminals.

## Test Plan
- [x] uv run pytest tests/dev/test_launch.py tests/dev/test_terminals.py