### PR TITLE
Fix macOS login item release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_VERSION: ${{ github.event.release.tag_name }}
+          BUILD_VERSION: ${{ github.run_number }}
         run: NOTARIZE=1 macos/build-macos-app.sh --dmg
       - name: Upload macOS app to GitHub Release
         env:

--- a/macos/AgentCLI/Sources/AgentCLI/LoginItemController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/LoginItemController.swift
@@ -21,9 +21,9 @@ struct LoginItemPresentation: Equatable {
 
     var canToggle: Bool {
         switch status {
-        case .notFound, .unavailable:
+        case .unavailable:
             return false
-        case .notRegistered, .enabled, .requiresApproval:
+        case .notRegistered, .enabled, .requiresApproval, .notFound:
             return true
         }
     }
@@ -37,7 +37,7 @@ struct LoginItemPresentation: Equatable {
         case .requiresApproval:
             return "Approve Agent CLI in System Settings > General > Login Items."
         case .notFound:
-            return "Start at login is only available when Agent CLI is running from an app bundle."
+            return "macOS could not find Agent CLI's login item registration. Remove old copies, keep Agent CLI in /Applications, then toggle Start at Login again."
         case .unavailable:
             return "Start at login is unavailable on this macOS version."
         case .notRegistered, .enabled:

--- a/macos/AgentCLI/Tests/AgentCLITests/LoginItemControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/LoginItemControllerTests.swift
@@ -21,5 +21,17 @@ final class LoginItemControllerTests: XCTestCase {
             "Approve Agent CLI in System Settings > General > Login Items."
         )
     }
+
+    func testNotFoundCanStillBeToggledToLetServiceManagementRecoverOrReportError() {
+        let presentation = LoginItemPresentation(status: .notFound)
+
+        XCTAssertFalse(presentation.isEnabled)
+        XCTAssertTrue(presentation.canToggle)
+        XCTAssertEqual(presentation.menuTitle, "Start at Login: Unavailable")
+        XCTAssertEqual(
+            presentation.helpText,
+            "macOS could not find Agent CLI's login item registration. Remove old copies, keep Agent CLI in /Applications, then toggle Start at Login again."
+        )
+    }
 }
 #endif

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -20,6 +20,10 @@ Options:
 
 Environment:
   CODESIGN_IDENTITY  Codesign identity to use. Defaults to ad-hoc signing (-).
+  APP_VERSION        CFBundleShortVersionString to stamp into the app.
+                     Defaults to the built wheel version.
+  BUILD_VERSION      CFBundleVersion to stamp into the app. Defaults to
+                     GITHUB_RUN_NUMBER, then the git commit count.
   UV_BINARY          uv binary to bundle. Defaults to the uv found on PATH.
   INSTALL_DIR        Install destination. Defaults to /Applications.
   AGENTCLI_SKIP_OPEN Set to 1 to skip opening the app after --install.
@@ -74,6 +78,8 @@ ICON_SOURCE_PNG="$DIST_DIR/logo-avatar-source.png"
 NOTIFICATION_LOGO_PNG="$DIST_DIR/logo-avatar.png"
 APP_ICON_ICNS="$DIST_DIR/AgentCLI.icns"
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
+APP_VERSION=${APP_VERSION:-}
+BUILD_VERSION=${BUILD_VERSION:-${GITHUB_RUN_NUMBER:-}}
 UV_BINARY=${UV_BINARY:-$(command -v uv || true)}
 INSTALL_DIR=${INSTALL_DIR:-/Applications}
 NOTARIZE=${NOTARIZE:-0}
@@ -160,6 +166,64 @@ sign_dmg_if_needed() {
     fi
 
     codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$dmg_path"
+}
+
+resolve_app_version() {
+    local wheel_filename="$1"
+    local raw_version="$APP_VERSION"
+    local major
+    local minor
+    local patch
+
+    if [[ -z "$raw_version" ]]; then
+        raw_version="${wheel_filename#agent_cli-}"
+        raw_version="${raw_version%%-*}"
+    fi
+
+    if [[ "$raw_version" =~ ^v?([0-9]+)(\.([0-9]+))?(\.([0-9]+))? ]]; then
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[3]:-0}"
+        patch="${BASH_REMATCH[5]:-0}"
+        printf '%s.%s.%s\n' "$major" "$minor" "$patch"
+        return
+    fi
+
+    echo "Could not derive a macOS app version from: $raw_version" >&2
+    exit 1
+}
+
+resolve_build_version() {
+    local build_version="$BUILD_VERSION"
+
+    if [[ -z "$build_version" ]]; then
+        build_version=$(git -C "$ROOT_DIR" rev-list --count HEAD 2>/dev/null || true)
+    fi
+    if [[ -z "$build_version" ]]; then
+        build_version=$(date +%Y%m%d%H%M%S)
+    fi
+
+    build_version=$(printf '%s' "$build_version" | tr -cd '0-9.')
+    if [[ -z "$build_version" || ! "$build_version" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+        echo "Could not derive a numeric macOS app build version from: ${BUILD_VERSION:-unset}" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$build_version"
+}
+
+stamp_info_plist() {
+    local wheel_filename="$1"
+    local app_version
+    local build_version
+
+    app_version=$(resolve_app_version "$wheel_filename")
+    build_version=$(resolve_build_version)
+
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $app_version" \
+        "$APP_DIR/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_version" \
+        "$APP_DIR/Contents/Info.plist"
+    echo "Stamped app bundle version $app_version ($build_version)"
 }
 
 require_notarization_env() {
@@ -475,6 +539,7 @@ test -f "$APP_DIR/Contents/Resources/AgentCLI.icns" || {
     exit 1
 }
 
+stamp_info_plist "$(basename "$WHEEL_PATH")"
 sign_bundled_executables
 sign_app "$APP_DIR"
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -757,6 +757,24 @@ def test_macos_build_script_creates_signed_app_bundle() -> None:
     assert "hdiutil create" in script
 
 
+def test_macos_build_script_stamps_release_version_into_app_bundle() -> None:
+    """Released app bundles should not keep the static template plist version."""
+    script = BUILD_SCRIPT.read_text()
+
+    assert "APP_VERSION" in script
+    assert "BUILD_VERSION" in script
+    assert "resolve_app_version" in script
+    assert "resolve_build_version" in script
+    assert "stamp_info_plist" in script
+    assert "/usr/libexec/PlistBuddy" in script
+    assert "CFBundleShortVersionString" in script
+    assert "CFBundleVersion" in script
+    assert 'stamp_info_plist "$(basename "$WHEEL_PATH")"' in script
+    assert script.index('stamp_info_plist "$(basename "$WHEEL_PATH")"') < script.index(
+        'sign_app "$APP_DIR"',
+    )
+
+
 def test_macos_build_script_can_notarize_release_dmg() -> None:
     """Release builds should notarize and staple a Developer ID-signed DMG."""
     script = BUILD_SCRIPT.read_text()
@@ -840,6 +858,8 @@ def test_release_workflow_publishes_macos_app_asset() -> None:
     assert "APPLE_ID" in workflow
     assert "APPLE_APP_SPECIFIC_PASSWORD" in workflow
     assert "APPLE_TEAM_ID" in workflow
+    assert "APP_VERSION: ${{ github.event.release.tag_name }}" in workflow
+    assert "BUILD_VERSION: ${{ github.run_number }}" in workflow
     assert "apple-actions/import-codesign-certs@v7" in workflow
     assert "p12-file-base64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_BASE64 }}" in workflow
     assert "p12-password: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}" in workflow


### PR DESCRIPTION
## Summary
- stamp released macOS app bundles with the release tag and GitHub run number before signing
- pass app/build version metadata from the release workflow into the DMG build
- allow Start at Login to retry registration when ServiceManagement reports `.notFound`, with clearer stale-registration guidance

## Verification
- `bash -n macos/build-macos-app.sh`
- `swift build -c debug --package-path macos/AgentCLI`
- `uv run pytest tests/test_macos_app.py -q` (`43 passed`)
- `APP_VERSION=v9.8.7 BUILD_VERSION=12345 macos/build-macos-app.sh`
- verified generated `dist/macos/AgentCLI.app/Contents/Info.plist` contains `CFBundleShortVersionString=9.8.7` and `CFBundleVersion=12345`
- `codesign --verify --deep --strict --verbose=2 dist/macos/AgentCLI.app`

## CI
The existing `pytest` workflow runs on `pull_request`. It runs Swift tests on `macos-latest` with Python 3.13, and pytest across Ubuntu, macOS, and Windows for Python 3.11 and 3.13.
