### PR TITLE
Fix macOS permission troubleshooting actions

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -114,15 +114,15 @@ struct AgentCLIApp: App {
                 Divider()
 
                 Button {
-                    runner.openNotificationSettings()
+                    runner.repairNotificationPermission()
                 } label: {
-                    Label("Open Notification Settings", systemImage: "bell.badge")
+                    Label("Fix Notification Permission...", systemImage: "bell.badge")
                 }
 
                 Button {
-                    runner.openAccessibilitySettings()
+                    runner.resetAccessibilityPermission()
                 } label: {
-                    Label("Open Accessibility Settings", systemImage: "figure.wave")
+                    Label("Reset Accessibility Permission...", systemImage: "figure.wave")
                 }
 
                 Button {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Foundation
 import SwiftUI
 import UserNotifications
@@ -348,23 +349,96 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     func notificationsDisabled() {
-        statusMessage = "Notifications are disabled. Use Open Notification Settings to enable Agent CLI notifications."
+        statusMessage = "Notifications are disabled. Use Fix Notification Permission to enable Agent CLI notifications."
     }
 
-    func openNotificationSettings() {
+    func repairNotificationPermission() {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, _ in
+                    Task { @MainActor in
+                        self.statusMessage = granted
+                            ? "Notification permission enabled"
+                            : "Notifications are disabled. Enable Agent CLI in Notification Settings."
+                    }
+                }
+            case .denied:
+                Task { @MainActor in
+                    _ = self.openNotificationSettings()
+                    self.statusMessage = "Notifications are disabled. Enable Agent CLI in Notification Settings."
+                }
+            default:
+                Task { @MainActor in
+                    self.statusMessage = "Notification permission is already enabled"
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func openNotificationSettings() -> Bool {
         for url in Self.notificationSettingsURLs where NSWorkspace.shared.open(url) {
             statusMessage = "Opened Notification Settings"
-            return
+            return true
         }
         statusMessage = "Could not open Notification Settings"
+        return false
     }
 
-    func openAccessibilitySettings() {
-        for url in Self.accessibilitySettingsURLs where NSWorkspace.shared.open(url) {
-            statusMessage = "Opened Accessibility Settings. Accessibility permission controls auto-inserting transcripts."
+    func resetAccessibilityPermission() {
+        let result = runTCCReset(service: "Accessibility")
+        try? FileManager.default.removeItem(at: AgentRuntime.shared.accessibilityPromptMarkerURL)
+        requestAccessibilityPermissionPrompt()
+        _ = openAccessibilitySettings()
+
+        guard result.exitCode == 0 else {
+            let output = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            statusMessage = output.isEmpty
+                ? "Could not reset Accessibility permission"
+                : "Could not reset Accessibility permission: \(output)"
             return
         }
+
+        statusMessage = "Accessibility permission reset. Enable Agent CLI in Accessibility, then reopen AgentCLI if auto-insert still fails."
+    }
+
+    @discardableResult
+    func openAccessibilitySettings() -> Bool {
+        for url in Self.accessibilitySettingsURLs where NSWorkspace.shared.open(url) {
+            statusMessage = "Opened Accessibility Settings. Accessibility permission controls auto-inserting transcripts."
+            return true
+        }
         statusMessage = "Could not open Accessibility Settings"
+        return false
+    }
+
+    private func requestAccessibilityPermissionPrompt() {
+        let promptOption = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let options = [promptOption: true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+    }
+
+    private func runTCCReset(service: String) -> CommandResult {
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "lt.nijho.agent-cli.menubar"
+        let process = Process()
+        let pipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+        process.arguments = ["reset", service, bundleIdentifier]
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            return CommandResult(exitCode: process.terminationStatus, output: output)
+        } catch {
+            return CommandResult(exitCode: 1, output: error.localizedDescription)
+        }
     }
 
     @discardableResult

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -638,27 +638,32 @@ def test_macos_app_sends_visible_transcription_notifications() -> None:
     assert "content.attachments = [attachment]" in source
 
 
-def test_macos_app_can_open_notification_settings() -> None:
-    """Users should get an in-app path to fix previously denied notification permission."""
+def test_macos_app_can_repair_notification_permission() -> None:
+    """Users should get an in-app path to request or fix notification permission."""
     source = swift_source()
 
-    assert 'Label("Open Notification Settings", systemImage: "bell.badge")' in source
-    assert "openNotificationSettings()" in source
+    assert 'Label("Fix Notification Permission...", systemImage: "bell.badge")' in source
+    assert "repairNotificationPermission()" in source
+    assert "requestAuthorization(options: [.alert])" in source
     assert "notificationSettingsURLs" in source
     assert "x-apple.systempreferences:com.apple.Notifications-Settings.extension" in source
     assert "x-apple.systempreferences:com.apple.preference.notifications" in source
     assert "Notifications are disabled" in source
 
 
-def test_macos_app_can_open_accessibility_settings() -> None:
-    """Users should get an explicit path to grant paste insertion permission."""
+def test_macos_app_can_reset_accessibility_permission() -> None:
+    """Users should get an explicit path to clear stale paste insertion permission."""
     source = swift_source()
 
-    assert 'Label("Open Accessibility Settings", systemImage: "figure.wave")' in source
-    assert "openAccessibilitySettings()" in source
+    assert 'Label("Reset Accessibility Permission...", systemImage: "figure.wave")' in source
+    assert "resetAccessibilityPermission()" in source
+    assert 'runTCCReset(service: "Accessibility")' in source
+    assert 'process.arguments = ["reset", service, bundleIdentifier]' in source
+    assert "accessibilityPromptMarkerURL" in source
+    assert "AXIsProcessTrustedWithOptions(options)" in source
     assert "accessibilitySettingsURLs" in source
     assert "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" in source
-    assert "Accessibility permission controls auto-inserting transcripts" in source
+    assert "Enable Agent CLI in Accessibility" in source
 
 
 def test_macos_app_makes_command_errors_discoverable() -> None:


### PR DESCRIPTION
## Summary
- replace direct settings links with permission repair actions in the macOS troubleshooting menu
- reset Accessibility TCC state, re-trigger the permission prompt, and open Accessibility settings
- request notification permission when possible, otherwise open Notification Settings with clearer guidance

## Tests
- uv run pytest tests/test_macos_app.py -q
- swift test
- git diff --check