### PR TITLE
Add transcribe process control

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ the `[defaults]` section of your configuration file.
 │                                 [env var: GEMINI_API_KEY]                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Process Management ───────────────────────────────────────────────────────────────────╮
+│ --start           Start this command if it is not already running.                     │
 │ --stop            Stop any running instance of this command.                           │
 │ --status          Check if an instance is currently running.                           │
 │ --toggle          Start if not running, stop if running. Ideal for hotkey binding.     │

--- a/README.md
+++ b/README.md
@@ -856,10 +856,13 @@ the `[defaults]` section of your configuration file.
 │                                 [env var: GEMINI_API_KEY]                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Process Management ───────────────────────────────────────────────────────────────────╮
-│ --start           Start this command if it is not already running.                     │
-│ --stop            Stop any running instance of this command.                           │
-│ --status          Check if an instance is currently running.                           │
-│ --toggle          Start if not running, stop if running. Ideal for hotkey binding.     │
+│ --start                   Start this command if it is not already running.             │
+│ --stop                    Stop any running instance of this command.                   │
+│ --status                  Check if an instance is currently running.                   │
+│ --toggle                  Start if not running, stop if running. Ideal for hotkey      │
+│                           binding.                                                     │
+│ --wait-for-start          When stopping, wait briefly for a just-launched process to   │
+│                           write its PID.                                               │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ General Options ──────────────────────────────────────────────────────────────────────╮
 │ --clipboard              --no-clipboard                          Copy result to        │

--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -629,6 +629,7 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     stop: bool = opts.STOP,
     status: bool = opts.STATUS,
     toggle: bool = opts.TOGGLE,
+    wait_for_start: bool = opts.WAIT_FOR_START,
     # --- General Options ---
     clipboard: bool = opts.CLIPBOARD,
     log_level: opts.LogLevel = opts.LOG_LEVEL,
@@ -886,6 +887,7 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
         toggle,
         quiet=general_cfg.quiet,
         json_output=json_output,
+        wait_for_start_seconds=300.0 if wait_for_start else 0.0,
     ):
         return
 

--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -625,6 +625,7 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     gemini_api_key: str | None = opts.GEMINI_API_KEY,
     llm: bool = opts.LLM,
     # --- Process Management ---
+    start: bool = opts.START,
     stop: bool = opts.STOP,
     status: bool = opts.STATUS,
     toggle: bool = opts.TOGGLE,
@@ -854,6 +855,29 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
 
     # Normal recording mode
     process_name = "transcribe"
+    if start:
+        process_status = process.get_process_status(process_name)
+        if process_status.running:
+            if json_output:
+                print(
+                    json.dumps(
+                        {
+                            "action": "start",
+                            "process": process_name,
+                            "running": True,
+                            "status": "running",
+                            "pid": process_status.pid,
+                            "stale_cleaned": process_status.stale_cleaned,
+                        },
+                    ),
+                )
+            elif not general_cfg.quiet:
+                print_with_style(
+                    f"✅ Transcribe is already running (PID: {process_status.pid}).",
+                    style="green",
+                )
+            return
+
     if stop_or_status_or_toggle(
         process_name,
         "transcribe",
@@ -861,24 +885,25 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
         status,
         toggle,
         quiet=general_cfg.quiet,
+        json_output=json_output,
     ):
         return
 
-    audio_in_cfg = config.AudioInput(
-        input_device_index=input_device_index,
-        input_device_name=input_device_name,
-    )
-
-    # We only use setup_devices for its input device handling
-    device_info = setup_devices(general_cfg, audio_in_cfg, None)
-    if device_info is None:
-        return
-    input_device_index, _, _ = device_info
-    audio_in_cfg.input_device_index = input_device_index
-
-    # Use context manager for PID file management
+    # Use context manager before audio setup so --stop can target startup reliably.
     try:
         with process.pid_file_context(process_name), suppress(KeyboardInterrupt):
+            audio_in_cfg = config.AudioInput(
+                input_device_index=input_device_index,
+                input_device_name=input_device_name,
+            )
+
+            # We only use setup_devices for its input device handling
+            device_info = setup_devices(general_cfg, audio_in_cfg, None)
+            if device_info is None:
+                return
+            input_device_index, _, _ = device_info
+            audio_in_cfg.input_device_index = input_device_index
+
             result = asyncio.run(
                 _async_main(
                     extra_instructions=extra_instructions,

--- a/agent_cli/core/process.py
+++ b/agent_cli/core/process.py
@@ -24,6 +24,24 @@ class _PidInfo(NamedTuple):
     uses_lock: bool
 
 
+class ProcessStatus(NamedTuple):
+    """Current state of a managed Agent CLI process."""
+
+    process_name: str
+    running: bool
+    pid: int | None
+    stale_cleaned: bool = False
+
+
+class StopProcessResult(NamedTuple):
+    """Result of a stop request for a managed Agent CLI process."""
+
+    process_name: str
+    was_running: bool
+    status: ProcessStatus
+    stale_cleaned: bool = False
+
+
 def _default_pid_dir() -> Path:
     """Return local runtime dir for process control files."""
     if runtime_dir := os.environ.get("AGENTCLI_RUNTIME_DIR"):
@@ -116,8 +134,10 @@ def _is_pid_running(pid: int) -> bool:
     try:
         os.kill(pid, 0)
         return True
-    except (ProcessLookupError, PermissionError):
+    except ProcessLookupError:
         return False
+    except PermissionError:
+        return True
 
 
 def _supports_process_locks() -> bool:
@@ -233,25 +253,46 @@ def _cleanup_process_files(process_name: str) -> None:
     clear_stop_file(process_name)
 
 
-def _get_running_pid(process_name: str) -> int | None:
-    """Get PID if process is running, None otherwise. Cleans up stale files."""
+def get_process_status(process_name: str) -> ProcessStatus:
+    """Return process state and deterministically clean stale control files."""
     if not _get_pid_file(process_name).exists():
-        return None
+        return ProcessStatus(process_name=process_name, running=False, pid=None)
 
     pid_info = _read_pid_info(process_name)
     if pid_info is None:
         _cleanup_process_files(process_name)
-        return None
+        return ProcessStatus(
+            process_name=process_name,
+            running=False,
+            pid=None,
+            stale_cleaned=True,
+        )
 
     if pid_info.uses_lock and _supports_process_locks() and not _is_process_lock_held(process_name):
         _cleanup_process_files(process_name)
-        return None
+        return ProcessStatus(
+            process_name=process_name,
+            running=False,
+            pid=None,
+            stale_cleaned=True,
+        )
 
     if _is_pid_running(pid_info.pid):
-        return pid_info.pid
+        return ProcessStatus(process_name=process_name, running=True, pid=pid_info.pid)
 
     _cleanup_process_files(process_name)
-    return None
+    return ProcessStatus(
+        process_name=process_name,
+        running=False,
+        pid=None,
+        stale_cleaned=True,
+    )
+
+
+def _get_running_pid(process_name: str) -> int | None:
+    """Get PID if process is running, None otherwise. Cleans up stale files."""
+    status = get_process_status(process_name)
+    return status.pid if status.running else None
 
 
 def is_process_running(process_name: str) -> bool:
@@ -264,27 +305,8 @@ def read_pid_file(process_name: str) -> int | None:
     return _get_running_pid(process_name)
 
 
-def kill_process(process_name: str) -> bool:
-    """Kill a process by name.
-
-    Returns True if killed or cleaned up, False if not found.
-    On Windows, creates a stop file first to allow graceful shutdown.
-    """
-    pid_file = _get_pid_file(process_name)
-
-    # If no PID file exists at all, nothing to do
-    if not pid_file.exists():
-        clear_stop_file(process_name)
-        return False
-
-    # Check if we have a running process
-    pid = _get_running_pid(process_name)
-
-    # If _get_running_pid returned None but file existed, it cleaned up a stale file
-    if pid is None:
-        clear_stop_file(process_name)
-        return True
-
+def _signal_running_process(process_name: str, pid: int) -> None:
+    """Signal a known-running process and clean control files if it exits."""
     stop_file = _get_stop_file(process_name)
     should_force_kill = sys.platform != "win32" and stop_file.exists()
 
@@ -317,7 +339,44 @@ def kill_process(process_name: str) -> bool:
     elif not should_force_kill:
         stop_file.touch()
 
-    return True
+
+def stop_process(process_name: str) -> StopProcessResult:
+    """Stop a process by name and return the resulting process state."""
+    initial_status = get_process_status(process_name)
+    if not initial_status.running or initial_status.pid is None:
+        clear_stop_file(process_name)
+        return StopProcessResult(
+            process_name=process_name,
+            was_running=False,
+            status=initial_status,
+            stale_cleaned=initial_status.stale_cleaned,
+        )
+
+    _signal_running_process(process_name, initial_status.pid)
+    status = get_process_status(process_name)
+    return StopProcessResult(
+        process_name=process_name,
+        was_running=True,
+        status=status,
+        stale_cleaned=initial_status.stale_cleaned or status.stale_cleaned,
+    )
+
+
+def kill_process(process_name: str) -> bool:
+    """Kill a process by name.
+
+    Returns True if killed or cleaned up, False if not found.
+    On Windows, creates a stop file first to allow graceful shutdown.
+    """
+    pid_file = _get_pid_file(process_name)
+
+    # If no PID file exists at all, nothing to do
+    if not pid_file.exists():
+        clear_stop_file(process_name)
+        return False
+
+    result = stop_process(process_name)
+    return result.was_running or result.stale_cleaned
 
 
 @contextmanager

--- a/agent_cli/core/process.py
+++ b/agent_cli/core/process.py
@@ -305,6 +305,21 @@ def read_pid_file(process_name: str) -> int | None:
     return _get_running_pid(process_name)
 
 
+def _wait_for_process_start(
+    process_name: str,
+    *,
+    wait_for_start_seconds: float,
+    poll_interval: float,
+) -> ProcessStatus:
+    """Wait briefly for a just-launched process to write its PID file."""
+    deadline = time.monotonic() + wait_for_start_seconds
+    status = get_process_status(process_name)
+    while not status.running and time.monotonic() < deadline:
+        time.sleep(poll_interval)
+        status = get_process_status(process_name)
+    return status
+
+
 def _signal_running_process(process_name: str, pid: int) -> None:
     """Signal a known-running process and clean control files if it exits."""
     stop_file = _get_stop_file(process_name)
@@ -340,9 +355,21 @@ def _signal_running_process(process_name: str, pid: int) -> None:
         stop_file.touch()
 
 
-def stop_process(process_name: str) -> StopProcessResult:
+def stop_process(
+    process_name: str,
+    *,
+    wait_for_start_seconds: float = 0.0,
+    poll_interval: float = 0.1,
+) -> StopProcessResult:
     """Stop a process by name and return the resulting process state."""
     initial_status = get_process_status(process_name)
+    if not initial_status.running and wait_for_start_seconds > 0:
+        initial_status = _wait_for_process_start(
+            process_name,
+            wait_for_start_seconds=wait_for_start_seconds,
+            poll_interval=poll_interval,
+        )
+
     if not initial_status.running or initial_status.pid is None:
         clear_stop_file(process_name)
         return StopProcessResult(

--- a/agent_cli/core/utils.py
+++ b/agent_cli/core/utils.py
@@ -326,6 +326,89 @@ def signal_handling_context(
             signal.signal(signum, previous)
 
 
+def _process_status_payload(
+    *,
+    action: str,
+    process_name: str,
+    process_status: process.ProcessStatus,
+    was_running: bool | None = None,
+    stale_cleaned: bool | None = None,
+) -> dict[str, object]:
+    """Build machine-readable process control output."""
+    payload: dict[str, object] = {
+        "action": action,
+        "process": process_name,
+        "running": process_status.running,
+        "status": "running" if process_status.running else "stopped",
+        "pid": process_status.pid,
+        "stale_cleaned": (process_status.stale_cleaned if stale_cleaned is None else stale_cleaned),
+    }
+    if was_running is not None:
+        payload["was_running"] = was_running
+    return payload
+
+
+def _handle_process_stop(
+    process_name: str,
+    which: str,
+    *,
+    quiet: bool,
+    json_output: bool,
+) -> bool:
+    """Handle a process stop request."""
+    if json_output:
+        result = process.stop_process(process_name)
+        print(
+            json.dumps(
+                _process_status_payload(
+                    action="stop",
+                    process_name=process_name,
+                    process_status=result.status,
+                    was_running=result.was_running,
+                    stale_cleaned=result.stale_cleaned,
+                ),
+            ),
+        )
+        return True
+
+    if process.kill_process(process_name):
+        if not quiet:
+            print_with_style(f"✅ {which.capitalize()} stopped.")
+    elif not quiet:
+        print_with_style(f"⚠️  No {which} is running.", style="yellow")
+    return True
+
+
+def _handle_process_status(
+    process_name: str,
+    which: str,
+    *,
+    quiet: bool,
+    json_output: bool,
+) -> bool:
+    """Handle a process status request."""
+    if json_output:
+        process_status = process.get_process_status(process_name)
+        print(
+            json.dumps(
+                _process_status_payload(
+                    action="status",
+                    process_name=process_name,
+                    process_status=process_status,
+                ),
+            ),
+        )
+        return True
+
+    if process.is_process_running(process_name):
+        pid = process.read_pid_file(process_name)
+        if not quiet:
+            print_with_style(f"✅ {which.capitalize()} is running (PID: {pid}).")
+    elif not quiet:
+        print_with_style(f"⚠️ {which.capitalize()} is not running.", style="yellow")
+    return True
+
+
 def stop_or_status_or_toggle(
     process_name: str,
     which: str,
@@ -334,24 +417,24 @@ def stop_or_status_or_toggle(
     toggle: bool,
     *,
     quiet: bool = False,
+    json_output: bool = False,
 ) -> bool:
     """Handle process control for a given process name."""
     if stop:
-        if process.kill_process(process_name):
-            if not quiet:
-                print_with_style(f"✅ {which.capitalize()} stopped.")
-        elif not quiet:
-            print_with_style(f"⚠️  No {which} is running.", style="yellow")
-        return True
+        return _handle_process_stop(
+            process_name,
+            which,
+            quiet=quiet,
+            json_output=json_output,
+        )
 
     if status:
-        if process.is_process_running(process_name):
-            pid = process.read_pid_file(process_name)
-            if not quiet:
-                print_with_style(f"✅ {which.capitalize()} is running (PID: {pid}).")
-        elif not quiet:
-            print_with_style(f"⚠️ {which.capitalize()} is not running.", style="yellow")
-        return True
+        return _handle_process_status(
+            process_name,
+            which,
+            quiet=quiet,
+            json_output=json_output,
+        )
 
     if toggle:
         if process.is_process_running(process_name):

--- a/agent_cli/core/utils.py
+++ b/agent_cli/core/utils.py
@@ -354,10 +354,14 @@ def _handle_process_stop(
     *,
     quiet: bool,
     json_output: bool,
+    wait_for_start_seconds: float,
 ) -> bool:
     """Handle a process stop request."""
     if json_output:
-        result = process.stop_process(process_name)
+        result = process.stop_process(
+            process_name,
+            wait_for_start_seconds=wait_for_start_seconds,
+        )
         print(
             json.dumps(
                 _process_status_payload(
@@ -371,7 +375,16 @@ def _handle_process_stop(
         )
         return True
 
-    if process.kill_process(process_name):
+    if wait_for_start_seconds > 0:
+        result = process.stop_process(
+            process_name,
+            wait_for_start_seconds=wait_for_start_seconds,
+        )
+        stopped = result.was_running or result.stale_cleaned
+    else:
+        stopped = process.kill_process(process_name)
+
+    if stopped:
         if not quiet:
             print_with_style(f"✅ {which.capitalize()} stopped.")
     elif not quiet:
@@ -418,6 +431,7 @@ def stop_or_status_or_toggle(
     *,
     quiet: bool = False,
     json_output: bool = False,
+    wait_for_start_seconds: float = 0.0,
 ) -> bool:
     """Handle process control for a given process name."""
     if stop:
@@ -426,6 +440,7 @@ def stop_or_status_or_toggle(
             which,
             quiet=quiet,
             json_output=json_output,
+            wait_for_start_seconds=wait_for_start_seconds,
         )
 
     if status:

--- a/agent_cli/opts.py
+++ b/agent_cli/opts.py
@@ -350,6 +350,12 @@ TOGGLE: bool = typer.Option(
     help="Start if not running, stop if running. Ideal for hotkey binding.",
     rich_help_panel="Process Management",
 )
+WAIT_FOR_START: bool = typer.Option(
+    False,  # noqa: FBT003
+    "--wait-for-start",
+    help="When stopping, wait briefly for a just-launched process to write its PID.",
+    rich_help_panel="Process Management",
+)
 
 # --- General Options ---
 

--- a/agent_cli/opts.py
+++ b/agent_cli/opts.py
@@ -326,6 +326,12 @@ TTS_GEMINI_VOICE: str = typer.Option(
 
 
 # --- Process Management Options ---
+START: bool = typer.Option(
+    False,  # noqa: FBT003
+    "--start",
+    help="Start this command if it is not already running.",
+    rich_help_panel="Process Management",
+)
 STOP: bool = typer.Option(
     False,  # noqa: FBT003
     "--stop",

--- a/docs/commands/transcribe.md
+++ b/docs/commands/transcribe.md
@@ -172,6 +172,7 @@ The `--from-file` option supports multiple audio formats:
 | `--stop` | `false` | Stop any running instance of this command. |
 | `--status` | `false` | Check if an instance is currently running. |
 | `--toggle` | `false` | Start if not running, stop if running. Ideal for hotkey binding. |
+| `--wait-for-start` | `false` | When stopping, wait briefly for a just-launched process to write its PID. |
 
 ### General Options
 

--- a/docs/commands/transcribe.md
+++ b/docs/commands/transcribe.md
@@ -168,6 +168,7 @@ The `--from-file` option supports multiple audio formats:
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `--start` | `false` | Start this command if it is not already running. |
 | `--stop` | `false` | Stop any running instance of this command. |
 | `--status` | `false` | Check if an instance is currently running. |
 | `--toggle` | `false` | Start if not running, stop if running. Ideal for hotkey binding. |

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -66,7 +66,7 @@ final class AgentCommandRunner: ObservableObject {
         URL(string: "x-apple.systempreferences:com.apple.Security-Privacy.extension?Privacy_Accessibility")!,
         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     ]
-    private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#
+    private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet --wait-for-start"#
 
     func beginHoldToTranscribe() {
         guard holdTranscriptionState == .idle else {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -66,7 +66,7 @@ final class AgentCommandRunner: ObservableObject {
         URL(string: "x-apple.systempreferences:com.apple.Security-Privacy.extension?Privacy_Accessibility")!,
         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     ]
-    private static let holdStopShell = #"for attempt in {1..3000}; do if [ -s "$AGENTCLI_RUNTIME_DIR/transcribe.pid" ]; then "$AGENTCLI_AGENT_CLI" transcribe --stop --quiet; exit $?; fi; sleep 0.1; done; "$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#
+    private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#
 
     func beginHoldToTranscribe() {
         guard holdTranscriptionState == .idle else {

--- a/tests/agents/test_transcribe_agent.py
+++ b/tests/agents/test_transcribe_agent.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
 from agent_cli.cli import app
+from agent_cli.core import process
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    import pytest
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
 
@@ -39,6 +49,51 @@ def test_transcribe_agent(
     mock_create_transcriber.assert_called_once()
     mock_transcriber.assert_called_once()
     mock_copy.assert_called_once_with("hello")
+
+
+@patch("agent_cli.agents.transcribe.asr.create_transcriber")
+@patch("agent_cli.agents.transcribe.setup_devices")
+def test_transcribe_start_writes_pid_before_audio_setup(
+    mock_setup_devices: MagicMock,
+    mock_create_transcriber: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Explicit start should enter the PID context before audio setup can block."""
+    events: list[str] = []
+    mock_transcriber = AsyncMock(return_value="hello")
+    mock_create_transcriber.return_value = mock_transcriber
+
+    def setup_devices(*_args: object, **_kwargs: object) -> tuple[int, str, None]:
+        events.append("setup_devices")
+        return (0, "mock_device", None)
+
+    @contextmanager
+    def pid_file_context(process_name: str) -> Generator[Path, None, None]:
+        events.append(f"pid_enter:{process_name}")
+        yield tmp_path / "transcribe.pid"
+        events.append(f"pid_exit:{process_name}")
+
+    mock_setup_devices.side_effect = setup_devices
+    with (
+        patch("agent_cli.agents.transcribe.process.pid_file_context", pid_file_context),
+        patch("pyperclip.copy"),
+        patch("pyperclip.paste", return_value=""),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "transcribe",
+                "--start",
+                "--asr-provider",
+                "wyoming",
+                "--openai-api-key",
+                "test",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert events[0] == "pid_enter:transcribe"
+    assert events[1] == "setup_devices"
 
 
 @patch("agent_cli.agents.transcribe.process.kill_process")
@@ -77,3 +132,52 @@ def test_transcribe_status_not_running(mock_is_process_running: MagicMock) -> No
     result = runner.invoke(app, ["transcribe", "--status"])
     assert result.exit_code == 0
     assert "Transcribe is not running" in result.stdout
+
+
+def test_transcribe_status_json_running() -> None:
+    """Transcribe status should support machine-readable process state."""
+    with patch(
+        "agent_cli.agents.transcribe.process.get_process_status",
+        return_value=process.ProcessStatus(
+            process_name="transcribe",
+            running=True,
+            pid=123,
+            stale_cleaned=False,
+        ),
+    ):
+        result = runner.invoke(app, ["transcribe", "--status", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "action": "status",
+        "process": "transcribe",
+        "running": True,
+        "status": "running",
+        "pid": 123,
+        "stale_cleaned": False,
+    }
+
+
+def test_transcribe_stop_json_cleans_stale_pid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping with a stale PID should clean it and report stopped as JSON."""
+    monkeypatch.setattr(process, "PID_DIR", tmp_path)
+    pid_file = process._get_pid_file("transcribe")
+    pid_file.write_text("999999")
+
+    with patch("agent_cli.core.process._is_pid_running", return_value=False):
+        result = runner.invoke(app, ["transcribe", "--stop", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "stop"
+    assert payload["process"] == "transcribe"
+    assert payload["running"] is False
+    assert payload["status"] == "stopped"
+    assert payload["pid"] is None
+    assert payload["was_running"] is False
+    assert payload["stale_cleaned"] is True
+    assert not pid_file.exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.console import Console
 
-from agent_cli.core import deps
+from agent_cli.core import deps, utils
 
 
 def _mock__check_extra_installed(extra: str) -> bool:  # noqa: ARG001
@@ -53,6 +53,13 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 def mock_console() -> Console:
     """Provide a console that writes to a StringIO for testing."""
     return Console(file=io.StringIO(), width=80, force_terminal=True)
+
+
+@pytest.fixture(autouse=True)
+def reset_rich_console_quiet() -> None:
+    """Prevent JSON-mode CLI tests from silencing later command output."""
+    utils.console.quiet = False
+    utils.err_console.quiet = False
 
 
 @pytest.fixture

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -92,6 +92,8 @@ def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
 
     assert "MenuBarExtra" in source
     assert '"$AGENTCLI_AGENT_CLI" transcribe --toggle --quiet' in source
+    assert '"$AGENTCLI_AGENT_CLI" transcribe --stop --quiet' in source
+    assert "transcribe.pid" not in source
     assert "transcribe --toggle --llm --quiet" not in source
     assert '"$AGENTCLI_AGENT_CLI" voice-edit --toggle --quiet' in source
     assert '"$AGENTCLI_AGENT_CLI" autocorrect --quiet' in source
@@ -362,8 +364,8 @@ def test_macos_app_models_hold_to_transcribe_as_explicit_state() -> None:
     assert "holdStopRequestActive" not in source
 
 
-def test_macos_app_uses_private_runtime_dir_for_hold_to_transcribe_stop() -> None:
-    """Hold-to-type stop should watch the same PID dir that the app passes to agent-cli."""
+def test_macos_app_uses_cli_owned_hold_to_transcribe_stop() -> None:
+    """Hold-to-type stop should use CLI process control, not PID polling in Swift."""
     source = swift_source()
     launchd = (ROOT / "agent_cli" / "install" / "launchd.py").read_text()
 
@@ -374,7 +376,11 @@ def test_macos_app_uses_private_runtime_dir_for_hold_to_transcribe_stop() -> Non
         "try fileManager.createDirectory(at: runtimeURL, withIntermediateDirectories: true)"
         in source
     )
-    assert '"$AGENTCLI_RUNTIME_DIR/transcribe.pid"' in source
+    assert (
+        'private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#'
+        in source
+    )
+    assert "transcribe.pid" not in source
     assert '"$HOME/.cache/agent-cli/transcribe.pid"' not in source
     assert '"AGENTCLI_RUNTIME_DIR"' in launchd
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -377,7 +377,7 @@ def test_macos_app_uses_cli_owned_hold_to_transcribe_stop() -> None:
         in source
     )
     assert (
-        'private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet"#'
+        'private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet --wait-for-start"#'
         in source
     )
     assert "transcribe.pid" not in source

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -84,6 +84,27 @@ def test_is_process_running_dead_process() -> None:
     assert not pid_file.exists()
 
 
+@patch("agent_cli.core.process._is_pid_running", return_value=False)
+def test_get_process_status_cleans_stale_pid(
+    mock_is_pid_running: MagicMock,  # noqa: ARG001
+) -> None:
+    """Status should deterministically remove a stale PID and report stopped."""
+    process_name = "test-process"
+    pid_file = process._get_pid_file(process_name)
+    stop_file = process._get_stop_file(process_name)
+    pid_file.write_text("999999")
+    stop_file.write_text("1")
+
+    status = process.get_process_status(process_name)
+
+    assert status.process_name == process_name
+    assert status.running is False
+    assert status.pid is None
+    assert status.stale_cleaned is True
+    assert not pid_file.exists()
+    assert not stop_file.exists()
+
+
 def test_is_process_running_current_process() -> None:
     """Test checking if a process is running with current process PID."""
     process_name = "test-process"
@@ -216,6 +237,35 @@ def test_kill_process_not_running_clears_stop_file(temp_pid_dir: Path) -> None:
 
     assert result is False
     assert not stop_file.exists()
+
+
+def test_stop_process_is_idempotent_when_missing() -> None:
+    """Stopping with no PID file should be a no-op stopped result."""
+    result = process.stop_process("test-process")
+
+    assert result.process_name == "test-process"
+    assert result.was_running is False
+    assert result.status.running is False
+    assert result.status.pid is None
+    assert result.stale_cleaned is False
+
+
+@patch("agent_cli.core.process._is_pid_running", return_value=False)
+def test_stop_process_cleans_stale_pid_and_reports_stopped(
+    mock_is_pid_running: MagicMock,  # noqa: ARG001
+) -> None:
+    """Stopping a stale PID should clean it and still report stopped."""
+    process_name = "test-process"
+    pid_file = process._get_pid_file(process_name)
+    pid_file.write_text("999999")
+
+    result = process.stop_process(process_name)
+
+    assert result.was_running is False
+    assert result.status.running is False
+    assert result.status.pid is None
+    assert result.stale_cleaned is True
+    assert not pid_file.exists()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SIGKILL escalation is Unix-only")

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -250,6 +250,37 @@ def test_stop_process_is_idempotent_when_missing() -> None:
     assert result.stale_cleaned is False
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="os.kill(pid, 0) not used on Windows")
+@patch("agent_cli.core.process._is_pid_running", side_effect=[True, False])
+@patch("os.kill")
+def test_stop_process_waits_for_starting_pid(
+    mock_os_kill: MagicMock,
+    mock_is_pid_running: MagicMock,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop can wait for a just-launched process to write its PID."""
+    process_name = "test-process"
+    pid_file = process._get_pid_file(process_name)
+    current_pid = os.getpid()
+
+    def write_pid(_seconds: float) -> None:
+        pid_file.write_text(str(current_pid))
+
+    monkeypatch.setattr(process.time, "sleep", write_pid)
+
+    result = process.stop_process(
+        process_name,
+        wait_for_start_seconds=1.0,
+        poll_interval=0.1,
+    )
+
+    assert result.was_running is True
+    assert result.status.running is False
+    assert result.status.pid is None
+    mock_os_kill.assert_any_call(current_pid, signal.SIGINT)
+    assert not pid_file.exists()
+
+
 @patch("agent_cli.core.process._is_pid_running", return_value=False)
 def test_stop_process_cleans_stale_pid_and_reports_stopped(
     mock_is_pid_running: MagicMock,  # noqa: ARG001


### PR DESCRIPTION
## Summary
- add shared process status/stop result helpers with deterministic stale PID cleanup
- add `agent-cli transcribe --start` and JSON process-control output for transcribe status/stop
- move transcribe PID context before audio setup and remove macOS Swift PID polling

## Verification
- `uv run pytest tests/test_process_manager.py tests/agents/test_transcribe_agent.py tests/test_macos_app.py tests/test_docs_gen.py -q`
- `uv run agent-cli transcribe --status --json`
- `uv run agent-cli transcribe --stop --json`
- `uv run pre-commit run --all-files`
