### PR TITLE
Warm up macOS transcription runtime on launch

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -18,6 +18,8 @@ private enum HoldTranscriptionState {
     }
 }
 
+typealias AgentBootstrap = @Sendable (AgentBootstrapRequirement, Bool) -> CommandResult
+
 @MainActor
 final class AgentCommandRunner: ObservableObject {
     static let shared = AgentCommandRunner()
@@ -29,10 +31,12 @@ final class AgentCommandRunner: ObservableObject {
     @Published private var activeCommandCount = 0
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
+    private let bootstrap: AgentBootstrap
     private var pendingStopRecordingCommands: Set<String> = []
     private var holdTranscriptionState: HoldTranscriptionState = .idle
     private var holdToTranscribePasteTarget: FocusedTextTarget?
     private var pasteAfterRecordingCommands: Set<String> = []
+    private var hasStartedTranscriptionWarmUp = false
 
     var isRunning: Bool {
         activeCommandCount > 0
@@ -51,10 +55,14 @@ final class AgentCommandRunner: ObservableObject {
         return Self.compactMenuStatus(statusMessage)
     }
 
-    private init(
-        pasteController: TranscriptPasteController = TranscriptPasteController()
+    init(
+        pasteController: TranscriptPasteController = TranscriptPasteController(),
+        bootstrap: @escaping AgentBootstrap = { requirement, force in
+            AgentRuntime.shared.ensureReady(for: requirement, force: force)
+        }
     ) {
         self.pasteController = pasteController
+        self.bootstrap = bootstrap
         hasLastError = FileManager.default.fileExists(atPath: AgentRuntime.shared.lastErrorURL.path)
     }
 
@@ -67,6 +75,40 @@ final class AgentCommandRunner: ObservableObject {
         URL(string: "x-apple.systempreferences:com.apple.Security-Privacy.extension?Privacy_Accessibility")!,
         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
     ]
+
+    func warmUpTranscription() {
+        guard !hasStartedTranscriptionWarmUp else { return }
+        hasStartedTranscriptionWarmUp = true
+
+        activeCommandCount += 1
+        if statusMessage == "Ready" {
+            statusMessage = "Preparing voice service..."
+        }
+
+        let bootstrap = self.bootstrap
+        DispatchQueue.global(qos: .utility).async {
+            let result = bootstrap(.transcription, false)
+
+            Task { @MainActor in
+                self.activeCommandCount = max(0, self.activeCommandCount - 1)
+                if !result.output.isEmpty {
+                    self.lastOutput = result.output
+                }
+
+                if result.exitCode == 0 {
+                    if self.statusMessage == "Preparing voice service..." {
+                        self.statusMessage = "Ready"
+                    }
+                    return
+                }
+
+                self.recordFailure(title: "Startup Voice Service Warm-Up", result: result)
+                self.statusMessage = result.output.isEmpty
+                    ? "Voice service warm-up failed with exit code \(result.exitCode)"
+                    : "Voice service warm-up failed: \(Self.summarize(result.output))"
+            }
+        }
+    }
 
     func beginHoldToTranscribe() {
         guard holdTranscriptionState == .idle else {
@@ -118,12 +160,13 @@ final class AgentCommandRunner: ObservableObject {
             ? "Stopping \(command.title)..."
             : "Running \(command.title)..."
 
+        let bootstrap = self.bootstrap
         DispatchQueue.global(qos: .userInitiated).async {
-            let bootstrap = AgentRuntime.shared.ensureReady(for: command.bootstrapRequirement, force: command.forceBootstrap)
-            guard bootstrap.exitCode == 0 else {
-                let message = Self.statusMessage(for: command, result: bootstrap)
-                let notificationTitle = Self.notificationTitle(for: command, result: bootstrap)
-                let notificationBody = Self.notificationBody(for: command, result: bootstrap, statusMessage: message)
+            let bootstrapResult = bootstrap(command.bootstrapRequirement, command.forceBootstrap)
+            guard bootstrapResult.exitCode == 0 else {
+                let message = Self.statusMessage(for: command, result: bootstrapResult)
+                let notificationTitle = Self.notificationTitle(for: command, result: bootstrapResult)
+                let notificationBody = Self.notificationBody(for: command, result: bootstrapResult, statusMessage: message)
                 Task { @MainActor in
                     if isStopRequest {
                         self.clearStopRequested(for: command)
@@ -133,8 +176,8 @@ final class AgentCommandRunner: ObservableObject {
                     }
                     self.clearHoldTranscriptionState(for: command)
                     self.activeCommandCount = max(0, self.activeCommandCount - 1)
-                    self.lastOutput = bootstrap.output
-                    self.recordFailure(command: command, result: bootstrap)
+                    self.lastOutput = bootstrapResult.output
+                    self.recordFailure(command: command, result: bootstrapResult)
                     self.statusMessage = message
                     self.notify(title: notificationTitle, body: notificationBody)
                 }
@@ -201,17 +244,18 @@ final class AgentCommandRunner: ObservableObject {
 
         statusMessage = "Stopping Toggle Transcription..."
 
+        let bootstrap = self.bootstrap
         DispatchQueue.global(qos: .userInitiated).async {
-            let bootstrap = AgentRuntime.shared.ensureReady(
-                for: AgentCommand.stopTranscription.bootstrapRequirement,
-                force: AgentCommand.stopTranscription.forceBootstrap
+            let bootstrapResult = bootstrap(
+                AgentCommand.stopTranscription.bootstrapRequirement,
+                AgentCommand.stopTranscription.forceBootstrap
             )
-            guard bootstrap.exitCode == 0 else {
-                let message = Self.statusMessage(for: AgentCommand.stopTranscription, result: bootstrap)
+            guard bootstrapResult.exitCode == 0 else {
+                let message = Self.statusMessage(for: AgentCommand.stopTranscription, result: bootstrapResult)
                 Task { @MainActor in
                     self.holdTranscriptionState = .idle
-                    self.lastOutput = bootstrap.output
-                    self.recordFailure(command: AgentCommand.stopTranscription, result: bootstrap)
+                    self.lastOutput = bootstrapResult.output
+                    self.recordFailure(command: AgentCommand.stopTranscription, result: bootstrapResult)
                     self.statusMessage = message
                     self.notify(
                         title: "Toggle Transcription Failed",

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -8,6 +8,7 @@ struct AgentRuntime {
     private static let bundledWheelsRelativePath = "Contents/Resources/wheels"
     private static let appSupportDisplayName = "Application Support"
     private static let fallbackPackageSource = "agent-cli"
+    private static let bootstrapQueue = DispatchQueue(label: "lt.nijho.agent-cli.bootstrap")
     private let fileManager = FileManager.default
     let appSupportURL: URL
     let bundledUVURL: URL
@@ -168,6 +169,12 @@ struct AgentRuntime {
     }
 
     func ensureReady(for requirement: AgentBootstrapRequirement, force: Bool = false) -> CommandResult {
+        Self.bootstrapQueue.sync {
+            ensureReadyUnsynchronized(for: requirement, force: force)
+        }
+    }
+
+    private func ensureReadyUnsynchronized(for requirement: AgentBootstrapRequirement, force: Bool = false) -> CommandResult {
         switch requirement {
         case .cliRuntime:
             return ensureInstalled(force: force)

--- a/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ShortcutDefaultsMigrator.migrate()
         ConfigurableHotkeyController.shared.registerDefaultHotkeys(runner: AgentCommandRunner.shared)
         ShortcutSummaryState.shared.refresh()
+        AgentCommandRunner.shared.warmUpTranscription()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -12,5 +12,41 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(AgentCommand.autocorrect.arguments, ["autocorrect", "--quiet"])
         XCTAssertEqual(AgentCommand.autocorrect.bootstrapRequirement, .cliRuntime)
     }
+
+    @MainActor
+    func testStartupWarmUpBootstrapsTranscriptionOnce() {
+        let recorder = BootstrapRecorder()
+        let runner = AgentCommandRunner(bootstrap: recorder.bootstrap)
+
+        runner.warmUpTranscription()
+        runner.warmUpTranscription()
+
+        wait(for: [recorder.expectation], timeout: 2)
+
+        XCTAssertEqual(recorder.calls, [.init(requirement: .transcription, force: false)])
+    }
+}
+
+private struct BootstrapCall: Equatable {
+    let requirement: AgentBootstrapRequirement
+    let force: Bool
+}
+
+private final class BootstrapRecorder {
+    let expectation = XCTestExpectation(description: "warm-up bootstrap called")
+    private let lock = NSLock()
+    private var storedCalls: [BootstrapCall] = []
+
+    var calls: [BootstrapCall] {
+        lock.withLock { storedCalls }
+    }
+
+    func bootstrap(requirement: AgentBootstrapRequirement, force: Bool) -> CommandResult {
+        lock.withLock {
+            storedCalls.append(.init(requirement: requirement, force: force))
+        }
+        expectation.fulfill()
+        return CommandResult(exitCode: 0, output: "")
+    }
 }
 #endif

--- a/tests/test_diarize_live_session.py
+++ b/tests/test_diarize_live_session.py
@@ -147,7 +147,11 @@ def test_select_recent_session_picks_nth_most_recent_session() -> None:
     assert [segment.audio_file.name for segment in selected] == ["first-one.mp3", "first-two.mp3"]
 
 
-def test_run_retranscribe_uses_transcribe_config_defaults(tmp_path: Path) -> None:
+def test_run_retranscribe_uses_transcribe_config_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     options = DiarizeLiveSessionOptions(
         date=date.fromisoformat("2026-04-23"),
         start=parse_clock_time("11:32"),

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -415,8 +415,9 @@ def test_macos_app_uses_cli_owned_hold_to_transcribe_stop() -> None:
         '        title: "Stop Transcription",\n'
         '        arguments: ["transcribe", "--stop", "--quiet", "--wait-for-start"]' in source
     )
-    assert "let bootstrap = AgentRuntime.shared.ensureReady(" in source
-    assert "for: AgentCommand.stopTranscription.bootstrapRequirement" in source
+    assert "let bootstrap = self.bootstrap" in source
+    assert "let bootstrapResult = bootstrap(" in source
+    assert "AgentCommand.stopTranscription.bootstrapRequirement" in source
     assert "holdStopShell" not in source
     assert "runShell(Self.holdStopShell)" not in source
     assert "transcribe.pid" not in source
@@ -432,8 +433,21 @@ def test_macos_app_uses_bootstrap_requirement_model() -> None:
     assert "case cliRuntime" in source
     assert "case transcription" in source
     assert "let bootstrapRequirement: AgentBootstrapRequirement" in source
-    assert "ensureReady(for: command.bootstrapRequirement" in source
+    assert "AgentRuntime.shared.ensureReady(for: requirement, force: force)" in source
+    assert "bootstrap(command.bootstrapRequirement, command.forceBootstrap)" in source
     assert "requiresWhisperDaemon" not in source
+
+
+def test_macos_app_warms_transcription_on_launch() -> None:
+    """Startup should eagerly prepare the CLI and voice service before first hotkey use."""
+    source = swift_source()
+
+    assert "AgentCommandRunner.shared.warmUpTranscription()" in source
+    assert "private var hasStartedTranscriptionWarmUp = false" in source
+    assert 'statusMessage = "Preparing voice service..."' in source
+    assert "let result = bootstrap(.transcription, false)" in source
+    assert 'recordFailure(title: "Startup Voice Service Warm-Up", result: result)' in source
+    assert 'DispatchQueue(label: "lt.nijho.agent-cli.bootstrap")' in source
 
 
 def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:
@@ -674,7 +688,7 @@ def test_macos_app_makes_command_errors_discoverable() -> None:
     assert "logsURL" in source
     assert 'appendingPathComponent("Logs"' in source
     assert "recordFailure(command: command, result: result)" in source
-    assert "recordFailure(command: command, result: bootstrap)" in source
+    assert "recordFailure(command: command, result: bootstrapResult)" in source
     assert 'recordFailure(title: "Toggle Transcription Stop", result: result)' in source
     assert "try details.write(to: AgentRuntime.shared.lastErrorURL" in source
     assert "openLastError()" in source


### PR DESCRIPTION
## Summary
- Start a background transcription warm-up when the macOS menu bar app launches so the private CLI and Whisper service are prepared before first hotkey use.
- Route macOS command bootstrapping through an injectable closure and serialize runtime bootstrap calls to avoid duplicate install/service setup races.
- Add/adjust tests for startup warm-up behavior and isolate a retranscription config-defaults test from ambient OpenAI API key state.

## Test Plan
- `swift test && swift build` from `macos/AgentCLI`
- `uv sync --all-extras`
- `uv run pytest`
- `pre-commit run --all-files`