### PR TITLE
fix(install): set PATH on macOS launchd daemons so they can find ffmpeg

### DIFF
--- a/agent_cli/install/launchd.py
+++ b/agent_cli/install/launchd.py
@@ -20,8 +20,26 @@ from agent_cli.install.service_config import (
     install_uv,
 )
 
+_MACOS_HOMEBREW_BIN = "/opt/homebrew/bin"
+
 # macOS-specific paths for uv (Homebrew)
-_MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
+_MACOS_UV_PATHS = [Path(_MACOS_HOMEBREW_BIN) / "uv"]
+
+# Default PATH for launchd-spawned daemons. The system default
+# (`/usr/bin:/bin:/usr/sbin:/sbin`) does not include Homebrew, and
+# `path_helper` does not run for launchd processes, so daemons that
+# shell out to ffmpeg/uv/etc. fail with "command not found" unless
+# we set PATH explicitly here.
+_MACOS_DAEMON_PATH = (
+    f"{_MACOS_HOMEBREW_BIN}:"
+    "/opt/homebrew/sbin:"
+    "/usr/local/bin:"
+    "/usr/local/sbin:"
+    "/usr/bin:"
+    "/bin:"
+    "/usr/sbin:"
+    "/sbin"
+)
 
 
 def _get_label(service_name: str) -> str:
@@ -83,6 +101,7 @@ def _generate_plist(
         "RunAtLoad": True,
         "KeepAlive": True,
         "WorkingDirectory": str(home_dir),
+        "EnvironmentVariables": {"PATH": _MACOS_DAEMON_PATH},
         "StandardOutPath": str(log_dir / "stdout.log"),
         "StandardErrorPath": str(log_dir / "stderr.log"),
     }

--- a/tests/install/test_launchd.py
+++ b/tests/install/test_launchd.py
@@ -1,0 +1,23 @@
+"""Tests for macOS launchd service management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_cli.install.launchd import _generate_plist
+from agent_cli.install.service_config import SERVICES
+
+
+def test_generate_plist_sets_path_for_homebrew_bins() -> None:
+    plist = _generate_plist(
+        SERVICES["whisper"],
+        Path("/opt/homebrew/bin/uv"),
+        Path("/Users/test"),
+        Path("/Users/test/Library/Logs/agent-cli-whisper"),
+    )
+
+    path = plist["EnvironmentVariables"]["PATH"]
+
+    assert "/opt/homebrew/bin" in path.split(":")
+    assert "/usr/local/bin" in path.split(":")
+    assert path.endswith("/usr/bin:/bin:/usr/sbin:/sbin")


### PR DESCRIPTION
## Summary

This fixes the launchd plist generated by agent-cli so macOS daemons get an explicit PATH that includes Homebrew locations such as /opt/homebrew/bin and /usr/local/bin.

launchd starts processes with the bare system PATH (/usr/bin:/bin:/usr/sbin:/sbin), and path_helper does not run for launchd-spawned processes. That means binaries installed by Homebrew are invisible to services. The user-visible symptom is that the MLX Whisper daemon rejects non-WAV uploads such as Matrix m4a voice messages because shutil.which("ffmpeg") returns None at request time.

This was discovered while wiring agent-cli's local Whisper/Kokoro daemons into MindRoom. The same plist defect will bite tts-kokoro once Kokoro needs ffmpeg for non-WAV output formats.

The fix is launchd-only. systemd services are unchanged because Linux services already have a sane PATH.

## Tests

- uv run pytest tests/install/test_launchd.py -v
- uv run pre-commit run --files agent_cli/install/launchd.py tests/install/test_launchd.py

Full suite note: uv run pytest -q was run and failed in existing ffmpeg integration paths unrelated to this launchd plist change:
- tests/core/test_audio_format.py::test_convert_audio_integration timed out inside ffmpeg conversion
- tests/test_api_integration.py::test_temp_file_cleanup timed out in the same conversion path with the local ffmpeg