### PR TITLE
Fix macOS release notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Publish Release
 
 on:
   release:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    name: Publish Python package
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -22,6 +23,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   build_macos_app:
+    name: Build and publish macOS app
     runs-on: macos-latest
     permissions:
       contents: write

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -102,10 +102,24 @@ if [[ "$NOTARIZE" == "1" && "$CREATE_DMG" != true ]]; then
 fi
 
 codesign_args() {
-    printf '%s\0' --force --deep --sign "$CODESIGN_IDENTITY"
+    printf '%s\0' --force --sign "$CODESIGN_IDENTITY"
     if [[ "$CODESIGN_IDENTITY" != "-" ]]; then
         printf '%s\0' --timestamp --options runtime
     fi
+}
+
+sign_executable() {
+    local target="$1"
+    local args=()
+    while IFS= read -r -d '' arg; do
+        args+=("$arg")
+    done < <(codesign_args)
+
+    codesign "${args[@]}" "$target"
+}
+
+sign_bundled_executables() {
+    sign_executable "$APP_DIR/Contents/Resources/bin/uv"
 }
 
 sign_app() {
@@ -115,7 +129,7 @@ sign_app() {
         args+=("$arg")
     done < <(codesign_args)
 
-    codesign "${args[@]}" "$target"
+    codesign --deep "${args[@]}" "$target"
 }
 
 sign_dmg_if_needed() {
@@ -143,14 +157,35 @@ require_notarization_env() {
 
 notarize_dmg() {
     local dmg_path="$1"
+    local notary_result="$DIST_DIR/notary-submit.json"
+    local submission_id
+    local status
 
     require_notarization_env
     echo "Submitting $dmg_path for Apple notarization..."
-    xcrun notarytool submit "$dmg_path" \
+    if ! xcrun notarytool submit "$dmg_path" \
         --apple-id "$APPLE_ID" \
         --password "$APPLE_APP_SPECIFIC_PASSWORD" \
         --team-id "$APPLE_TEAM_ID" \
-        --wait
+        --wait \
+        --output-format json | tee "$notary_result"; then
+        echo "Apple notarization submission failed." >&2
+        exit 1
+    fi
+
+    submission_id=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("id", ""))' "$notary_result")
+    status=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("status", ""))' "$notary_result")
+    if [[ "$status" != "Accepted" ]]; then
+        echo "Apple notarization failed with status: ${status:-unknown}." >&2
+        if [[ -n "$submission_id" ]]; then
+            xcrun notarytool log "$submission_id" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" >&2 || true
+        fi
+        exit 1
+    fi
+
     xcrun stapler staple "$dmg_path"
     xcrun stapler validate "$dmg_path"
     echo "Notarized and stapled $dmg_path"
@@ -284,6 +319,7 @@ test -f "$APP_DIR/Contents/Resources/AgentCLI.icns" || {
     exit 1
 }
 
+sign_bundled_executables
 sign_app "$APP_DIR"
 
 echo "Built $APP_DIR"

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -696,6 +696,8 @@ def test_macos_build_script_can_notarize_release_dmg() -> None:
     assert "APPLE_TEAM_ID" in script
     assert "xcrun notarytool submit" in script
     assert "--wait" in script
+    assert "xcrun notarytool log" in script
+    assert "Accepted" in script
     assert "xcrun stapler staple" in script
     assert "xcrun stapler validate" in script
     assert "--timestamp" in script
@@ -703,12 +705,30 @@ def test_macos_build_script_can_notarize_release_dmg() -> None:
     assert "Developer ID signing identity" in script
 
 
+def test_macos_build_script_signs_bundled_executables_before_notarization() -> None:
+    """Every executable shipped inside the app bundle must be signed for notarization."""
+    script = BUILD_SCRIPT.read_text()
+
+    assert "sign_bundled_executables" in script
+    assert 'sign_executable "$APP_DIR/Contents/Resources/bin/uv"' in script
+    assert script.index('sign_executable "$APP_DIR/Contents/Resources/bin/uv"') < script.index(
+        'sign_app "$APP_DIR"',
+    )
+
+
 def test_release_workflow_publishes_macos_app_asset() -> None:
     """Publishing a GitHub release should attach the notarized macOS DMG."""
     workflow = RELEASE_WORKFLOW.read_text()
 
+    assert workflow.startswith("name: Publish Release\n")
+    assert "name: Upload Python Package" not in workflow
+    assert "name: Publish Python package" in workflow
+    assert "name: Build and publish macOS app" in workflow
     assert "build_macos_app" in workflow
-    assert re.search(r"build_macos_app:\n\s+runs-on: macos-latest", workflow)
+    assert re.search(
+        r"build_macos_app:\n\s+name: Build and publish macOS app\n\s+runs-on: macos-latest",
+        workflow,
+    )
     assert "contents: write" in workflow
     assert "MACOS_CODESIGN_CERTIFICATE_BASE64" in workflow
     assert "MACOS_CODESIGN_CERTIFICATE_PASSWORD" in workflow


### PR DESCRIPTION
## Summary
- explicitly sign the bundled `uv` executable before sealing the `.app` bundle, so Apple notarization sees all executable code as signed
- print Apple notary logs when notarization returns a non-accepted status
- rename the release workflow to `Publish Release` and add clearer job names for Python package and macOS app publishing

## Verification
- `uv run pytest tests/test_macos_app.py -q`
- `bash -n macos/build-macos-app.sh && git diff --check`
- `./macos/test-macos-app-e2e.sh`
- `codesign --verify --strict dist/macos/AgentCLI.app/Contents/Resources/bin/uv && codesign --verify --deep --strict dist/macos/AgentCLI.app`
- `pre-commit run --all-files`
- `PYTHON_DOTENV_DISABLED=1 env -u OPENAI_API_KEY uv run --all-extras pytest`
