### PR TITLE
Add macOS release publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,3 +20,42 @@ jobs:
         run: uv build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  build_macos_app:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+      - name: Import Developer ID certificate
+        uses: apple-actions/import-codesign-certs@v7
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      - name: Resolve Developer ID identity
+        id: codesign
+        run: |
+          IDENTITY=$(
+            security find-identity -v -p codesigning |
+              awk -F '"' '/Developer ID Application/ { print $2; exit }'
+          )
+          if [[ -z "$IDENTITY" ]]; then
+            echo "Developer ID Application signing identity not found." >&2
+            exit 1
+          fi
+          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+      - name: Build notarized macOS DMG
+        env:
+          CODESIGN_IDENTITY: ${{ steps.codesign.outputs.identity }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: NOTARIZE=1 macos/build-macos-app.sh --dmg
+      - name: Upload macOS app to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" dist/macos/AgentCLI.dmg --clobber

--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -68,3 +68,30 @@ or DMG:
 ```bash
 CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" ./macos/build-macos-app.sh --dmg
 ```
+
+To notarize during the build, set `NOTARIZE=1` and provide Apple notary
+credentials:
+
+```bash
+CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+NOTARIZE=1 \
+APPLE_ID="you@example.com" \
+APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx" \
+APPLE_TEAM_ID="TEAMID" \
+./macos/build-macos-app.sh --dmg
+```
+
+## Release CI
+
+Publishing a GitHub release runs `.github/workflows/release.yml`, which imports
+the Developer ID certificate with `apple-actions/import-codesign-certs`, builds,
+notarizes, staples, and uploads `dist/macos/AgentCLI.dmg` to the release. The
+workflow expects these repository secrets:
+
+- `MACOS_CODESIGN_CERTIFICATE_BASE64`: base64-encoded Developer ID Application
+  `.p12` certificate export
+- `MACOS_CODESIGN_CERTIFICATE_PASSWORD`: password for that `.p12`
+- `MACOS_KEYCHAIN_PASSWORD`: temporary CI keychain password
+- `APPLE_ID`: Apple ID email for notarization
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for `notarytool`
+- `APPLE_TEAM_ID`: Apple Developer Team ID

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -23,6 +23,11 @@ Environment:
   UV_BINARY          uv binary to bundle. Defaults to the uv found on PATH.
   INSTALL_DIR        Install destination. Defaults to /Applications.
   AGENTCLI_SKIP_OPEN Set to 1 to skip opening the app after --install.
+  NOTARIZE           Set to 1 to notarize and staple the DMG. Requires --dmg.
+  APPLE_ID           Apple ID email used for notarization.
+  APPLE_APP_SPECIFIC_PASSWORD
+                     App-specific password used by xcrun notarytool.
+  APPLE_TEAM_ID      Apple Developer Team ID used for notarization.
 EOF
 }
 
@@ -62,6 +67,7 @@ APP_ICON_ICNS="$DIST_DIR/AgentCLI.icns"
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
 UV_BINARY=${UV_BINARY:-$(command -v uv || true)}
 INSTALL_DIR=${INSTALL_DIR:-/Applications}
+NOTARIZE=${NOTARIZE:-0}
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This script builds a macOS .app bundle and must run on macOS." >&2
@@ -89,6 +95,66 @@ if [[ ! -f "$MENU_BAR_LOGO_SVG" ]]; then
     echo "AgentCLI menu bar logo SVG is missing: $MENU_BAR_LOGO_SVG" >&2
     exit 1
 fi
+
+if [[ "$NOTARIZE" == "1" && "$CREATE_DMG" != true ]]; then
+    echo "NOTARIZE=1 requires --dmg so there is a distributable artifact to notarize." >&2
+    exit 1
+fi
+
+codesign_args() {
+    printf '%s\0' --force --deep --sign "$CODESIGN_IDENTITY"
+    if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
+        printf '%s\0' --timestamp --options runtime
+    fi
+}
+
+sign_app() {
+    local target="$1"
+    local args=()
+    while IFS= read -r -d '' arg; do
+        args+=("$arg")
+    done < <(codesign_args)
+
+    codesign "${args[@]}" "$target"
+}
+
+sign_dmg_if_needed() {
+    local dmg_path="$1"
+    if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
+        return
+    fi
+
+    codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$dmg_path"
+}
+
+require_notarization_env() {
+    if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
+        echo "A Developer ID signing identity is required when NOTARIZE=1." >&2
+        exit 1
+    fi
+
+    for variable in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+        if [[ -z "${!variable:-}" ]]; then
+            echo "$variable is required when NOTARIZE=1." >&2
+            exit 1
+        fi
+    done
+}
+
+notarize_dmg() {
+    local dmg_path="$1"
+
+    require_notarization_env
+    echo "Submitting $dmg_path for Apple notarization..."
+    xcrun notarytool submit "$dmg_path" \
+        --apple-id "$APPLE_ID" \
+        --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+        --team-id "$APPLE_TEAM_ID" \
+        --wait
+    xcrun stapler staple "$dmg_path"
+    xcrun stapler validate "$dmg_path"
+    echo "Notarized and stapled $dmg_path"
+}
 
 render_logo_png() {
     local size="$1"
@@ -218,7 +284,7 @@ test -f "$APP_DIR/Contents/Resources/AgentCLI.icns" || {
     exit 1
 }
 
-codesign --force --deep --sign "$CODESIGN_IDENTITY" "$APP_DIR"
+sign_app "$APP_DIR"
 
 echo "Built $APP_DIR"
 
@@ -240,6 +306,10 @@ if [[ "$CREATE_DMG" == true ]]; then
         fi
         sleep 2
     done
+    sign_dmg_if_needed "$DMG_PATH"
+    if [[ "$NOTARIZE" == "1" ]]; then
+        notarize_dmg "$DMG_PATH"
+    fi
     echo "Built $DMG_PATH"
 fi
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import plistlib
+import re
 import shutil
 import stat
 import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 MACOS_APP = ROOT / "macos" / "AgentCLI"
 SWIFT_SOURCE_DIR = MACOS_APP / "Sources" / "AgentCLI"
 BUILD_SCRIPT = ROOT / "macos" / "build-macos-app.sh"
@@ -669,6 +671,47 @@ def test_macos_build_script_creates_signed_app_bundle() -> None:
     assert "--install" in script
     assert "--dmg" in script
     assert "hdiutil create" in script
+
+
+def test_macos_build_script_can_notarize_release_dmg() -> None:
+    """Release builds should notarize and staple a Developer ID-signed DMG."""
+    script = BUILD_SCRIPT.read_text()
+
+    assert "NOTARIZE" in script
+    assert "APPLE_ID" in script
+    assert "APPLE_APP_SPECIFIC_PASSWORD" in script
+    assert "APPLE_TEAM_ID" in script
+    assert "xcrun notarytool submit" in script
+    assert "--wait" in script
+    assert "xcrun stapler staple" in script
+    assert "xcrun stapler validate" in script
+    assert "--timestamp" in script
+    assert "--options runtime" in script
+    assert "Developer ID signing identity" in script
+
+
+def test_release_workflow_publishes_macos_app_asset() -> None:
+    """Publishing a GitHub release should attach the notarized macOS DMG."""
+    workflow = RELEASE_WORKFLOW.read_text()
+
+    assert "build_macos_app" in workflow
+    assert re.search(r"build_macos_app:\n\s+runs-on: macos-latest", workflow)
+    assert "contents: write" in workflow
+    assert "MACOS_CODESIGN_CERTIFICATE_BASE64" in workflow
+    assert "MACOS_CODESIGN_CERTIFICATE_PASSWORD" in workflow
+    assert "MACOS_KEYCHAIN_PASSWORD" in workflow
+    assert "APPLE_ID" in workflow
+    assert "APPLE_APP_SPECIFIC_PASSWORD" in workflow
+    assert "APPLE_TEAM_ID" in workflow
+    assert "apple-actions/import-codesign-certs@v7" in workflow
+    assert "p12-file-base64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_BASE64 }}" in workflow
+    assert "p12-password: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}" in workflow
+    assert "security create-keychain" not in workflow
+    assert "security import" not in workflow
+    assert "macos/build-macos-app.sh --dmg" in workflow
+    assert "NOTARIZE=1" in workflow
+    assert "gh release upload" in workflow
+    assert "dist/macos/AgentCLI.dmg" in workflow
 
 
 def test_macos_app_bootstraps_private_uv_runtime() -> None:


### PR DESCRIPTION
## Summary
- add a macOS release job that imports the Developer ID certificate with `apple-actions/import-codesign-certs`, builds a signed DMG, notarizes/staples it, and uploads it to the GitHub Release
- teach `macos/build-macos-app.sh` to sign with hardened runtime, notarize release DMGs, and validate stapling
- document local notarization plus the required GitHub Actions secrets, and add tests covering the release workflow wiring

## Release credentials
Configured repo secrets for:
- `MACOS_CODESIGN_CERTIFICATE_BASE64`
- `MACOS_CODESIGN_CERTIFICATE_PASSWORD`
- `MACOS_KEYCHAIN_PASSWORD`
- `APPLE_ID`
- `APPLE_APP_SPECIFIC_PASSWORD`
- `APPLE_TEAM_ID`

Created Apple Developer ID Application certificate `82QW9J3AFQ` for team `DNA6966LGZ`.

## Verification
- `uv run pytest tests/test_macos_app.py -q`
- `bash -n macos/build-macos-app.sh && bash -n macos/test-macos-app-e2e.sh`
- `./macos/test-macos-app-e2e.sh`
- `PYTHON_DOTENV_DISABLED=1 env -u OPENAI_API_KEY uv run --all-extras pytest`
- `pre-commit run --all-files`
- `git diff --cached --check`
