### PR TITLE
Add macOS transcription instructions setting

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -9,6 +9,7 @@ struct AgentCommand {
     let identifier: String
     let title: String
     let arguments: [String]
+    let appliesTranscriptionExtraInstructions: Bool
     let forceBootstrap: Bool
     let bootstrapRequirement: AgentBootstrapRequirement
     let showsRecordingIndicator: Bool
@@ -20,6 +21,7 @@ struct AgentCommand {
         identifier: String,
         title: String,
         arguments: [String],
+        appliesTranscriptionExtraInstructions: Bool = false,
         forceBootstrap: Bool = false,
         bootstrapRequirement: AgentBootstrapRequirement = .cliRuntime,
         showsRecordingIndicator: Bool = false,
@@ -30,6 +32,7 @@ struct AgentCommand {
         self.identifier = identifier
         self.title = title
         self.arguments = arguments
+        self.appliesTranscriptionExtraInstructions = appliesTranscriptionExtraInstructions
         self.forceBootstrap = forceBootstrap
         self.bootstrapRequirement = bootstrapRequirement
         self.showsRecordingIndicator = showsRecordingIndicator
@@ -38,10 +41,20 @@ struct AgentCommand {
         self.finishNotificationTitle = finishNotificationTitle
     }
 
+    func resolvedArguments(extraInstructions: String?) -> [String] {
+        guard appliesTranscriptionExtraInstructions else { return arguments }
+
+        let trimmedInstructions = extraInstructions?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedInstructions.isEmpty else { return arguments }
+
+        return arguments + ["--extra-instructions", trimmedInstructions]
+    }
+
     static let toggleTranscription = AgentCommand(
         identifier: "transcribe",
         title: "Toggle Transcription",
         arguments: ["transcribe", "--toggle", "--quiet"],
+        appliesTranscriptionExtraInstructions: true,
         bootstrapRequirement: .transcription,
         showsRecordingIndicator: true,
         startNotificationTitle: "Transcription Started",

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -161,6 +161,7 @@ final class AgentCommandRunner: ObservableObject {
             : "Running \(command.title)..."
 
         let bootstrap = self.bootstrap
+        let commandArguments = command.resolvedArguments(extraInstructions: TranscriptionSettings.extraInstructions)
         DispatchQueue.global(qos: .userInitiated).async {
             let bootstrapResult = bootstrap(command.bootstrapRequirement, command.forceBootstrap)
             guard bootstrapResult.exitCode == 0 else {
@@ -192,7 +193,7 @@ final class AgentCommandRunner: ObservableObject {
                 }
             }
 
-            let result = AgentRuntime.shared.runAgentCLI(arguments: command.arguments)
+            let result = AgentRuntime.shared.runAgentCLI(arguments: commandArguments)
             let message = Self.statusMessage(for: command, result: result)
             let notificationTitle = Self.notificationTitle(for: command, result: result)
             let notificationBody = Self.notificationBody(for: command, result: result, statusMessage: message)

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -150,6 +150,8 @@ enum ShortcutDefaultsMigrator {
 
 struct SettingsView: View {
     @ObservedObject private var loginItemController = LoginItemController.shared
+    @AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)
+    private var transcriptionExtraInstructions = ""
     @State private var shortcutRevision = 0
 
     var body: some View {
@@ -171,6 +173,17 @@ struct SettingsView: View {
                 }
             } header: {
                 Text("General")
+            }
+
+            Section {
+                TextEditor(text: $transcriptionExtraInstructions)
+                    .font(.body)
+                    .frame(minHeight: 96)
+                    .scrollContentBackground(.hidden)
+            } header: {
+                Text("Transcription Instructions")
+            } footer: {
+                Text("Names, vocabulary, and guidance to pass as initial transcription context.")
             }
 
             Section {

--- a/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum TranscriptionSettings {
+    static let transcriptionExtraInstructionsKey = "transcriptionExtraInstructions"
+
+    static var extraInstructions: String {
+        UserDefaults.standard.string(forKey: transcriptionExtraInstructionsKey) ?? ""
+    }
+}

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -8,6 +8,35 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(AgentCommand.toggleTranscription.bootstrapRequirement, .transcription)
     }
 
+    func testToggleTranscriptionAppendsConfiguredExtraInstructions() {
+        XCTAssertEqual(
+            AgentCommand.toggleTranscription.resolvedArguments(
+                extraInstructions: "  Remember Bas and Henk.\nPrefer project names.  "
+            ),
+            [
+                "transcribe",
+                "--toggle",
+                "--quiet",
+                "--extra-instructions",
+                "Remember Bas and Henk.\nPrefer project names.",
+            ]
+        )
+    }
+
+    func testBlankExtraInstructionsAreIgnored() {
+        XCTAssertEqual(
+            AgentCommand.toggleTranscription.resolvedArguments(extraInstructions: "  \n\t  "),
+            AgentCommand.toggleTranscription.arguments
+        )
+    }
+
+    func testExtraInstructionsOnlyApplyToTranscription() {
+        XCTAssertEqual(
+            AgentCommand.autocorrect.resolvedArguments(extraInstructions: "Remember Bas."),
+            AgentCommand.autocorrect.arguments
+        )
+    }
+
     func testAutocorrectOnlyRequiresCliRuntime() {
         XCTAssertEqual(AgentCommand.autocorrect.arguments, ["autocorrect", "--quiet"])
         XCTAssertEqual(AgentCommand.autocorrect.bootstrapRequirement, .cliRuntime)

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -143,6 +143,23 @@ def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
     assert "daemon install rag" not in source
 
 
+def test_macos_app_settings_pass_extra_instructions_to_transcription() -> None:
+    """Settings should persist transcription context and pass it to the ASR prompt."""
+    source = swift_source()
+
+    assert (
+        'static let transcriptionExtraInstructionsKey = "transcriptionExtraInstructions"' in source
+    )
+    assert "Transcription Instructions" in source
+    assert "@AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)" in source
+    assert '"--extra-instructions"' in source
+    assert (
+        "command.resolvedArguments(extraInstructions: TranscriptionSettings.extraInstructions)"
+        in source
+    )
+    assert "appliesTranscriptionExtraInstructions: true" in source
+
+
 def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     """Daily actions should stay top-level; diagnostics belong in troubleshooting."""
     source = swift_source()


### PR DESCRIPTION
## Summary
- add a persisted macOS settings field for transcription instructions
- append nonblank instructions to transcription runs via `--extra-instructions`
- cover the command argument behavior and macOS app source wiring with tests

## Tests
- `swift build --package-path macos/AgentCLI`
- `uv run pytest tests/test_macos_app.py -q`
- `uv run pytest`
- `uv run pre-commit run --all-files`