### PR TITLE
Clean up process control API usage

### DIFF
--- a/agent_cli/agents/transcribe_live.py
+++ b/agent_cli/agents/transcribe_live.py
@@ -408,7 +408,8 @@ def transcribe_live(  # noqa: PLR0912
 
     # Handle stop/status commands
     if stop:
-        if process.kill_process(process_name):
+        result = process.stop_process(process_name)
+        if result.was_running or result.stale_cleaned:
             if not quiet:
                 print_with_style(f"✅ Stopped {process_name}", style="green")
         elif not quiet:
@@ -416,7 +417,8 @@ def transcribe_live(  # noqa: PLR0912
         return
 
     if status:
-        if process.is_process_running(process_name):
+        process_status = process.get_process_status(process_name)
+        if process_status.running:
             if not quiet:
                 print_with_style(f"✅ {process_name} is running", style="green")
         elif not quiet:

--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -382,7 +382,7 @@ def _should_skip_extra_check_for_process_control(
 
     from agent_cli.core import process  # noqa: PLC0415
 
-    return process.is_process_running(process_name)
+    return process.get_process_status(process_name).running
 
 
 def requires_extras(

--- a/agent_cli/core/process.py
+++ b/agent_cli/core/process.py
@@ -289,22 +289,6 @@ def get_process_status(process_name: str) -> ProcessStatus:
     )
 
 
-def _get_running_pid(process_name: str) -> int | None:
-    """Get PID if process is running, None otherwise. Cleans up stale files."""
-    status = get_process_status(process_name)
-    return status.pid if status.running else None
-
-
-def is_process_running(process_name: str) -> bool:
-    """Check if a process is currently running."""
-    return _get_running_pid(process_name) is not None
-
-
-def read_pid_file(process_name: str) -> int | None:
-    """Read PID from file if process is running."""
-    return _get_running_pid(process_name)
-
-
 def _wait_for_process_start(
     process_name: str,
     *,
@@ -389,23 +373,6 @@ def stop_process(
     )
 
 
-def kill_process(process_name: str) -> bool:
-    """Kill a process by name.
-
-    Returns True if killed or cleaned up, False if not found.
-    On Windows, creates a stop file first to allow graceful shutdown.
-    """
-    pid_file = _get_pid_file(process_name)
-
-    # If no PID file exists at all, nothing to do
-    if not pid_file.exists():
-        clear_stop_file(process_name)
-        return False
-
-    result = stop_process(process_name)
-    return result.was_running or result.stale_cleaned
-
-
 @contextmanager
 def pid_file_context(process_name: str) -> Generator[Path, None, None]:
     """Context manager for PID file lifecycle.
@@ -415,14 +382,15 @@ def pid_file_context(process_name: str) -> Generator[Path, None, None]:
     """
     lock_fd = _acquire_process_lock(process_name)
     if _supports_process_locks() and lock_fd is None:
-        existing_pid = _get_running_pid(process_name)
-        print(f"Process {process_name} is already running (PID: {existing_pid})")
+        existing_status = get_process_status(process_name)
+        print(f"Process {process_name} is already running (PID: {existing_status.pid})")
         sys.exit(1)
 
-    if not _supports_process_locks() and is_process_running(process_name):
-        existing_pid = _get_running_pid(process_name)
-        print(f"Process {process_name} is already running (PID: {existing_pid})")
-        sys.exit(1)
+    if not _supports_process_locks():
+        existing_status = get_process_status(process_name)
+        if existing_status.running:
+            print(f"Process {process_name} is already running (PID: {existing_status.pid})")
+            sys.exit(1)
 
     if _supports_process_locks():
         pid_info = _read_pid_info(process_name)

--- a/agent_cli/core/utils.py
+++ b/agent_cli/core/utils.py
@@ -357,11 +357,11 @@ def _handle_process_stop(
     wait_for_start_seconds: float,
 ) -> bool:
     """Handle a process stop request."""
+    result = process.stop_process(
+        process_name,
+        wait_for_start_seconds=wait_for_start_seconds,
+    )
     if json_output:
-        result = process.stop_process(
-            process_name,
-            wait_for_start_seconds=wait_for_start_seconds,
-        )
         print(
             json.dumps(
                 _process_status_payload(
@@ -375,14 +375,7 @@ def _handle_process_stop(
         )
         return True
 
-    if wait_for_start_seconds > 0:
-        result = process.stop_process(
-            process_name,
-            wait_for_start_seconds=wait_for_start_seconds,
-        )
-        stopped = result.was_running or result.stale_cleaned
-    else:
-        stopped = process.kill_process(process_name)
+    stopped = result.was_running or result.stale_cleaned
 
     if stopped:
         if not quiet:
@@ -400,8 +393,8 @@ def _handle_process_status(
     json_output: bool,
 ) -> bool:
     """Handle a process status request."""
+    process_status = process.get_process_status(process_name)
     if json_output:
-        process_status = process.get_process_status(process_name)
         print(
             json.dumps(
                 _process_status_payload(
@@ -413,10 +406,9 @@ def _handle_process_status(
         )
         return True
 
-    if process.is_process_running(process_name):
-        pid = process.read_pid_file(process_name)
+    if process_status.running:
         if not quiet:
-            print_with_style(f"✅ {which.capitalize()} is running (PID: {pid}).")
+            print_with_style(f"✅ {which.capitalize()} is running (PID: {process_status.pid}).")
     elif not quiet:
         print_with_style(f"⚠️ {which.capitalize()} is not running.", style="yellow")
     return True
@@ -452,8 +444,10 @@ def stop_or_status_or_toggle(
         )
 
     if toggle:
-        if process.is_process_running(process_name):
-            if process.kill_process(process_name) and not quiet:
+        process_status = process.get_process_status(process_name)
+        if process_status.running:
+            result = process.stop_process(process_name)
+            if (result.was_running or result.stale_cleaned) and not quiet:
                 print_with_style(f"✅ {which.capitalize()} stopped.")
             return True
         if not quiet:

--- a/tests/agents/test_speak.py
+++ b/tests/agents/test_speak.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from agent_cli import config
 from agent_cli.agents.speak import _async_main
 from agent_cli.cli import app
+from agent_cli.core import process
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
 
@@ -103,39 +104,48 @@ def test_speak_agent(mock_async_main: AsyncMock) -> None:
     mock_async_main.assert_called_once()
 
 
-@patch("agent_cli.agents.speak.process.kill_process")
-def test_speak_stop(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.speak.process.stop_process")
+def test_speak_stop(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag."""
-    mock_kill_process.return_value = True
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="speak",
+        was_running=True,
+        status=process.ProcessStatus("speak", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["speak", "--stop"])
     assert result.exit_code == 0
     assert "Speak process stopped" in result.stdout
-    mock_kill_process.assert_called_once_with("speak")
+    mock_stop_process.assert_called_once_with("speak", wait_for_start_seconds=0.0)
 
 
-@patch("agent_cli.agents.speak.process.kill_process")
-def test_speak_stop_not_running(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.speak.process.stop_process")
+def test_speak_stop_not_running(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag when the process is not running."""
-    mock_kill_process.return_value = False
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="speak",
+        was_running=False,
+        status=process.ProcessStatus("speak", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["speak", "--stop"])
     assert result.exit_code == 0
     assert "No speak process is running" in result.stdout
 
 
-@patch("agent_cli.agents.speak.process.is_process_running")
-def test_speak_status_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.speak.process.get_process_status")
+def test_speak_status_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is running."""
-    mock_is_process_running.return_value = True
-    with patch("agent_cli.agents.speak.process.read_pid_file", return_value=123):
-        result = runner.invoke(app, ["speak", "--status"])
+    mock_get_process_status.return_value = process.ProcessStatus("speak", running=True, pid=123)
+    result = runner.invoke(app, ["speak", "--status"])
     assert result.exit_code == 0
     assert "Speak process is running" in result.stdout
 
 
-@patch("agent_cli.agents.speak.process.is_process_running")
-def test_speak_status_not_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.speak.process.get_process_status")
+def test_speak_status_not_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is not running."""
-    mock_is_process_running.return_value = False
+    mock_get_process_status.return_value = process.ProcessStatus("speak", running=False, pid=None)
     result = runner.invoke(app, ["speak", "--status"])
     assert result.exit_code == 0
     assert "Speak process is not running" in result.stdout

--- a/tests/agents/test_transcribe_agent.py
+++ b/tests/agents/test_transcribe_agent.py
@@ -96,39 +96,56 @@ def test_transcribe_start_writes_pid_before_audio_setup(
     assert events[1] == "setup_devices"
 
 
-@patch("agent_cli.agents.transcribe.process.kill_process")
-def test_transcribe_stop(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.transcribe.process.stop_process")
+def test_transcribe_stop(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag."""
-    mock_kill_process.return_value = True
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="transcribe",
+        was_running=True,
+        status=process.ProcessStatus("transcribe", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["transcribe", "--stop"])
     assert result.exit_code == 0
     assert "Transcribe stopped" in result.stdout
-    mock_kill_process.assert_called_once_with("transcribe")
+    mock_stop_process.assert_called_once_with("transcribe", wait_for_start_seconds=0.0)
 
 
-@patch("agent_cli.agents.transcribe.process.kill_process")
-def test_transcribe_stop_not_running(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.transcribe.process.stop_process")
+def test_transcribe_stop_not_running(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag when the process is not running."""
-    mock_kill_process.return_value = False
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="transcribe",
+        was_running=False,
+        status=process.ProcessStatus("transcribe", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["transcribe", "--stop"])
     assert result.exit_code == 0
     assert "No transcribe is running" in result.stdout
 
 
-@patch("agent_cli.agents.transcribe.process.is_process_running")
-def test_transcribe_status_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.transcribe.process.get_process_status")
+def test_transcribe_status_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is running."""
-    mock_is_process_running.return_value = True
-    with patch("agent_cli.agents.transcribe.process.read_pid_file", return_value=123):
-        result = runner.invoke(app, ["transcribe", "--status"])
+    mock_get_process_status.return_value = process.ProcessStatus(
+        process_name="transcribe",
+        running=True,
+        pid=123,
+    )
+    result = runner.invoke(app, ["transcribe", "--status"])
     assert result.exit_code == 0
     assert "Transcribe is running" in result.stdout
 
 
-@patch("agent_cli.agents.transcribe.process.is_process_running")
-def test_transcribe_status_not_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.transcribe.process.get_process_status")
+def test_transcribe_status_not_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is not running."""
-    mock_is_process_running.return_value = False
+    mock_get_process_status.return_value = process.ProcessStatus(
+        process_name="transcribe",
+        running=False,
+        pid=None,
+    )
     result = runner.invoke(app, ["transcribe", "--status"])
     assert result.exit_code == 0
     assert "Transcribe is not running" in result.stdout

--- a/tests/agents/test_voice_edit.py
+++ b/tests/agents/test_voice_edit.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from agent_cli.cli import app
+from agent_cli.core import process
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
 
@@ -46,42 +47,56 @@ def test_voice_edit_agent(
     mock_async_main.assert_called_once()
 
 
-@patch("agent_cli.agents.voice_edit.process.kill_process")
-def test_voice_edit_stop(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.voice_edit.process.stop_process")
+def test_voice_edit_stop(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag."""
-    mock_kill_process.return_value = True
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="voice-edit",
+        was_running=True,
+        status=process.ProcessStatus("voice-edit", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["voice-edit", "--stop"])
     assert result.exit_code == 0
     assert "Voice assistant stopped" in result.stdout
-    mock_kill_process.assert_called_once_with("voice-edit")
+    mock_stop_process.assert_called_once_with("voice-edit", wait_for_start_seconds=0.0)
 
 
-@patch("agent_cli.agents.voice_edit.process.kill_process")
-def test_voice_edit_stop_not_running(mock_kill_process: MagicMock) -> None:
+@patch("agent_cli.agents.voice_edit.process.stop_process")
+def test_voice_edit_stop_not_running(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag when the process is not running."""
-    mock_kill_process.return_value = False
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="voice-edit",
+        was_running=False,
+        status=process.ProcessStatus("voice-edit", running=False, pid=None),
+        stale_cleaned=False,
+    )
     result = runner.invoke(app, ["voice-edit", "--stop"])
     assert result.exit_code == 0
     assert "No voice assistant is running" in result.stdout
 
 
-@patch("agent_cli.agents.voice_edit.process.is_process_running")
-def test_voice_edit_status_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.voice_edit.process.get_process_status")
+def test_voice_edit_status_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is running."""
-    mock_is_process_running.return_value = True
-    with patch(
-        "agent_cli.agents.voice_edit.process.read_pid_file",
-        return_value=123,
-    ):
-        result = runner.invoke(app, ["voice-edit", "--status"])
+    mock_get_process_status.return_value = process.ProcessStatus(
+        "voice-edit",
+        running=True,
+        pid=123,
+    )
+    result = runner.invoke(app, ["voice-edit", "--status"])
     assert result.exit_code == 0
     assert "Voice assistant is running" in result.stdout
 
 
-@patch("agent_cli.agents.voice_edit.process.is_process_running")
-def test_voice_edit_status_not_running(mock_is_process_running: MagicMock) -> None:
+@patch("agent_cli.agents.voice_edit.process.get_process_status")
+def test_voice_edit_status_not_running(mock_get_process_status: MagicMock) -> None:
     """Test the --status flag when the process is not running."""
-    mock_is_process_running.return_value = False
+    mock_get_process_status.return_value = process.ProcessStatus(
+        "voice-edit",
+        running=False,
+        pid=None,
+    )
     result = runner.invoke(app, ["voice-edit", "--status"])
     assert result.exit_code == 0
     assert "Voice assistant is not running" in result.stdout

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -52,26 +52,32 @@ def test_get_pid_file(temp_pid_dir: Path) -> None:
     assert temp_pid_dir.exists()
 
 
-def test_is_process_running_no_file() -> None:
-    """Test checking if a process is running when no PID file exists."""
-    assert not process.is_process_running("nonexistent-process")
+def test_get_process_status_no_file() -> None:
+    """Missing PID files should report stopped."""
+    status = process.get_process_status("nonexistent-process")
+    assert status.running is False
+    assert status.pid is None
+    assert status.stale_cleaned is False
 
 
-def test_is_process_running_invalid_pid() -> None:
-    """Test checking if a process is running with invalid PID."""
+def test_get_process_status_invalid_pid() -> None:
+    """Invalid PID files should be cleaned and report stopped."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
 
     # Write invalid PID
     pid_file.write_text("invalid")
 
-    assert not process.is_process_running(process_name)
+    status = process.get_process_status(process_name)
+    assert status.running is False
+    assert status.pid is None
+    assert status.stale_cleaned is True
     # Should clean up invalid PID file
     assert not pid_file.exists()
 
 
-def test_is_process_running_dead_process() -> None:
-    """Test checking if a process is running with dead process PID."""
+def test_get_process_status_dead_process() -> None:
+    """Dead PID files should be cleaned and report stopped."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
 
@@ -79,7 +85,10 @@ def test_is_process_running_dead_process() -> None:
     dead_pid = 999999
     pid_file.write_text(str(dead_pid))
 
-    assert not process.is_process_running(process_name)
+    status = process.get_process_status(process_name)
+    assert status.running is False
+    assert status.pid is None
+    assert status.stale_cleaned is True
     # Should clean up stale PID file
     assert not pid_file.exists()
 
@@ -105,32 +114,17 @@ def test_get_process_status_cleans_stale_pid(
     assert not stop_file.exists()
 
 
-def test_is_process_running_current_process() -> None:
-    """Test checking if a process is running with current process PID."""
+def test_get_process_status_current_process() -> None:
+    """Current PID files should report running."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
 
     # Write current process PID
     pid_file.write_text(str(os.getpid()))
 
-    assert process.is_process_running(process_name)
-
-
-def test_read_pid_file_no_file() -> None:
-    """Test reading PID file when it doesn't exist."""
-    assert process.read_pid_file("nonexistent-process") is None
-
-
-def test_read_pid_file_current_process() -> None:
-    """Test reading PID file with current process."""
-    process_name = "test-process"
-    pid_file = process._get_pid_file(process_name)
-
-    # Write current process PID
-    current_pid = os.getpid()
-    pid_file.write_text(str(current_pid))
-
-    assert process.read_pid_file(process_name) == current_pid
+    status = process.get_process_status(process_name)
+    assert status.running is True
+    assert status.pid == os.getpid()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX lock files are Unix-only")
@@ -145,13 +139,14 @@ def test_pid_file_context_writes_metadata_and_holds_lock() -> None:
         assert metadata["version"] == 1
         assert metadata["process_name"] == process_name
         assert metadata["pid"] == os.getpid()
-        assert process.is_process_running(process_name)
-        assert process.read_pid_file(process_name) == os.getpid()
+        status = process.get_process_status(process_name)
+        assert status.running is True
+        assert status.pid == os.getpid()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX lock files are Unix-only")
 @patch("agent_cli.core.process._is_pid_running", return_value=True)
-def test_is_process_running_cleans_unlocked_metadata_pid_file(
+def test_get_process_status_cleans_unlocked_metadata_pid_file(
     mock_is_pid_running: MagicMock,  # noqa: ARG001
 ) -> None:
     """A new-format PID file without a held lock is stale even if the PID exists."""
@@ -169,7 +164,9 @@ def test_is_process_running_cleans_unlocked_metadata_pid_file(
     )
     stop_file.write_text("1")
 
-    assert not process.is_process_running(process_name)
+    status = process.get_process_status(process_name)
+    assert status.running is False
+    assert status.stale_cleaned is True
     assert not pid_file.exists()
     assert not stop_file.exists()
 
@@ -177,11 +174,11 @@ def test_is_process_running_cleans_unlocked_metadata_pid_file(
 @pytest.mark.skipif(sys.platform == "win32", reason="os.kill(pid, 0) not used on Windows")
 @patch("agent_cli.core.process._is_pid_running", side_effect=[True, False])
 @patch("os.kill")
-def test_kill_process_success(
+def test_stop_process_success(
     mock_os_kill: MagicMock,
     mock_is_pid_running: MagicMock,
 ) -> None:
-    """Test successfully killing a process."""
+    """Test successfully stopping a process."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
 
@@ -189,8 +186,9 @@ def test_kill_process_success(
     current_pid = os.getpid()
     pid_file.write_text(str(current_pid))
 
-    result = process.kill_process(process_name)
-    assert result is True
+    result = process.stop_process(process_name)
+    assert result.was_running is True
+    assert result.status.running is False
     mock_os_kill.assert_any_call(current_pid, signal.SIGINT)
     assert mock_is_pid_running.call_count >= 2
     assert not pid_file.exists()
@@ -200,7 +198,7 @@ def test_kill_process_success(
 @patch("time.sleep", return_value=None)
 @patch("agent_cli.core.process._is_pid_running", return_value=True)
 @patch("os.kill")
-def test_kill_process_keeps_pid_file_while_process_is_still_running(
+def test_stop_process_keeps_pid_file_while_process_is_still_running(
     mock_os_kill: MagicMock,
     mock_is_pid_running: MagicMock,
     mock_sleep: MagicMock,  # noqa: ARG001
@@ -211,9 +209,10 @@ def test_kill_process_keeps_pid_file_while_process_is_still_running(
     current_pid = os.getpid()
     pid_file.write_text(str(current_pid))
 
-    result = process.kill_process(process_name)
+    result = process.stop_process(process_name)
 
-    assert result is True
+    assert result.was_running is True
+    assert result.status.running is True
     mock_os_kill.assert_any_call(current_pid, signal.SIGINT)
     assert mock_is_pid_running.call_count >= 1
     assert pid_file.exists()
@@ -221,21 +220,22 @@ def test_kill_process_keeps_pid_file_while_process_is_still_running(
     assert stop_file.exists()
 
 
-def test_kill_process_not_running() -> None:
-    """Test killing a process that is not running."""
-    result = process.kill_process("nonexistent-process")
-    assert result is False
+def test_stop_process_not_running() -> None:
+    """Test stopping a process that is not running."""
+    result = process.stop_process("nonexistent-process")
+    assert result.was_running is False
+    assert result.status.running is False
 
 
-def test_kill_process_not_running_clears_stop_file(temp_pid_dir: Path) -> None:
+def test_stop_process_not_running_clears_stop_file(temp_pid_dir: Path) -> None:
     """Stop marker should be removed when no process is running."""
     process_name = "test-process"
     stop_file = temp_pid_dir / f"{process_name}.stop"
     stop_file.write_text("1")
 
-    result = process.kill_process(process_name)
+    result = process.stop_process(process_name)
 
-    assert result is False
+    assert result.was_running is False
     assert not stop_file.exists()
 
 
@@ -303,39 +303,41 @@ def test_stop_process_cleans_stale_pid_and_reports_stopped(
 @patch("time.sleep", return_value=None)
 @patch("agent_cli.core.process._is_pid_running", side_effect=[True, False])
 @patch("os.kill")
-def test_kill_process_escalates_to_sigkill_on_second_stop_request(
+def test_stop_process_escalates_to_sigkill_on_second_stop_request(
     mock_os_kill: MagicMock,
     mock_is_pid_running: MagicMock,  # noqa: ARG001
     mock_sleep: MagicMock,  # noqa: ARG001
 ) -> None:
-    """If stop marker exists, kill_process should escalate to SIGKILL."""
+    """If stop marker exists, stop_process should escalate to SIGKILL."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
     current_pid = os.getpid()
     pid_file.write_text(str(current_pid))
     process._get_stop_file(process_name).write_text("1")
 
-    result = process.kill_process(process_name)
+    result = process.stop_process(process_name)
 
-    assert result is True
+    assert result.was_running is True
     mock_os_kill.assert_any_call(current_pid, signal.SIGKILL)
     assert not pid_file.exists()
     assert not process._get_stop_file(process_name).exists()
 
 
 @patch("os.kill", side_effect=ProcessLookupError)
-def test_kill_process_already_dead(
+@patch("agent_cli.core.process._is_pid_running", side_effect=[True, False])
+def test_stop_process_already_dead(
+    mock_is_pid_running: MagicMock,  # noqa: ARG001
     mock_os_kill: MagicMock,  # noqa: ARG001
 ) -> None:
-    """Test killing a process that is already dead (stale PID file)."""
+    """Test stopping a process that exits before SIGINT is delivered."""
     process_name = "test-process"
     pid_file = process._get_pid_file(process_name)
 
     # Write a PID (doesn't matter if it's valid since we're mocking)
     pid_file.write_text("12345")
 
-    result = process.kill_process(process_name)
-    assert result is True
+    result = process.stop_process(process_name)
+    assert result.was_running is True
     assert not pid_file.exists()
 
 
@@ -408,11 +410,11 @@ def test_pid_file_context_exception_cleanup() -> None:
     assert not pid_file.exists()
 
 
-def test_kill_process_creates_stop_file_on_windows(
+def test_stop_process_creates_stop_file_on_windows(
     temp_pid_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that kill_process creates a stop file on Windows for graceful shutdown."""
+    """Test that stop_process creates a stop file on Windows for graceful shutdown."""
     process_name = "test-process"
     pid_file = temp_pid_dir / f"{process_name}.pid"
     stop_file = temp_pid_dir / f"{process_name}.stop"
@@ -431,14 +433,14 @@ def test_kill_process_creates_stop_file_on_windows(
             stop_file_created = True
         original_touch(self)
 
-    # Mock sys.platform, _is_pid_running (to avoid ctypes.windll), is_process_running, and os.kill
+    # Mock sys.platform and _is_pid_running to avoid ctypes.windll.
     monkeypatch.setattr(process.sys, "platform", "win32")
     with (
         patch.object(process, "_is_pid_running", side_effect=[True, False]),
         patch.object(Path, "touch", tracking_touch),
         patch("os.kill"),
     ):
-        process.kill_process(process_name)
+        process.stop_process(process_name)
 
     # Verify stop file was created during the call
     assert stop_file_created

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
+from agent_cli.core import process
 from agent_cli.core.deps import (
     EXTRAS,
     _check_and_install_extras,
@@ -328,14 +329,20 @@ class TestProcessControlBypass:
 
     def test_skip_for_toggle_when_process_running(self) -> None:
         """Toggle should bypass extra checks when it is acting as stop."""
-        with patch("agent_cli.core.process.is_process_running", return_value=True):
+        with patch(
+            "agent_cli.core.process.get_process_status",
+            return_value=process.ProcessStatus("transcribe", running=True, pid=123),
+        ):
             assert (
                 _should_skip_extra_check_for_process_control({"toggle": True}, "transcribe") is True
             )
 
     def test_no_skip_for_toggle_when_process_not_running(self) -> None:
         """Toggle start still needs dependency checks."""
-        with patch("agent_cli.core.process.is_process_running", return_value=False):
+        with patch(
+            "agent_cli.core.process.get_process_status",
+            return_value=process.ProcessStatus("transcribe", running=False, pid=None),
+        ):
             assert (
                 _should_skip_extra_check_for_process_control({"toggle": True}, "transcribe")
                 is False
@@ -344,7 +351,10 @@ class TestProcessControlBypass:
     def test_decorator_skips_extra_checks_for_toggle_stop(self) -> None:
         """Decorated commands should stop an existing process without installing extras."""
         with (
-            patch("agent_cli.core.process.is_process_running", return_value=True),
+            patch(
+                "agent_cli.core.process.get_process_status",
+                return_value=process.ProcessStatus("transcribe", running=True, pid=123),
+            ),
             patch("agent_cli.core.deps._check_and_install_extras") as mock_check,
         ):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from agent_cli.core import utils
+from agent_cli.core import process, utils
 
 
 @pytest.mark.parametrize(
@@ -136,33 +136,37 @@ def test_interactive_stop_event_checks_stop_file(mock_check_stop_file: Mock) -> 
     mock_check_stop_file.assert_not_called()  # Event already set, no need to check file
 
 
-@patch("agent_cli.core.process.kill_process")
-@patch("agent_cli.core.process.is_process_running")
+@patch("agent_cli.core.process.stop_process")
+@patch("agent_cli.core.process.get_process_status")
 def test_stop_or_status_or_toggle(
-    mock_is_process_running: Mock,
-    mock_kill_process: Mock,
+    mock_get_process_status: Mock,
+    mock_stop_process: Mock,
 ) -> None:
     """Test the stop_or_status_or_toggle function."""
     # Test stop
-    mock_is_process_running.return_value = True
-    mock_kill_process.return_value = True
+    stopped_status = process.ProcessStatus("test", running=False, pid=None)
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="test",
+        was_running=True,
+        status=stopped_status,
+        stale_cleaned=False,
+    )
     assert utils.stop_or_status_or_toggle("test", "test", True, False, False, quiet=True)
-    mock_kill_process.assert_called_with("test")
+    mock_stop_process.assert_called_with("test", wait_for_start_seconds=0.0)
 
     # Test status
-    mock_is_process_running.return_value = True
-    with patch("agent_cli.core.process.read_pid_file", return_value=123):
-        assert utils.stop_or_status_or_toggle(
-            "test",
-            "test",
-            False,
-            True,
-            False,
-            quiet=True,
-        )
+    mock_get_process_status.return_value = process.ProcessStatus("test", running=True, pid=123)
+    assert utils.stop_or_status_or_toggle(
+        "test",
+        "test",
+        False,
+        True,
+        False,
+        quiet=True,
+    )
 
     # Test toggle on
-    mock_is_process_running.return_value = False
+    mock_get_process_status.return_value = process.ProcessStatus("test", running=False, pid=None)
     assert not utils.stop_or_status_or_toggle(
         "test",
         "test",
@@ -173,10 +177,15 @@ def test_stop_or_status_or_toggle(
     )
 
     # Test toggle off
-    mock_is_process_running.return_value = True
-    mock_kill_process.return_value = True
+    mock_get_process_status.return_value = process.ProcessStatus("test", running=True, pid=123)
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="test",
+        was_running=True,
+        status=stopped_status,
+        stale_cleaned=False,
+    )
     assert utils.stop_or_status_or_toggle("test", "test", False, False, True, quiet=True)
-    mock_kill_process.assert_called_with("test")
+    mock_stop_process.assert_called_with("test")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove legacy boolean process-control wrappers from core/process.py
- route shared stop/status/toggle handling, dependency bypass checks, and transcribe-live through get_process_status()/stop_process()
- update process-control tests and agent CLI tests to mock/assert the structured API directly

## Verification
- uv run pytest tests/test_process_manager.py tests/test_utils.py tests/test_requires_extras.py tests/agents/test_transcribe_agent.py tests/agents/test_speak.py tests/agents/test_voice_edit.py -q
- uv run pre-commit run --all-files

## Full suite note
- env -u OPENAI_API_KEY uv run pytest -q reached 1300 passed / 4 skipped, but failed on two unrelated existing environment/flaky cases:
  - tests/test_api_integration.py::test_temp_file_cleanup timed out while diffing /tmp entries
  - tests/test_diarize_live_session.py::test_run_retranscribe_uses_transcribe_config_defaults observed a real OpenAI key from local config/env instead of the mocked config default