### PR TITLE
Harden CLI process runtime locks

### DIFF
--- a/agent_cli/core/process.py
+++ b/agent_cli/core/process.py
@@ -2,22 +2,47 @@
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import sys
+import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-# Default location for PID files
-PID_DIR = Path.home() / ".cache" / "agent-cli"
-
 # Store the original process title before any modifications
 _original_proctitle: str | None = None
+
+
+class _PidInfo(NamedTuple):
+    pid: int
+    uses_lock: bool
+
+
+def _default_pid_dir() -> Path:
+    """Return local runtime dir for process control files."""
+    if runtime_dir := os.environ.get("AGENTCLI_RUNTIME_DIR"):
+        return Path(runtime_dir)
+
+    if xdg_runtime_dir := os.environ.get("XDG_RUNTIME_DIR"):
+        return Path(xdg_runtime_dir) / "agent-cli"
+
+    if os.name == "posix":
+        return Path(tempfile.gettempdir()) / f"agent-cli-{os.getuid()}"
+
+    if local_app_data := os.environ.get("LOCALAPPDATA"):
+        return Path(local_app_data) / "agent-cli" / "runtime"
+
+    return Path(tempfile.gettempdir()) / "agent-cli-runtime"
+
+
+# Default location for PID files and process locks.
+PID_DIR = _default_pid_dir()
 
 
 def set_process_title(process_name: str) -> None:
@@ -57,6 +82,12 @@ def _get_pid_file(process_name: str) -> Path:
     return PID_DIR / f"{process_name}.pid"
 
 
+def _get_lock_file(process_name: str) -> Path:
+    """Get the path to the process lock file for a given process name."""
+    PID_DIR.mkdir(parents=True, exist_ok=True)
+    return PID_DIR / f"{process_name}.lock"
+
+
 def _get_stop_file(process_name: str) -> Path:
     """Get the path to the stop file for a given process name."""
     PID_DIR.mkdir(parents=True, exist_ok=True)
@@ -89,28 +120,137 @@ def _is_pid_running(pid: int) -> bool:
         return False
 
 
-def _get_running_pid(process_name: str) -> int | None:
-    """Get PID if process is running, None otherwise. Cleans up stale files."""
-    pid_file = _get_pid_file(process_name)
+def _supports_process_locks() -> bool:
+    """Return whether this platform supports POSIX advisory locks."""
+    return sys.platform != "win32"
 
-    if not pid_file.exists():
+
+def _acquire_process_lock(process_name: str) -> int | None:
+    """Try to acquire the per-process lock. Return fd when held."""
+    if not _supports_process_locks():
+        return None
+
+    import fcntl  # noqa: PLC0415
+
+    lock_file = _get_lock_file(process_name)
+    fd = os.open(lock_file, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(fd)
+        return None
+    except OSError:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _release_process_lock(lock_fd: int | None) -> None:
+    """Release a lock fd returned by _acquire_process_lock."""
+    if lock_fd is None:
+        return
+
+    import fcntl  # noqa: PLC0415
+
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    os.close(lock_fd)
+
+
+def _is_process_lock_held(process_name: str) -> bool:
+    """Return True when another process still owns the lock."""
+    if not _supports_process_locks():
+        return True
+
+    lock_fd = _acquire_process_lock(process_name)
+    if lock_fd is None:
+        return True
+
+    _release_process_lock(lock_fd)
+    return False
+
+
+def _legacy_pid_info(raw: str) -> _PidInfo | None:
+    """Parse a legacy numeric PID file."""
+    try:
+        return _PidInfo(pid=int(raw), uses_lock=False)
+    except ValueError:
+        return None
+
+
+def _pid_info_from_payload(process_name: str, payload: object) -> _PidInfo | None:
+    """Parse JSON PID metadata."""
+    if isinstance(payload, int):
+        return _PidInfo(pid=payload, uses_lock=False)
+
+    if (
+        not isinstance(payload, dict)
+        or payload.get("version") != 1
+        or payload.get("process_name") != process_name
+    ):
         return None
 
     try:
-        with pid_file.open() as f:
-            pid = int(f.read().strip())
+        pid = int(payload["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
-        # Check if process is actually running
-        if _is_pid_running(pid):
-            return pid
+    return _PidInfo(pid=pid, uses_lock=True)
 
-    except (FileNotFoundError, ValueError):
-        pass
 
-    # Clean up stale/invalid PID file
+def _read_pid_info(process_name: str) -> _PidInfo | None:
+    """Read either current JSON PID metadata or a legacy numeric PID file."""
+    pid_file = _get_pid_file(process_name)
+    try:
+        raw = pid_file.read_text().strip()
+    except FileNotFoundError:
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _legacy_pid_info(raw)
+
+    return _pid_info_from_payload(process_name, payload)
+
+
+def _write_pid_info(process_name: str) -> None:
+    """Write PID metadata for the current process."""
+    pid_file = _get_pid_file(process_name)
+    payload = {
+        "version": 1,
+        "process_name": process_name,
+        "pid": os.getpid(),
+        "created_at": time.time(),
+    }
+    pid_file.write_text(json.dumps(payload, sort_keys=True))
+
+
+def _cleanup_process_files(process_name: str) -> None:
+    """Remove stale process control files."""
+    pid_file = _get_pid_file(process_name)
     if pid_file.exists():
         pid_file.unlink()
     clear_stop_file(process_name)
+
+
+def _get_running_pid(process_name: str) -> int | None:
+    """Get PID if process is running, None otherwise. Cleans up stale files."""
+    if not _get_pid_file(process_name).exists():
+        return None
+
+    pid_info = _read_pid_info(process_name)
+    if pid_info is None:
+        _cleanup_process_files(process_name)
+        return None
+
+    if pid_info.uses_lock and _supports_process_locks() and not _is_process_lock_held(process_name):
+        _cleanup_process_files(process_name)
+        return None
+
+    if _is_pid_running(pid_info.pid):
+        return pid_info.pid
+
+    _cleanup_process_files(process_name)
     return None
 
 
@@ -173,9 +313,7 @@ def kill_process(process_name: str) -> bool:
     # Keep PID file if process is still alive so subsequent --status/--toggle
     # calls continue targeting the same process.
     if process_stopped:
-        clear_stop_file(process_name)
-        if pid_file.exists():
-            pid_file.unlink()
+        _cleanup_process_files(process_name)
     elif not should_force_kill:
         stop_file.touch()
 
@@ -189,21 +327,33 @@ def pid_file_context(process_name: str) -> Generator[Path, None, None]:
     Creates PID file on entry, cleans up on exit.
     Exits with error if process already running.
     """
-    if is_process_running(process_name):
+    lock_fd = _acquire_process_lock(process_name)
+    if _supports_process_locks() and lock_fd is None:
         existing_pid = _get_running_pid(process_name)
         print(f"Process {process_name} is already running (PID: {existing_pid})")
         sys.exit(1)
+
+    if not _supports_process_locks() and is_process_running(process_name):
+        existing_pid = _get_running_pid(process_name)
+        print(f"Process {process_name} is already running (PID: {existing_pid})")
+        sys.exit(1)
+
+    if _supports_process_locks():
+        pid_info = _read_pid_info(process_name)
+        if pid_info and not pid_info.uses_lock and _is_pid_running(pid_info.pid):
+            _release_process_lock(lock_fd)
+            print(f"Process {process_name} is already running (PID: {pid_info.pid})")
+            sys.exit(1)
+        _cleanup_process_files(process_name)
 
     # Clear stale stop markers from previous runs.
     clear_stop_file(process_name)
 
     pid_file = _get_pid_file(process_name)
-    with pid_file.open("w") as f:
-        f.write(str(os.getpid()))
+    _write_pid_info(process_name)
 
     try:
         yield pid_file
     finally:
-        if pid_file.exists():
-            pid_file.unlink()
-        clear_stop_file(process_name)
+        _cleanup_process_files(process_name)
+        _release_process_lock(lock_fd)

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import sys
@@ -18,13 +19,30 @@ import pytest
 from agent_cli.core import process
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def temp_pid_dir(monkeypatch: pytest.MonkeyPatch) -> Generator[Path, None, None]:
     """Create a temporary directory for PID files during testing."""
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_path = Path(tmpdir)
         monkeypatch.setattr(process, "PID_DIR", temp_path)
         yield temp_path
+
+
+def test_default_pid_dir_prefers_explicit_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runtime control files should allow an explicit local directory override."""
+    runtime_dir = Path(tempfile.gettempdir()) / "agent-cli-runtime-test"
+    monkeypatch.setenv("AGENTCLI_RUNTIME_DIR", str(runtime_dir))
+
+    assert process._default_pid_dir() == runtime_dir
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX fallback uses /tmp and uid")
+def test_default_pid_dir_uses_local_tmp_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runtime control files should not default to a possibly networked home dir."""
+    monkeypatch.delenv("AGENTCLI_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+    assert process._default_pid_dir() == Path(tempfile.gettempdir()) / f"agent-cli-{os.getuid()}"
 
 
 def test_get_pid_file(temp_pid_dir: Path) -> None:
@@ -92,6 +110,47 @@ def test_read_pid_file_current_process() -> None:
     pid_file.write_text(str(current_pid))
 
     assert process.read_pid_file(process_name) == current_pid
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX lock files are Unix-only")
+def test_pid_file_context_writes_metadata_and_holds_lock() -> None:
+    """New PID files should carry process metadata and be backed by a live lock."""
+    process_name = "test-process"
+    pid_file = process._get_pid_file(process_name)
+
+    with process.pid_file_context(process_name):
+        metadata = json.loads(pid_file.read_text())
+
+        assert metadata["version"] == 1
+        assert metadata["process_name"] == process_name
+        assert metadata["pid"] == os.getpid()
+        assert process.is_process_running(process_name)
+        assert process.read_pid_file(process_name) == os.getpid()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX lock files are Unix-only")
+@patch("agent_cli.core.process._is_pid_running", return_value=True)
+def test_is_process_running_cleans_unlocked_metadata_pid_file(
+    mock_is_pid_running: MagicMock,  # noqa: ARG001
+) -> None:
+    """A new-format PID file without a held lock is stale even if the PID exists."""
+    process_name = "test-process"
+    pid_file = process._get_pid_file(process_name)
+    stop_file = process._get_stop_file(process_name)
+    pid_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "process_name": process_name,
+                "pid": os.getpid(),
+            },
+        ),
+    )
+    stop_file.write_text("1")
+
+    assert not process.is_process_running(process_name)
+    assert not pid_file.exists()
+    assert not stop_file.exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="os.kill(pid, 0) not used on Windows")
@@ -215,9 +274,9 @@ def test_pid_file_context_success() -> None:
         assert returned_pid_file == pid_file
 
         # PID file should contain current process ID
-        with pid_file.open() as f:
-            stored_pid = int(f.read().strip())
-        assert stored_pid == os.getpid()
+        metadata = json.loads(pid_file.read_text())
+        assert metadata["pid"] == os.getpid()
+        assert metadata["process_name"] == process_name
 
     # PID file should be cleaned up after context
     assert not pid_file.exists()


### PR DESCRIPTION
## Summary
- Move CLI process control files to a local runtime directory instead of home cache.
- Add lock-backed PID metadata while preserving legacy numeric PID file support.
- Clean stale PID/stop files when JSON metadata has no live lock owner.

## Test Plan
- uv run pytest tests/test_process_manager.py tests/test_utils.py tests/agents/test_transcribe_agent.py tests/agents/test_voice_edit.py tests/test_requires_extras.py
- uv run pre-commit run --all-files

## Notes
- This is the core Agent CLI process-control PR and should merge before the macOS menu bar branch.