### PR TITLE
Fix macOS microphone entitlement

### DIFF
--- a/macos/AgentCLI/Resources/AgentCLI.entitlements
+++ b/macos/AgentCLI/Resources/AgentCLI.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -63,6 +63,7 @@ DIST_DIR="$ROOT_DIR/dist/macos"
 APP_DIR="$DIST_DIR/$APP_NAME.app"
 WHEEL_BUILD_DIR="$DIST_DIR/wheels-build"
 INFO_PLIST="$PACKAGE_DIR/Resources/Info.plist"
+ENTITLEMENTS_PLIST="$PACKAGE_DIR/Resources/AgentCLI.entitlements"
 MENU_BAR_LOGO_SVG="$ROOT_DIR/docs/logo-avatar.svg"
 ICONSET_DIR="$DIST_DIR/AgentCLI.iconset"
 ICON_SOURCE_PNG="$DIST_DIR/logo-avatar-source.png"
@@ -102,6 +103,11 @@ if [[ ! -f "$MENU_BAR_LOGO_SVG" ]]; then
     exit 1
 fi
 
+if [[ ! -f "$ENTITLEMENTS_PLIST" ]]; then
+    echo "AgentCLI entitlements plist is missing: $ENTITLEMENTS_PLIST" >&2
+    exit 1
+fi
+
 if [[ "$NOTARIZE" == "1" && "$CREATE_DMG" != true ]]; then
     echo "NOTARIZE=1 requires --dmg so there is a distributable artifact to notarize." >&2
     exit 1
@@ -135,7 +141,7 @@ sign_app() {
         args+=("$arg")
     done < <(codesign_args)
 
-    codesign --deep "${args[@]}" "$target"
+    codesign --deep --entitlements "$ENTITLEMENTS_PLIST" "${args[@]}" "$target"
 }
 
 sign_dmg_if_needed() {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -103,6 +103,20 @@ def test_macos_info_plist_declares_menu_bar_agent_app() -> None:
     assert "microphone" in plist["NSMicrophoneUsageDescription"].lower()
 
 
+def test_macos_app_signing_declares_audio_input_entitlement() -> None:
+    """Developer ID hardened runtime builds need audio-input entitlement for mic capture."""
+    entitlements_path = MACOS_APP / "Resources" / "AgentCLI.entitlements"
+    with entitlements_path.open("rb") as f:
+        entitlements = plistlib.load(f)
+    script = BUILD_SCRIPT.read_text()
+
+    assert entitlements["com.apple.security.device.audio-input"] is True
+    assert 'ENTITLEMENTS_PLIST="$PACKAGE_DIR/Resources/AgentCLI.entitlements"' in script
+    assert "--entitlements" in script
+    assert '"$ENTITLEMENTS_PLIST"' in script
+    assert '[[ ! -f "$ENTITLEMENTS_PLIST" ]]' in script
+
+
 def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
     """The wrapper should invoke the existing CLI surface through its private runtime."""
     source = swift_source()


### PR DESCRIPTION
## Summary
- Add the macOS audio-input entitlement required for hardened runtime microphone capture.
- Fail the macOS app build early if the entitlements plist is missing.
- Add a packaging regression test that verifies the entitlement and signing path.

## Test Plan
- `uv run pytest tests/test_macos_app.py`
- `bash -n macos/build-macos-app.sh && plutil -lint macos/AgentCLI/Resources/AgentCLI.entitlements macos/AgentCLI/Resources/Info.plist`
- `macos/build-macos-app.sh`
- `codesign --verify --deep --strict dist/macos/AgentCLI.app`
- `codesign -d --entitlements :- dist/macos/AgentCLI.app` shows `com.apple.security.device.audio-input => true`
- `uv run pytest` ran after `uv sync --all-extras`: 1306 passed, 4 skipped, 1 unrelated failure from a real `OPENAI_API_KEY` leaking into `test_run_retranscribe_uses_transcribe_config_defaults`; the failing test passes in isolation with `env -u OPENAI_API_KEY`.
