### PR TITLE
Move hold transcription stop into CLI

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -49,6 +49,13 @@ struct AgentCommand {
         finishNotificationTitle: "Transcription Finished"
     )
 
+    static let stopTranscription = AgentCommand(
+        identifier: "transcribe-stop",
+        title: "Stop Transcription",
+        arguments: ["transcribe", "--stop", "--quiet", "--wait-for-start"],
+        bootstrapRequirement: .transcription
+    )
+
     static let voiceEdit = AgentCommand(
         identifier: "voice-edit",
         title: "Voice Edit Clipboard",

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -6,12 +6,11 @@ import UserNotifications
 private enum HoldTranscriptionState {
     case idle
     case recording
-    case awaitingPid
     case stopping
 
     var isFinishing: Bool {
         switch self {
-        case .awaitingPid, .stopping:
+        case .stopping:
             return true
         case .idle, .recording:
             return false
@@ -68,7 +67,6 @@ final class AgentCommandRunner: ObservableObject {
         URL(string: "x-apple.systempreferences:com.apple.Security-Privacy.extension?Privacy_Accessibility")!,
         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     ]
-    nonisolated private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet --wait-for-start"#
 
     func beginHoldToTranscribe() {
         guard holdTranscriptionState == .idle else {
@@ -90,16 +88,16 @@ final class AgentCommandRunner: ObservableObject {
 
     func endHoldToTranscribe() {
         guard holdTranscriptionState == .recording else { return }
-        holdTranscriptionState = .awaitingPid
+        holdTranscriptionState = .stopping
 
         let wasRecording = recordingIndicator.isRecordingCommand(.toggleTranscription)
         if wasRecording {
             endRecordingIndicator(for: .toggleTranscription)
             statusMessage = "Transcribing..."
-            stopHeldTranscriptionWhenReady()
         } else {
             statusMessage = "Stopping transcription as soon as it starts..."
         }
+        stopHeldTranscriptionWhenReady()
     }
 
     func run(_ command: AgentCommand) {
@@ -145,8 +143,9 @@ final class AgentCommandRunner: ObservableObject {
 
             if shouldStartRecording {
                 Task { @MainActor in
-                    self.beginRecordingIndicator(for: command)
-                    self.notifyStart(for: command)
+                    if self.beginRecordingIndicator(for: command) {
+                        self.notifyStart(for: command)
+                    }
                 }
             }
 
@@ -198,13 +197,31 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     private func stopHeldTranscriptionWhenReady() {
-        guard holdTranscriptionState == .awaitingPid else { return }
+        guard holdTranscriptionState == .stopping else { return }
 
-        holdTranscriptionState = .stopping
         statusMessage = "Stopping Toggle Transcription..."
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = AgentRuntime.shared.runShell(Self.holdStopShell)
+            let bootstrap = AgentRuntime.shared.ensureReady(
+                for: AgentCommand.stopTranscription.bootstrapRequirement,
+                force: AgentCommand.stopTranscription.forceBootstrap
+            )
+            guard bootstrap.exitCode == 0 else {
+                let message = Self.statusMessage(for: AgentCommand.stopTranscription, result: bootstrap)
+                Task { @MainActor in
+                    self.holdTranscriptionState = .idle
+                    self.lastOutput = bootstrap.output
+                    self.recordFailure(command: AgentCommand.stopTranscription, result: bootstrap)
+                    self.statusMessage = message
+                    self.notify(
+                        title: "Toggle Transcription Failed",
+                        body: Self.errorNotificationBody(message)
+                    )
+                }
+                return
+            }
+
+            let result = AgentRuntime.shared.runAgentCLI(arguments: AgentCommand.stopTranscription.arguments)
 
             Task { @MainActor in
                 if result.exitCode == 0 {
@@ -254,14 +271,15 @@ final class AgentCommandRunner: ObservableObject {
         holdTranscriptionState = .idle
     }
 
-    private func beginRecordingIndicator(for command: AgentCommand) {
+    private func beginRecordingIndicator(for command: AgentCommand) -> Bool {
+        if command.identifier == AgentCommand.toggleTranscription.identifier,
+           holdTranscriptionState == .stopping {
+            return false
+        }
+
         recordingIndicator.begin(for: command)
         isRecording = recordingIndicator.isRecording
-        if command.identifier == AgentCommand.toggleTranscription.identifier,
-           holdTranscriptionState == .awaitingPid {
-            endRecordingIndicator(for: command)
-            stopHeldTranscriptionWhenReady()
-        }
+        return true
     }
 
     private func endRecordingIndicator(for command: AgentCommand) {

--- a/tests/agents/test_transcribe_agent.py
+++ b/tests/agents/test_transcribe_agent.py
@@ -112,6 +112,21 @@ def test_transcribe_stop(mock_stop_process: MagicMock) -> None:
 
 
 @patch("agent_cli.agents.transcribe.process.stop_process")
+def test_transcribe_stop_waits_for_start(mock_stop_process: MagicMock) -> None:
+    """Test --stop --wait-for-start delegates startup waiting to process control."""
+    mock_stop_process.return_value = process.StopProcessResult(
+        process_name="transcribe",
+        was_running=True,
+        status=process.ProcessStatus("transcribe", running=False, pid=None),
+        stale_cleaned=False,
+    )
+    result = runner.invoke(app, ["transcribe", "--stop", "--wait-for-start"])
+    assert result.exit_code == 0
+    assert "Transcribe stopped" in result.stdout
+    mock_stop_process.assert_called_once_with("transcribe", wait_for_start_seconds=300.0)
+
+
+@patch("agent_cli.agents.transcribe.process.stop_process")
 def test_transcribe_stop_not_running(mock_stop_process: MagicMock) -> None:
     """Test the --stop flag when the process is not running."""
     mock_stop_process.return_value = process.StopProcessResult(

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -108,7 +108,9 @@ def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
     source = swift_source()
 
     assert "MenuBarExtra" in source
-    assert '"$AGENTCLI_AGENT_CLI" transcribe --stop --quiet' in source
+    assert 'arguments: ["transcribe", "--stop", "--quiet", "--wait-for-start"]' in source
+    assert "holdStopShell" not in source
+    assert "runShell(Self.holdStopShell)" not in source
     assert "transcribe.pid" not in source
     assert 'arguments: ["transcribe", "--toggle", "--quiet"]' in source
     assert "transcribe --toggle --llm --quiet" not in source
@@ -325,18 +327,15 @@ def test_macos_app_hides_hold_recording_ui_immediately_on_key_release() -> None:
     assert (
         "let wasRecording = recordingIndicator.isRecordingCommand(.toggleTranscription)" in source
     )
-    assert "holdTranscriptionState = .awaitingPid" in source
+    assert "holdTranscriptionState = .stopping" in source
+    assert "case awaitingPid" not in source
     assert (
         "if wasRecording {\n"
         "            endRecordingIndicator(for: .toggleTranscription)\n"
-        '            statusMessage = "Transcribing..."\n'
-        "            stopHeldTranscriptionWhenReady()" in source
+        '            statusMessage = "Transcribing..."' in source
     )
-    assert (
-        "holdTranscriptionState == .awaitingPid {\n"
-        "            endRecordingIndicator(for: command)\n"
-        "            stopHeldTranscriptionWhenReady()" in source
-    )
+    assert "stopHeldTranscriptionWhenReady()" in source
+    assert "holdTranscriptionState == .awaitingPid" not in source
     assert (
         "if shouldStartRecording {\n"
         "                    self.clearHoldTranscriptionState(for: command)" in source
@@ -376,7 +375,6 @@ def test_macos_app_models_hold_to_transcribe_as_explicit_state() -> None:
     assert "private enum HoldTranscriptionState" in source
     assert "case idle" in source
     assert "case recording" in source
-    assert "case awaitingPid" in source
     assert "case stopping" in source
     assert "private var holdTranscriptionState: HoldTranscriptionState = .idle" in source
     assert "holdTranscriptionState.isFinishing" in source
@@ -398,9 +396,15 @@ def test_macos_app_uses_cli_owned_hold_to_transcribe_stop() -> None:
         in source
     )
     assert (
-        'private static let holdStopShell = #""$AGENTCLI_AGENT_CLI" transcribe --stop --quiet --wait-for-start"#'
-        in source
+        "static let stopTranscription = AgentCommand(\n"
+        '        identifier: "transcribe-stop",\n'
+        '        title: "Stop Transcription",\n'
+        '        arguments: ["transcribe", "--stop", "--quiet", "--wait-for-start"]' in source
     )
+    assert "let bootstrap = AgentRuntime.shared.ensureReady(" in source
+    assert "for: AgentCommand.stopTranscription.bootstrapRequirement" in source
+    assert "holdStopShell" not in source
+    assert "runShell(Self.holdStopShell)" not in source
     assert "transcribe.pid" not in source
     assert '"$HOME/.cache/agent-cli/transcribe.pid"' not in source
     assert '"AGENTCLI_RUNTIME_DIR"' in launchd


### PR DESCRIPTION
## Summary
- add a typed macOS stop-transcription command that calls `agent-cli transcribe --stop --quiet --wait-for-start`
- remove Swift-owned PID/shell stop handling and the `awaitingPid` state
- keep hold-release UI responsive while CLI owns wait/status/PID behavior
- add regression coverage for `transcribe --stop --wait-for-start` delegation

## Test plan
- `swift test --package-path macos/AgentCLI`
- `uv run pytest tests/agents/test_transcribe_agent.py tests/test_process_manager.py tests/test_utils.py tests/test_macos_app.py`
- `uv run pre-commit run --all-files`