### PR TITLE
Fix backend-specific extras for server auto-install

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -385,7 +385,11 @@ def _should_skip_extra_check_for_process_control(
     return process.is_process_running(process_name)
 
 
-def requires_extras(*extras: str, process_name: str | None = None) -> Callable[[F], F]:
+def requires_extras(
+    *extras: str,
+    process_name: str | None = None,
+    resolve_extras: Callable[[dict[str, object]], tuple[str, ...]] | None = None,
+) -> Callable[[F], F]:
     """Decorator to declare required extras for a command.
 
     Auto-installs missing extras by default. Disable via AGENT_CLI_NO_AUTO_INSTALL=1
@@ -399,7 +403,8 @@ def requires_extras(*extras: str, process_name: str | None = None) -> Callable[[
         def wrapper(*args: object, **kwargs: object) -> object:
             if _should_skip_extra_check_for_process_control(kwargs, process_name):
                 return func(*args, **kwargs)
-            if _check_and_install_extras(extras):
+            required_extras = resolve_extras(kwargs) if resolve_extras is not None else extras
+            if _check_and_install_extras(required_extras):
                 raise typer.Exit(1)
             return func(*args, **kwargs)
 

--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -87,6 +87,13 @@ def _check_server_deps() -> None:
         raise typer.Exit(1)
 
 
+def _resolve_tts_required_extras(kwargs: dict[str, object]) -> tuple[str, ...]:
+    """Choose the TTS backend extra after Typer has parsed --backend."""
+    backend = kwargs.get("backend")
+    backend_extra = backend if backend in ("piper", "kokoro") else "piper|kokoro"
+    return ("server", str(backend_extra), "wyoming")
+
+
 def _check_tts_deps(backend: str = "auto") -> None:
     """Check that TTS dependencies are available."""
     _check_server_deps()
@@ -95,8 +102,8 @@ def _check_tts_deps(backend: str = "auto") -> None:
         if not _has("kokoro"):
             err_console.print(
                 "[bold red]Error:[/bold red] Kokoro backend requires kokoro. "
-                "Run: [cyan]pip install agent-cli\\[tts-kokoro][/cyan] "
-                "or [cyan]uv sync --extra tts-kokoro[/cyan]",
+                "Run: [cyan]pip install agent-cli\\[kokoro][/cyan] "
+                "or [cyan]uv sync --extra kokoro[/cyan]",
             )
             raise typer.Exit(1)
         return
@@ -105,8 +112,8 @@ def _check_tts_deps(backend: str = "auto") -> None:
         if not _has("piper"):
             err_console.print(
                 "[bold red]Error:[/bold red] Piper backend requires piper-tts. "
-                "Run: [cyan]pip install agent-cli\\[tts][/cyan] "
-                "or [cyan]uv sync --extra tts[/cyan]",
+                "Run: [cyan]pip install agent-cli\\[piper][/cyan] "
+                "or [cyan]uv sync --extra piper[/cyan]",
             )
             raise typer.Exit(1)
         return
@@ -115,8 +122,8 @@ def _check_tts_deps(backend: str = "auto") -> None:
     if not _has("piper") and not _has("kokoro"):
         err_console.print(
             "[bold red]Error:[/bold red] No TTS backend available. "
-            "Run: [cyan]pip install agent-cli\\[tts][/cyan] for Piper "
-            "or [cyan]pip install agent-cli\\[tts-kokoro][/cyan] for Kokoro",
+            "Run: [cyan]pip install agent-cli\\[piper][/cyan] for Piper "
+            "or [cyan]pip install agent-cli\\[kokoro][/cyan] for Kokoro",
         )
         raise typer.Exit(1)
 
@@ -169,7 +176,8 @@ def _check_whisper_deps(backend: str, *, download_only: bool = False) -> None:
         if not _has("mlx_whisper"):
             err_console.print(
                 "[bold red]Error:[/bold red] MLX Whisper backend requires mlx-whisper. "
-                "Run: [cyan]pip install mlx-whisper[/cyan]",
+                "Run: [cyan]pip install agent-cli\\[mlx-whisper][/cyan] "
+                "or [cyan]uv sync --extra mlx-whisper[/cyan]",
             )
             raise typer.Exit(1)
         return
@@ -233,6 +241,21 @@ def _check_transformers_audio_model_deps(models: list[str]) -> None:
     raise typer.Exit(1)
 
 
+def _resolve_whisper_required_extras(kwargs: dict[str, object]) -> tuple[str, ...]:
+    """Choose the Whisper backend extra after Typer has parsed --backend."""
+    backend_extras = {
+        "faster-whisper": "faster-whisper",
+        "mlx": "mlx-whisper",
+        "transformers": "whisper-transformers",
+    }
+    backend = kwargs.get("backend")
+    backend_extra = backend_extras.get(
+        str(backend),
+        "faster-whisper|mlx-whisper|whisper-transformers",
+    )
+    return ("server", backend_extra, "wyoming")
+
+
 def _print_optional_whisper_config(
     *,
     default_language: str | None,
@@ -249,7 +272,12 @@ def _print_optional_whisper_config(
 
 
 @app.command("whisper")
-@requires_extras("server", "faster-whisper|mlx-whisper|whisper-transformers", "wyoming")
+@requires_extras(
+    "server",
+    "faster-whisper|mlx-whisper|whisper-transformers",
+    "wyoming",
+    resolve_extras=_resolve_whisper_required_extras,
+)
 def whisper_cmd(  # noqa: PLR0912, PLR0915
     model: Annotated[
         list[str] | None,
@@ -639,7 +667,7 @@ def transcribe_proxy_cmd(
 
 
 @app.command("tts")
-@requires_extras("server", "piper|kokoro", "wyoming")
+@requires_extras("server", "piper|kokoro", "wyoming", resolve_extras=_resolve_tts_required_extras)
 def tts_cmd(  # noqa: PLR0915
     model: Annotated[
         list[str] | None,

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -33,6 +33,32 @@ class TestRequiresExtrasDecorator:
         assert hasattr(sample_command, "_required_extras")
         assert sample_command._required_extras == ("audio", "llm")
 
+    def test_decorator_uses_runtime_extras_resolver(self) -> None:
+        """Commands can choose concrete extras after Typer parses options."""
+
+        def resolve_extras(kwargs: dict[str, object]) -> tuple[str, ...]:
+            backend = kwargs["backend"]
+            return ("server", str(backend), "wyoming")
+
+        @requires_extras(
+            "server",
+            "piper|kokoro",
+            "wyoming",
+            resolve_extras=resolve_extras,
+        )
+        def sample_command(*, backend: str) -> str:
+            return f"success:{backend}"
+
+        with patch("agent_cli.core.deps._check_and_install_extras", return_value=[]) as mock_check:
+            assert sample_command(backend="kokoro") == "success:kokoro"
+
+        mock_check.assert_called_once_with(("server", "kokoro", "wyoming"))
+        assert getattr(sample_command, "_required_extras") == (  # noqa: B009
+            "server",
+            "piper|kokoro",
+            "wyoming",
+        )
+
     def test__get_install_hint_with_pipe_syntax(self) -> None:
         """Pipe syntax shows all alternatives in the hint."""
         hint = _get_install_hint("piper|kokoro")

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -68,6 +70,44 @@ class TestRequiresExtrasDecorator:
         # Brackets are escaped for rich markup (\\[)
         assert "agent-cli\\[piper]" in hint
         assert "agent-cli\\[kokoro]" in hint
+
+    def test_commands_with_alternative_extras_have_runtime_resolver(self) -> None:
+        """Alternative extras on commands need a resolver for explicit backend options."""
+        repo_root = Path(__file__).resolve().parents[1]
+        violations: list[str] = []
+
+        for path in (repo_root / "agent_cli").rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+
+                for decorator in node.decorator_list:
+                    if not isinstance(decorator, ast.Call):
+                        continue
+
+                    func = decorator.func
+                    if not isinstance(func, ast.Name) or func.id != "requires_extras":
+                        continue
+
+                    extras = [
+                        arg.value
+                        for arg in decorator.args
+                        if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+                    ]
+                    if not any("|" in extra for extra in extras):
+                        continue
+
+                    has_resolver = any(
+                        keyword.arg == "resolve_extras" for keyword in decorator.keywords
+                    )
+                    if not has_resolver:
+                        violations.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+
+        assert not violations, (
+            "requires_extras alternatives choose a default extra during auto-install. "
+            "Pass resolve_extras for commands with alternative extras: " + ", ".join(violations)
+        )
 
 
 class TestExtrasMetadata:

--- a/tests/test_server_tts.py
+++ b/tests/test_server_tts.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
+import typer
 from fastapi.testclient import TestClient
 
+from agent_cli.server.cli import _check_tts_deps, _resolve_tts_required_extras
 from agent_cli.server.model_manager import ModelStats
 from agent_cli.server.tts.backends import SynthesisResult
 from agent_cli.server.tts.model_manager import TTSModelConfig, TTSModelManager
@@ -53,6 +55,78 @@ class TestTTSModelConfig:
         assert config.model_name == "/path/to/kokoro-v1_0.pth"
         assert config.device == "cuda"
         assert config.backend_type == "kokoro"
+
+
+class TestTTSDependencyChecks:
+    """Tests for server TTS optional dependency handling."""
+
+    def test_resolve_tts_required_extras_uses_explicit_backend(self) -> None:
+        """Explicit TTS backends should install their matching extra."""
+        assert _resolve_tts_required_extras({"backend": "kokoro"}) == (
+            "server",
+            "kokoro",
+            "wyoming",
+        )
+        assert _resolve_tts_required_extras({"backend": "piper"}) == (
+            "server",
+            "piper",
+            "wyoming",
+        )
+
+    def test_resolve_tts_required_extras_keeps_auto_backend_alternatives(self) -> None:
+        """Auto backend should keep the existing Piper-or-Kokoro fallback."""
+        assert _resolve_tts_required_extras({"backend": "auto"}) == (
+            "server",
+            "piper|kokoro",
+            "wyoming",
+        )
+
+    @pytest.mark.parametrize(
+        ("backend", "expected_extra", "unexpected"),
+        [
+            ("kokoro", "kokoro", "tts-kokoro"),
+            ("piper", "piper", "agent-cli\\[tts]"),
+        ],
+    )
+    def test_backend_dependency_hint_uses_existing_extra(
+        self,
+        backend: str,
+        expected_extra: str,
+        unexpected: str,
+    ) -> None:
+        """Missing backend deps should point at existing extras."""
+        with (
+            patch(
+                "agent_cli.server.cli._has",
+                side_effect=lambda package: package in {"uvicorn", "fastapi"},
+            ),
+            patch("agent_cli.server.cli.err_console.print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            _check_tts_deps(backend)
+
+        message = mock_print.call_args[0][0]
+        assert f"agent-cli\\[{expected_extra}]" in message
+        assert f"uv sync --extra {expected_extra}" in message
+        assert unexpected not in message
+
+    def test_auto_dependency_hint_uses_backend_extras(self) -> None:
+        """Missing auto backend deps should list installable backend extras."""
+        with (
+            patch(
+                "agent_cli.server.cli._has",
+                side_effect=lambda package: package in {"uvicorn", "fastapi"},
+            ),
+            patch("agent_cli.server.cli.err_console.print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            _check_tts_deps("auto")
+
+        message = mock_print.call_args[0][0]
+        assert "agent-cli\\[piper]" in message
+        assert "agent-cli\\[kokoro]" in message
+        assert "agent-cli\\[tts]" not in message
+        assert "tts-kokoro" not in message
 
 
 class TestModelStats:

--- a/tests/test_server_whisper.py
+++ b/tests/test_server_whisper.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import typer
 from fastapi.testclient import TestClient
 
+from agent_cli.server.cli import _check_whisper_deps, _resolve_whisper_required_extras
 from agent_cli.server.model_manager import ModelStats
 from agent_cli.server.whisper.backends import TranscriptionResult
 from agent_cli.server.whisper.backends.base import UnsupportedRequestError
@@ -66,6 +68,64 @@ class TestModelConfig:
         assert config.cpu_threads == 8
         assert config.default_language == "en"
         assert config.trust_remote_code is True
+
+
+class TestWhisperDependencyChecks:
+    """Tests for server Whisper optional dependency handling."""
+
+    def test_resolve_whisper_required_extras_uses_explicit_backend(self) -> None:
+        """Explicit Whisper backends should install their matching extra."""
+        assert _resolve_whisper_required_extras({"backend": "faster-whisper"}) == (
+            "server",
+            "faster-whisper",
+            "wyoming",
+        )
+        assert _resolve_whisper_required_extras({"backend": "mlx"}) == (
+            "server",
+            "mlx-whisper",
+            "wyoming",
+        )
+        assert _resolve_whisper_required_extras({"backend": "transformers"}) == (
+            "server",
+            "whisper-transformers",
+            "wyoming",
+        )
+
+    def test_resolve_whisper_required_extras_keeps_auto_backend_alternatives(self) -> None:
+        """Auto backend should keep the existing Whisper backend fallback."""
+        assert _resolve_whisper_required_extras({"backend": "auto"}) == (
+            "server",
+            "faster-whisper|mlx-whisper|whisper-transformers",
+            "wyoming",
+        )
+
+    @pytest.mark.parametrize(
+        ("backend", "expected_extra"),
+        [
+            ("faster-whisper", "faster-whisper"),
+            ("mlx", "mlx-whisper"),
+            ("transformers", "whisper-transformers"),
+        ],
+    )
+    def test_backend_dependency_hint_uses_existing_extra(
+        self,
+        backend: str,
+        expected_extra: str,
+    ) -> None:
+        """Missing backend deps should point at existing extras."""
+        with (
+            patch(
+                "agent_cli.server.cli._has",
+                side_effect=lambda package: package in {"uvicorn", "fastapi"},
+            ),
+            patch("agent_cli.server.cli.err_console.print") as mock_print,
+            pytest.raises(typer.Exit),
+        ):
+            _check_whisper_deps(backend)
+
+        message = mock_print.call_args[0][0]
+        assert f"agent-cli\\[{expected_extra}]" in message
+        assert f"uv sync --extra {expected_extra}" in message
 
 
 class TestModelStats:


### PR DESCRIPTION
## Summary
- Resolve server backend extras after Typer parses `--backend`, so explicit TTS/Whisper backends install the matching extra under `uvx`.
- Correct TTS and MLX Whisper dependency hints to use installable project extras.
- Add regression coverage for TTS, Whisper, and the dynamic extras resolver.

## Test Plan
- [x] uv run pytest
- [x] pre-commit run --all-files