### PR TITLE
Model hold transcription as explicit state

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -5,6 +5,22 @@ import Foundation
 import SwiftUI
 import UserNotifications
 
+private enum HoldTranscriptionState {
+    case idle
+    case recording
+    case awaitingPid
+    case stopping
+
+    var isFinishing: Bool {
+        switch self {
+        case .awaitingPid, .stopping:
+            return true
+        case .idle, .recording:
+            return false
+        }
+    }
+}
+
 final class AgentCommandRunner: ObservableObject {
     static let shared = AgentCommandRunner()
 
@@ -16,9 +32,7 @@ final class AgentCommandRunner: ObservableObject {
     private var recordingCommandCount = 0
     private var activeRecordingCommands: [String: Int] = [:]
     private var pendingStopRecordingCommands: Set<String> = []
-    private var holdToTranscribeActive = false
-    private var pendingHoldToTranscribeStop = false
-    private var holdStopRequestActive = false
+    private var holdTranscriptionState: HoldTranscriptionState = .idle
     private var holdToTranscribePasteTarget: FocusedTextTarget?
     private var pasteAfterRecordingCommands: Set<String> = []
 
@@ -30,7 +44,7 @@ final class AgentCommandRunner: ObservableObject {
         if isRecording {
             return "Recording"
         }
-        if pendingHoldToTranscribeStop || holdStopRequestActive {
+        if holdTranscriptionState.isFinishing {
             return "Transcribing..."
         }
         if hasLastError && statusMessage.localizedCaseInsensitiveContains("failed") {
@@ -55,9 +69,10 @@ final class AgentCommandRunner: ObservableObject {
     private static let holdStopShell = #"for attempt in {1..3000}; do if [ -s "$AGENTCLI_RUNTIME_DIR/transcribe.pid" ]; then "$AGENTCLI_AGENT_CLI" transcribe --stop --quiet; exit $?; fi; sleep 0.1; done; "$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#
 
     func beginHoldToTranscribe() {
-        guard !holdToTranscribeActive else { return }
-        guard !pendingHoldToTranscribeStop, !holdStopRequestActive else {
-            statusMessage = "Finishing previous hold-to-transcribe request"
+        guard holdTranscriptionState == .idle else {
+            if holdTranscriptionState.isFinishing {
+                statusMessage = "Finishing previous hold-to-transcribe request"
+            }
             return
         }
         guard !isRecordingCommand(.toggleTranscription), !isStopPending(for: .toggleTranscription) else {
@@ -65,16 +80,15 @@ final class AgentCommandRunner: ObservableObject {
             return
         }
 
-        holdToTranscribeActive = true
+        holdTranscriptionState = .recording
         holdToTranscribePasteTarget = FocusedTextTarget.capture()
         pasteAfterRecordingCommands.insert(AgentCommand.toggleTranscription.identifier)
         run(.toggleTranscription)
     }
 
     func endHoldToTranscribe() {
-        guard holdToTranscribeActive else { return }
-        holdToTranscribeActive = false
-        pendingHoldToTranscribeStop = true
+        guard holdTranscriptionState == .recording else { return }
+        holdTranscriptionState = .awaitingPid
 
         let wasRecording = isRecordingCommand(.toggleTranscription)
         if wasRecording {
@@ -119,7 +133,7 @@ final class AgentCommandRunner: ObservableObject {
                     if shouldStartRecording {
                         self.clearPasteAfterRecording(for: command)
                     }
-                    self.clearHoldToTranscribeStopState(for: command)
+                    self.clearHoldTranscriptionState(for: command)
                     self.activeCommandCount = max(0, self.activeCommandCount - 1)
                     self.lastOutput = bootstrap.output
                     self.recordFailure(command: command, result: bootstrap)
@@ -143,7 +157,7 @@ final class AgentCommandRunner: ObservableObject {
 
             DispatchQueue.main.async {
                 if shouldStartRecording {
-                    self.clearHoldToTranscribeStopState(for: command)
+                    self.clearHoldTranscriptionState(for: command)
                     let shouldPaste = self.shouldPasteAfterRecording(for: command) && result.exitCode == 0
                     let pasteTarget = self.holdToTranscribePasteTarget
                     self.endRecordingIndicator(for: command)
@@ -182,9 +196,9 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     private func stopHeldTranscriptionWhenReady() {
-        guard pendingHoldToTranscribeStop, !holdStopRequestActive else { return }
+        guard holdTranscriptionState == .awaitingPid else { return }
 
-        holdStopRequestActive = true
+        holdTranscriptionState = .stopping
         statusMessage = "Stopping Toggle Transcription..."
 
         DispatchQueue.global(qos: .userInitiated).async {
@@ -192,15 +206,13 @@ final class AgentCommandRunner: ObservableObject {
 
             DispatchQueue.main.async {
                 if result.exitCode == 0 {
-                    self.holdStopRequestActive = false
-                    if self.pendingHoldToTranscribeStop {
+                    if self.holdTranscriptionState == .stopping {
                         self.statusMessage = "Transcribing..."
                     }
                     return
                 }
 
-                self.pendingHoldToTranscribeStop = false
-                self.holdStopRequestActive = false
+                self.holdTranscriptionState = .idle
                 let message = result.output.isEmpty
                     ? "Toggle Transcription stop failed with exit code \(result.exitCode)"
                     : "Toggle Transcription stop failed: \(result.output)"
@@ -239,10 +251,9 @@ final class AgentCommandRunner: ObservableObject {
         }
     }
 
-    private func clearHoldToTranscribeStopState(for command: AgentCommand) {
+    private func clearHoldTranscriptionState(for command: AgentCommand) {
         guard command.identifier == AgentCommand.toggleTranscription.identifier else { return }
-        pendingHoldToTranscribeStop = false
-        holdStopRequestActive = false
+        holdTranscriptionState = .idle
     }
 
     private func beginRecordingIndicator(for command: AgentCommand) {
@@ -250,10 +261,9 @@ final class AgentCommandRunner: ObservableObject {
         recordingCommandCount += 1
         isRecording = true
         VoiceLevelOverlayController.shared.show()
-        if command.identifier == AgentCommand.toggleTranscription.identifier {
-            if pendingHoldToTranscribeStop {
-                endRecordingIndicator(for: command)
-            }
+        if command.identifier == AgentCommand.toggleTranscription.identifier,
+           holdTranscriptionState == .awaitingPid {
+            endRecordingIndicator(for: command)
             stopHeldTranscriptionWhenReady()
         }
     }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -291,7 +291,7 @@ def test_macos_app_supports_configurable_hold_to_transcribe_shortcut() -> None:
     assert "runner.endHoldToTranscribe()" in source
     assert "func beginHoldToTranscribe()" in source
     assert "func endHoldToTranscribe()" in source
-    assert "private var holdToTranscribeActive = false" in source
+    assert "private var holdTranscriptionState: HoldTranscriptionState = .idle" in source
     assert "private var pasteAfterRecordingCommands: Set<String> = []" in source
 
 
@@ -300,6 +300,7 @@ def test_macos_app_hides_hold_recording_ui_immediately_on_key_release() -> None:
     source = swift_source()
 
     assert "let wasRecording = isRecordingCommand(.toggleTranscription)" in source
+    assert "holdTranscriptionState = .awaitingPid" in source
     assert (
         "if wasRecording {\n"
         "            endRecordingIndicator(for: .toggleTranscription)\n"
@@ -307,19 +308,17 @@ def test_macos_app_hides_hold_recording_ui_immediately_on_key_release() -> None:
         "            stopHeldTranscriptionWhenReady()" in source
     )
     assert (
-        "if pendingHoldToTranscribeStop {\n"
-        "                endRecordingIndicator(for: command)\n"
-        "            }\n"
+        "holdTranscriptionState == .awaitingPid {\n"
+        "            endRecordingIndicator(for: command)\n"
         "            stopHeldTranscriptionWhenReady()" in source
     )
     assert (
         "if shouldStartRecording {\n"
-        "                    self.clearHoldToTranscribeStopState(for: command)" in source
+        "                    self.clearHoldTranscriptionState(for: command)" in source
     )
     assert (
         "if result.exitCode == 0 {\n"
-        "                    self.holdStopRequestActive = false\n"
-        "                    if self.pendingHoldToTranscribeStop {\n"
+        "                    if self.holdTranscriptionState == .stopping {\n"
         '                        self.statusMessage = "Transcribing..."' in source
     )
 
@@ -328,23 +327,37 @@ def test_macos_app_clears_hold_stop_state_before_showing_finished_transcript() -
     """Hold-to-type should not leave the menu stuck on Transcribing after output is ready."""
     source = swift_source()
 
-    assert "private func clearHoldToTranscribeStopState(for command: AgentCommand)" in source
+    assert "private func clearHoldTranscriptionState(for command: AgentCommand)" in source
     assert (
-        "private func clearHoldToTranscribeStopState(for command: AgentCommand) {\n"
+        "private func clearHoldTranscriptionState(for command: AgentCommand) {\n"
         "        guard command.identifier == AgentCommand.toggleTranscription.identifier else { return }\n"
-        "        pendingHoldToTranscribeStop = false\n"
-        "        holdStopRequestActive = false\n"
+        "        holdTranscriptionState = .idle\n"
         "    }" in source
     )
-    assert "self.clearHoldToTranscribeStopState(for: command)" in source
+    assert "self.clearHoldTranscriptionState(for: command)" in source
     assert (
         "if result.exitCode == 0 {\n"
-        "                    self.holdStopRequestActive = false\n"
-        "                    if self.pendingHoldToTranscribeStop {\n"
+        "                    if self.holdTranscriptionState == .stopping {\n"
         '                        self.statusMessage = "Transcribing..."\n'
         "                    }\n"
         "                    return" in source
     )
+
+
+def test_macos_app_models_hold_to_transcribe_as_explicit_state() -> None:
+    """Hold-to-type coordination should use one state machine instead of boolean soup."""
+    source = swift_source()
+
+    assert "private enum HoldTranscriptionState" in source
+    assert "case idle" in source
+    assert "case recording" in source
+    assert "case awaitingPid" in source
+    assert "case stopping" in source
+    assert "private var holdTranscriptionState: HoldTranscriptionState = .idle" in source
+    assert "holdTranscriptionState.isFinishing" in source
+    assert "holdToTranscribeActive" not in source
+    assert "pendingHoldToTranscribeStop" not in source
+    assert "holdStopRequestActive" not in source
 
 
 def test_macos_app_uses_private_runtime_dir_for_hold_to_transcribe_stop() -> None:


### PR DESCRIPTION
## Summary
- Replace hold-to-transcribe boolean coordination with an explicit `HoldTranscriptionState` enum.
- Preserve the immediate recording UI shutdown on key release and finishing status while stop/transcription completes.
- Add source-shape coverage to prevent the old boolean soup from coming back.

## Test Plan
- `swift build -c release --package-path macos/AgentCLI`
- `uv run pytest tests/test_macos_app.py`
- `uv run pre-commit run --all-files`
- `macos/test-macos-app-e2e.sh`
