### PR TITLE
Add macOS start at login option

### DIFF
--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -18,9 +18,11 @@ The packaged app registers native macOS global hotkeys itself:
 - `Cmd+Shift+A` autocorrects clipboard text
 - `Cmd+Shift+V` starts voice edit
 
-Choose **Keyboard Shortcuts...** from the menu bar app to change these
-shortcuts. The settings UI uses the `KeyboardShortcuts` Swift package for
-shortcut parsing, `UserDefaults` storage, and global key-up handlers.
+Choose **Settings...** from the menu bar app to change these shortcuts or enable
+**Start at Login**. The settings UI uses the `KeyboardShortcuts` Swift package
+for shortcut parsing, `UserDefaults` storage, and global key-up handlers. The
+login option uses Apple's login item API for the main app bundle, so macOS may
+require approval in System Settings → General → Login Items.
 
 ## Build
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -6,6 +6,7 @@ struct AgentCLIApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Environment(\.openWindow) private var openWindow
     @StateObject private var runner = AgentCommandRunner.shared
+    @StateObject private var loginItemController = LoginItemController.shared
     @StateObject private var shortcutSummary = ShortcutSummaryState.shared
 
     var body: some Scene {
@@ -39,10 +40,20 @@ struct AgentCLIApp: App {
             Divider()
 
             Button {
+                loginItemController.toggle()
+            } label: {
+                Label(
+                    loginItemController.presentation.menuTitle,
+                    systemImage: loginItemController.presentation.isEnabled ? "checkmark.circle" : "circle"
+                )
+            }
+            .disabled(!loginItemController.presentation.canToggle)
+
+            Button {
                 openWindow(id: "settings")
                 NSApp.activate(ignoringOtherApps: true)
             } label: {
-                Label("Keyboard Shortcuts...", systemImage: "command")
+                Label("Settings...", systemImage: "gearshape")
             }
 
             Menu {

--- a/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         UNUserNotificationCenter.current().delegate = self
         configureNotifications()
         ShortcutDefaultsMigrator.migrate()
+        LoginItemController.shared.refresh()
         ConfigurableHotkeyController.shared.registerDefaultHotkeys(runner: AgentCommandRunner.shared)
         ShortcutSummaryState.shared.refresh()
     }

--- a/macos/AgentCLI/Sources/AgentCLI/LoginItemController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/LoginItemController.swift
@@ -1,0 +1,173 @@
+import Foundation
+#if canImport(ServiceManagement)
+import ServiceManagement
+#endif
+import SwiftUI
+
+enum LoginItemStatus: Equatable {
+    case notRegistered
+    case enabled
+    case requiresApproval
+    case notFound
+    case unavailable
+}
+
+struct LoginItemPresentation: Equatable {
+    let status: LoginItemStatus
+
+    var isEnabled: Bool {
+        status == .enabled
+    }
+
+    var canToggle: Bool {
+        switch status {
+        case .notFound, .unavailable:
+            return false
+        case .notRegistered, .enabled, .requiresApproval:
+            return true
+        }
+    }
+
+    var menuTitle: String {
+        "Start at Login: \(statusTitle)"
+    }
+
+    var helpText: String {
+        switch status {
+        case .requiresApproval:
+            return "Approve Agent CLI in System Settings > General > Login Items."
+        case .notFound:
+            return "Start at login is only available when Agent CLI is running from an app bundle."
+        case .unavailable:
+            return "Start at login is unavailable on this macOS version."
+        case .notRegistered, .enabled:
+            return ""
+        }
+    }
+
+    private var statusTitle: String {
+        switch status {
+        case .notRegistered:
+            return "Off"
+        case .enabled:
+            return "On"
+        case .requiresApproval:
+            return "Needs Approval"
+        case .notFound, .unavailable:
+            return "Unavailable"
+        }
+    }
+}
+
+protocol LoginItemServicing {
+    var status: LoginItemStatus { get }
+    func register() throws
+    func unregister() throws
+}
+
+@MainActor
+final class LoginItemController: ObservableObject {
+    static let shared = LoginItemController(service: MainAppLoginItemService())
+
+    @Published private(set) var status: LoginItemStatus
+    @Published private(set) var errorMessage = ""
+
+    private let service: LoginItemServicing
+
+    var presentation: LoginItemPresentation {
+        LoginItemPresentation(status: status)
+    }
+
+    var detailText: String {
+        if !errorMessage.isEmpty {
+            return errorMessage
+        }
+        return presentation.helpText
+    }
+
+    init(service: LoginItemServicing) {
+        self.service = service
+        self.status = service.status
+    }
+
+    func refresh() {
+        status = service.status
+    }
+
+    func toggle() {
+        setEnabled(!presentation.isEnabled)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                try service.register()
+            } else {
+                try service.unregister()
+            }
+            errorMessage = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        refresh()
+    }
+}
+
+struct MainAppLoginItemService: LoginItemServicing {
+    var status: LoginItemStatus {
+        #if canImport(ServiceManagement)
+        if #available(macOS 13.0, *) {
+            return LoginItemStatus(SMAppService.mainApp.status)
+        }
+        #endif
+        return .unavailable
+    }
+
+    func register() throws {
+        #if canImport(ServiceManagement)
+        if #available(macOS 13.0, *) {
+            try SMAppService.mainApp.register()
+            return
+        }
+        #endif
+        throw LoginItemServiceError.unavailable
+    }
+
+    func unregister() throws {
+        #if canImport(ServiceManagement)
+        if #available(macOS 13.0, *) {
+            try SMAppService.mainApp.unregister()
+            return
+        }
+        #endif
+        throw LoginItemServiceError.unavailable
+    }
+}
+
+private enum LoginItemServiceError: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? {
+        "Start at login is unavailable on this macOS version."
+    }
+}
+
+#if canImport(ServiceManagement)
+@available(macOS 13.0, *)
+private extension LoginItemStatus {
+    init(_ status: SMAppService.Status) {
+        switch status {
+        case .notRegistered:
+            self = .notRegistered
+        case .enabled:
+            self = .enabled
+        case .requiresApproval:
+            self = .requiresApproval
+        case .notFound:
+            self = .notFound
+        @unknown default:
+            self = .unavailable
+        }
+    }
+}
+#endif

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -149,10 +149,30 @@ enum ShortcutDefaultsMigrator {
 }
 
 struct SettingsView: View {
+    @ObservedObject private var loginItemController = LoginItemController.shared
     @State private var shortcutRevision = 0
 
     var body: some View {
         Form {
+            Section {
+                Toggle(
+                    "Start at Login",
+                    isOn: Binding(
+                        get: { loginItemController.presentation.isEnabled },
+                        set: { loginItemController.setEnabled($0) }
+                    )
+                )
+                .disabled(!loginItemController.presentation.canToggle)
+
+                if !loginItemController.detailText.isEmpty {
+                    Text(loginItemController.detailText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("General")
+            }
+
             Section {
                 ShortcutRecorderRow(
                     title: "Toggle Transcription",
@@ -187,6 +207,9 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onAppear {
+            loginItemController.refresh()
+        }
     }
 }
 

--- a/macos/AgentCLI/Tests/AgentCLITests/LoginItemControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/LoginItemControllerTests.swift
@@ -1,0 +1,25 @@
+#if canImport(XCTest)
+import XCTest
+@testable import AgentCLI
+
+final class LoginItemControllerTests: XCTestCase {
+    func testEnabledStatusIsPresentedAsOn() {
+        let presentation = LoginItemPresentation(status: .enabled)
+
+        XCTAssertTrue(presentation.isEnabled)
+        XCTAssertEqual(presentation.menuTitle, "Start at Login: On")
+        XCTAssertEqual(presentation.helpText, "")
+    }
+
+    func testRequiresApprovalIsNotPresentedAsOn() {
+        let presentation = LoginItemPresentation(status: .requiresApproval)
+
+        XCTAssertFalse(presentation.isEnabled)
+        XCTAssertEqual(presentation.menuTitle, "Start at Login: Needs Approval")
+        XCTAssertEqual(
+            presentation.helpText,
+            "Approve Agent CLI in System Settings > General > Login Items."
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add a ServiceManagement-backed login item controller for the macOS app
- Add Start at Login controls in the menu bar menu and settings window
- Document the new setting and approval path

## Test Plan
- swift test
- ./macos/build-macos-app.sh