### PR TITLE
Create an installer-style macOS DMG with drag-to-Applications layout

### DIFF
--- a/macos/AgentCLI/Resources/dmg-background.svg
+++ b/macos/AgentCLI/Resources/dmg-background.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="360" viewBox="0 0 600 360">
+  <rect width="600" height="360" fill="#f6f7f9"/>
+  <rect x="28" y="28" width="544" height="304" rx="24" fill="#ffffff" stroke="#d7dbe2"/>
+  <path d="M255 180h110" fill="none" stroke="#7b8494" stroke-width="10" stroke-linecap="round"/>
+  <path d="M335 140l40 40-40 40" fill="none" stroke="#7b8494" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="300" y="78" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="24" font-weight="600" fill="#242933">Install Agent CLI</text>
+  <text x="300" y="112" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" font-size="15" fill="#596171">Drag AgentCLI.app to Applications</text>
+</svg>

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -62,9 +62,13 @@ PACKAGE_DIR="$ROOT_DIR/macos/$APP_NAME"
 DIST_DIR="$ROOT_DIR/dist/macos"
 APP_DIR="$DIST_DIR/$APP_NAME.app"
 WHEEL_BUILD_DIR="$DIST_DIR/wheels-build"
+DMG_STAGING_DIR="$DIST_DIR/dmg-staging"
+DMG_RW_PATH="$DIST_DIR/$APP_NAME-rw.dmg"
 INFO_PLIST="$PACKAGE_DIR/Resources/Info.plist"
 ENTITLEMENTS_PLIST="$PACKAGE_DIR/Resources/AgentCLI.entitlements"
 MENU_BAR_LOGO_SVG="$ROOT_DIR/docs/logo-avatar.svg"
+DMG_BACKGROUND_SVG="$PACKAGE_DIR/Resources/dmg-background.svg"
+DMG_BACKGROUND_PNG="$DIST_DIR/dmg-background.png"
 ICONSET_DIR="$DIST_DIR/AgentCLI.iconset"
 ICON_SOURCE_PNG="$DIST_DIR/logo-avatar-source.png"
 NOTIFICATION_LOGO_PNG="$DIST_DIR/logo-avatar.png"
@@ -105,6 +109,11 @@ fi
 
 if [[ ! -f "$ENTITLEMENTS_PLIST" ]]; then
     echo "AgentCLI entitlements plist is missing: $ENTITLEMENTS_PLIST" >&2
+    exit 1
+fi
+
+if [[ "$CREATE_DMG" == true && ! -f "$DMG_BACKGROUND_SVG" ]]; then
+    echo "AgentCLI DMG background SVG is missing: $DMG_BACKGROUND_SVG" >&2
     exit 1
 fi
 
@@ -293,6 +302,90 @@ build_app_icon() {
     rm -rf "$ICONSET_DIR"
 }
 
+render_dmg_background() {
+    local render_dir="$DIST_DIR/dmg-background-render"
+    local rendered="$render_dir/$(basename "$DMG_BACKGROUND_SVG").png"
+
+    rm -rf "$render_dir" "$DMG_BACKGROUND_PNG"
+    mkdir -p "$render_dir"
+    qlmanage -t -s 600 -o "$render_dir" "$DMG_BACKGROUND_SVG" >/dev/null 2>&1
+    if [[ ! -f "$rendered" ]]; then
+        echo "Failed to render AgentCLI DMG background PNG: $rendered" >&2
+        exit 1
+    fi
+    cp "$rendered" "$DMG_BACKGROUND_PNG"
+    rm -rf "$render_dir"
+}
+
+set_dmg_finder_layout() {
+    local volume_path="$1"
+
+    osascript <<APPLESCRIPT
+tell application "Finder"
+    tell disk "$DISPLAY_NAME"
+        open
+        set current view of container window to icon view
+        set toolbar visible of container window to false
+        set statusbar visible of container window to false
+        set bounds of container window to {100, 100, 700, 460}
+        set theViewOptions to icon view options of container window
+        set arrangement of theViewOptions to not arranged
+        set icon size of theViewOptions to 96
+        set background picture of theViewOptions to file ".background:dmg-background.png"
+        set position of item "AgentCLI.app" of container window to {150, 180}
+        set position of item "Applications" of container window to {450, 180}
+        close
+        open
+        update without registering applications
+        delay 1
+    end tell
+end tell
+APPLESCRIPT
+
+    sync
+    touch "$volume_path/.metadata_never_index"
+}
+
+create_drag_install_dmg() {
+    local dmg_path="$1"
+    local attach_output
+    local volume_path
+
+    hdiutil detach "/Volumes/$DISPLAY_NAME" >/dev/null 2>&1 || true
+    rm -rf "$DMG_STAGING_DIR" "$DMG_RW_PATH" "$dmg_path" || return
+    mkdir -p "$DMG_STAGING_DIR/.background" || return
+
+    ditto "$APP_DIR" "$DMG_STAGING_DIR/$APP_NAME.app" || return
+    ln -s /Applications "$DMG_STAGING_DIR/Applications" || return
+    render_dmg_background || return
+    cp "$DMG_BACKGROUND_PNG" "$DMG_STAGING_DIR/.background/dmg-background.png" || return
+
+    hdiutil create "$DMG_RW_PATH" \
+        -volname "$DISPLAY_NAME" \
+        -srcfolder "$DMG_STAGING_DIR" \
+        -ov \
+        -format UDRW || return
+    attach_output=$(hdiutil attach "$DMG_RW_PATH" \
+        -nobrowse \
+        -noautoopen) || return
+    volume_path=$(printf '%s\n' "$attach_output" | awk -F '\t' '/\/Volumes\// { mount=$NF } END { if (mount) print mount; else exit 1 }')
+    if [[ -z "$volume_path" ]]; then
+        echo "Failed to resolve mounted DMG volume from hdiutil attach output." >&2
+        printf '%s\n' "$attach_output" >&2
+        return 1
+    fi
+    if ! set_dmg_finder_layout "$volume_path"; then
+        hdiutil detach "$volume_path" >/dev/null 2>&1 || true
+        return 1
+    fi
+    hdiutil detach "$volume_path" >/dev/null || return
+    hdiutil convert "$DMG_RW_PATH" \
+        -format UDZO \
+        -imagekey zlib-level=9 \
+        -o "$dmg_path" || return
+    rm -rf "$DMG_STAGING_DIR" "$DMG_RW_PATH" || return
+}
+
 quit_running_app() {
     if ! pgrep -x "$APP_NAME" >/dev/null 2>&1; then
         return
@@ -390,13 +483,7 @@ echo "Built $APP_DIR"
 if [[ "$CREATE_DMG" == true ]]; then
     DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
     for attempt in 1 2 3; do
-        rm -f "$DMG_PATH"
-        if hdiutil create \
-            -volname "$DISPLAY_NAME" \
-            -srcfolder "$APP_DIR" \
-            -ov \
-            -format UDZO \
-            "$DMG_PATH"; then
+        if create_drag_install_dmg "$DMG_PATH"; then
             break
         fi
         if [[ "$attempt" == 3 ]]; then

--- a/macos/test-macos-app-e2e.sh
+++ b/macos/test-macos-app-e2e.sh
@@ -121,6 +121,15 @@ test -f "$APP/Contents/Resources/wheels/agent_cli-0.0.0-py3-none-any.whl"
 codesign --verify --verbose=2 "$APP"
 hdiutil verify "$DMG"
 
+DMG_MOUNT="$TMP_DIR/dmg-mount"
+mkdir -p "$DMG_MOUNT"
+hdiutil attach "$DMG" -mountpoint "$DMG_MOUNT" -nobrowse -noautoopen >/dev/null
+test -d "$DMG_MOUNT/AgentCLI.app"
+test -L "$DMG_MOUNT/Applications"
+test "$(readlink "$DMG_MOUNT/Applications")" = "/Applications"
+test -f "$DMG_MOUNT/.background/dmg-background.png"
+hdiutil detach "$DMG_MOUNT" >/dev/null
+
 SUPPORT_DIR="$TMP_DIR/Application Support/AgentCLI"
 SELF_TEST_OUTPUT=$(
     AGENTCLI_APP_SUPPORT_DIR="$SUPPORT_DIR" \

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -791,6 +791,31 @@ def test_macos_build_script_signs_bundled_executables_before_notarization() -> N
     )
 
 
+def test_macos_build_script_creates_drag_install_dmg() -> None:
+    """The release DMG should open as a drag-to-Applications installer window."""
+    script = BUILD_SCRIPT.read_text()
+
+    assert 'DMG_STAGING_DIR="$DIST_DIR/dmg-staging"' in script
+    assert 'DMG_RW_PATH="$DIST_DIR/$APP_NAME-rw.dmg"' in script
+    assert 'DMG_BACKGROUND_SVG="$PACKAGE_DIR/Resources/dmg-background.svg"' in script
+    assert 'DMG_BACKGROUND_PNG="$DIST_DIR/dmg-background.png"' in script
+    assert 'ln -s /Applications "$DMG_STAGING_DIR/Applications"' in script
+    assert '"$DMG_STAGING_DIR/$APP_NAME.app"' in script
+    assert 'hdiutil create "$DMG_RW_PATH"' in script
+    assert "-format UDRW" in script
+    assert "hdiutil attach" in script
+    assert "-mountpoint" not in script
+    assert 'volume_path=$(printf' in script
+    assert 'set background picture of theViewOptions to file ".background:dmg-background.png"' in script
+    assert 'set position of item "AgentCLI.app" of container window to {150, 180}' in script
+    assert 'set position of item "Applications" of container window to {450, 180}' in script
+    assert 'if ! set_dmg_finder_layout "$volume_path"; then' in script
+    assert "hdiutil convert" in script
+    assert "-format UDZO" in script
+    assert "sign_dmg_if_needed" in script
+    assert (MACOS_APP / "Resources" / "dmg-background.svg").is_file()
+
+
 def test_release_workflow_publishes_macos_app_asset() -> None:
     """Publishing a GitHub release should attach the notarized macOS DMG."""
     workflow = RELEASE_WORKFLOW.read_text()
@@ -893,6 +918,10 @@ def test_macos_app_has_end_to_end_packaging_test() -> None:
     assert "AGENTCLI_INSTANCE_LOCK_PATH" in script
     assert "UV_BINARY=" in script
     assert "uv build --wheel" in script
+    assert 'test -d "$DMG_MOUNT/AgentCLI.app"' in script
+    assert 'test -L "$DMG_MOUNT/Applications"' in script
+    assert 'readlink "$DMG_MOUNT/Applications"' in script
+    assert 'test -f "$DMG_MOUNT/.background/dmg-background.png"' in script
     assert "--agentcli-bootstrap-self-test" in script
     assert "daemon install whisper -y" in script
     assert "transcribe --toggle --quiet" in script


### PR DESCRIPTION
## Summary
- Build the release DMG as a Finder-style installer volume instead of a plain compressed app image.
- Add a DMG background asset and Finder layout steps so the volume opens with `AgentCLI.app` and an `Applications` symlink.
- Extend the macOS packaging E2E to verify the DMG contents and install flow.

## Testing
- `uv run pytest tests/test_macos_app.py::test_macos_build_script_creates_drag_install_dmg tests/test_macos_app.py::test_macos_app_has_end_to_end_packaging_test -q`
- `macos/test-macos-app-e2e.sh`
- `uv run pytest` after installing all extras; one unrelated local-environment test failure remained when `OPENAI_API_KEY` was set, and the targeted retranscribe test passed when that variable was unset.