### PR TITLE
Fix dev worktrees from submodule worktrees

### DIFF
--- a/agent_cli/dev/worktree.py
+++ b/agent_cli/dev/worktree.py
@@ -73,6 +73,15 @@ def get_repo_root(path: Path | None = None) -> Path | None:
         return None
 
 
+def _resolve_git_path(path: str, cwd: Path | None = None) -> Path:
+    """Resolve a path emitted by Git relative to the command cwd."""
+    resolved = Path(path).expanduser()
+    if resolved.is_absolute():
+        return resolved
+    base = cwd if cwd is not None else Path.cwd()
+    return (base / resolved).resolve()
+
+
 def get_common_dir(path: Path | None = None) -> Path | None:
     """Get the common git directory (shared across worktrees)."""
     try:
@@ -82,9 +91,41 @@ def get_common_dir(path: Path | None = None) -> Path | None:
             # In main repo, resolve relative to toplevel
             repo_root = get_repo_root(path)
             return repo_root / ".git" if repo_root else None
-        return Path(common_dir)
+        return _resolve_git_path(common_dir, path)
     except subprocess.CalledProcessError:
         return None
+
+
+def _is_git_modules_path(path: Path) -> bool:
+    """Return True when path points inside a .git/modules directory."""
+    parts = path.parts
+    return any(
+        part == ".git" and parts[i + 1 : i + 2] == ("modules",) for i, part in enumerate(parts)
+    )
+
+
+def _get_configured_worktree(common_dir: Path) -> Path | None:
+    """Read core.worktree from a Git dir config, if present."""
+    config_file = common_dir / "config"
+    if not config_file.exists():
+        return None
+
+    result = _run_git(
+        "config",
+        "--file",
+        str(config_file),
+        "--path",
+        "core.worktree",
+        cwd=common_dir,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    worktree = result.stdout.strip()
+    if not worktree:
+        return None
+    return _resolve_git_path(worktree, common_dir)
 
 
 def get_main_repo_root(path: Path | None = None) -> Path | None:
@@ -100,11 +141,17 @@ def get_main_repo_root(path: Path | None = None) -> Path | None:
         return common_dir.parent
     # Check if we're in a submodule (common_dir is inside .git/modules/)
     # e.g., /path/to/parent/.git/modules/submodule-name
-    parts = common_dir.parts
-    for i, part in enumerate(parts[:-1]):
-        if part == ".git" and parts[i + 1] == "modules":
-            # For submodules, use --show-toplevel to get the submodule's working directory
-            return get_repo_root(path)
+    if _is_git_modules_path(common_dir):
+        # For submodules, use --show-toplevel to get the submodule's working
+        # directory. Linked worktrees of submodules can report the internal
+        # .git/modules directory instead, so fall back to core.worktree.
+        repo_root = get_repo_root(path)
+        if repo_root is not None and not _is_git_modules_path(repo_root):
+            return repo_root
+        configured_worktree = _get_configured_worktree(common_dir)
+        if configured_worktree is not None:
+            return configured_worktree
+        return repo_root
     # For bare repos or unusual setups, try to go up from common_dir
     return common_dir.parent
 

--- a/tests/dev/test_worktree.py
+++ b/tests/dev/test_worktree.py
@@ -14,6 +14,7 @@ from agent_cli.dev.worktree import (
     _pull_lfs,
     create_worktree,
     find_worktree_by_name,
+    get_common_dir,
     get_main_repo_root,
     has_origin_remote,
     list_worktrees,
@@ -113,6 +114,21 @@ class TestResolveWorktreeBaseDir:
         assert result == tmp_path / "agent"
 
 
+class TestGetCommonDir:
+    """Tests for get_common_dir function."""
+
+    def test_relative_common_dir_resolves_against_git_cwd(self, tmp_path: Path) -> None:
+        """Relative git-common-dir output is anchored to the Git command cwd."""
+        module_dir = tmp_path / "parent" / ".git" / "modules" / "my-submodule"
+        module_dir.mkdir(parents=True)
+        mock_run = MagicMock(return_value=MagicMock(stdout=".\n"))
+
+        with patch("agent_cli.dev.worktree._run_git", mock_run):
+            result = get_common_dir(module_dir)
+
+        assert result == module_dir
+
+
 class TestGetMainRepoRoot:
     """Tests for get_main_repo_root function."""
 
@@ -153,6 +169,33 @@ class TestGetMainRepoRoot:
         mock_repo_root.assert_called_once()
         assert result == submodule_toplevel
         assert ".git/modules" not in str(result)
+
+    def test_linked_submodule_worktree_uses_configured_main_worktree(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Linked worktrees of submodules resolve to the submodule checkout.
+
+        In this layout, git rev-parse --show-toplevel can return the internal
+        .git/modules/<name> directory. The main checkout is stored as
+        core.worktree in the module config.
+        """
+        parent = tmp_path / "parent"
+        submodule_common_dir = parent / ".git" / "modules" / "my-submodule"
+        submodule_common_dir.mkdir(parents=True)
+        (submodule_common_dir / "config").write_text(
+            "[core]\n\tworktree = ../../../my-submodule\n",
+        )
+        submodule_toplevel = parent / "my-submodule"
+        linked_worktree = parent / "my-submodule-worktrees" / "feature"
+
+        with (
+            patch("agent_cli.dev.worktree.get_common_dir", return_value=submodule_common_dir),
+            patch("agent_cli.dev.worktree.get_repo_root", return_value=submodule_common_dir),
+        ):
+            result = get_main_repo_root(linked_worktree)
+
+        assert result == submodule_toplevel
 
 
 class TestListWorktrees:


### PR DESCRIPTION
## Summary
- resolve relative Git common-dir paths against the command cwd
- use submodule core.worktree when linked worktrees report .git/modules as the top level
- add regression coverage for relative common dirs and linked submodule worktrees

## Verification
- uv run pytest tests/dev
- uv run ruff check agent_cli/dev/worktree.py tests/dev/test_worktree.py
- uv run ruff format --check agent_cli/dev/worktree.py tests/dev/test_worktree.py
- uv run python direct check against /Users/bas.nijholt/Work/dev/mindroom-worktrees/feature-optional-knowledge-db-embeddings

Note: uv run pytest tests is blocked in this local env by missing optional extras such as numpy, fastapi, wyoming, watchfiles, pydantic_ai, and torch during collection.