### PR TITLE
Warm up Whisper model on macOS launch

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 enum AgentBootstrapRequirement: Equatable {
     case cliRuntime
     case transcription
+    case transcriptionModel
 }
 
 struct AgentCommand {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -88,7 +88,7 @@ final class AgentCommandRunner: ObservableObject {
 
         let bootstrap = self.bootstrap
         DispatchQueue.global(qos: .utility).async {
-            let result = bootstrap(.transcription, false)
+            let result = bootstrap(.transcriptionModel, false)
 
             Task { @MainActor in
                 self.activeCommandCount = max(0, self.activeCommandCount - 1)

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -20,6 +20,7 @@ struct AgentRuntime {
     let agentCLIURL: URL
     let agentCLIInstallMarkerURL: URL
     let whisperDaemonMarkerURL: URL
+    let whisperWarmUpAudioURL: URL
     let accessibilityPromptMarkerURL: URL
     let notificationLogoURL: URL?
     let lastErrorURL: URL
@@ -48,6 +49,7 @@ struct AgentRuntime {
         agentCLIURL = binURL.appendingPathComponent("agent-cli")
         agentCLIInstallMarkerURL = appSupportURL.appendingPathComponent(".agent-cli-installed")
         whisperDaemonMarkerURL = appSupportURL.appendingPathComponent(".whisper-daemon-installed")
+        whisperWarmUpAudioURL = runtimeURL.appendingPathComponent("whisper-model-warmup.wav")
         accessibilityPromptMarkerURL = appSupportURL.appendingPathComponent(".accessibility-prompted")
         notificationLogoURL = bundle.url(forResource: "logo-avatar", withExtension: "png")
         lastErrorURL = appSupportURL.appendingPathComponent("last-error.txt")
@@ -184,6 +186,12 @@ struct AgentRuntime {
                 return installResult
             }
             return ensureWhisperDaemon(force: force)
+        case .transcriptionModel:
+            let daemonResult = ensureReadyUnsynchronized(for: .transcription, force: force)
+            guard daemonResult.exitCode == 0 else {
+                return daemonResult
+            }
+            return warmUpWhisperModel()
         }
     }
 
@@ -204,6 +212,86 @@ struct AgentRuntime {
             encoding: .utf8
         )
         return waitForWhisperDaemonReady()
+    }
+
+    private func warmUpWhisperModel() -> CommandResult {
+        let warmUpAudioURL: URL
+        do {
+            warmUpAudioURL = try writeWhisperWarmUpAudio()
+        } catch {
+            return CommandResult(
+                exitCode: 1,
+                output: "Could not prepare Whisper model warm-up audio: \(error.localizedDescription)"
+            )
+        }
+
+        let result = runAgentCLI(arguments: [
+            "transcribe",
+            "--from-file",
+            warmUpAudioURL.path,
+            "--asr-provider",
+            "wyoming",
+            "--asr-wyoming-ip",
+            "127.0.0.1",
+            "--asr-wyoming-port",
+            "10300",
+            "--no-llm",
+            "--no-clipboard",
+            "--quiet"
+        ])
+        guard result.exitCode == 0 else {
+            return result
+        }
+        return CommandResult(exitCode: 0, output: "")
+    }
+
+    private func writeWhisperWarmUpAudio() throws -> URL {
+        let sampleRate: UInt32 = 16_000
+        let channelCount: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let sampleCount: UInt32 = sampleRate / 4
+        let bytesPerSample = bitsPerSample / 8
+        let byteRate = sampleRate * UInt32(channelCount) * UInt32(bytesPerSample)
+        let blockAlign = channelCount * bytesPerSample
+        let dataSize = sampleCount * UInt32(blockAlign)
+        let riffSize = 36 + dataSize
+
+        var data = Data()
+        appendASCII("RIFF", to: &data)
+        appendUInt32(riffSize, to: &data)
+        appendASCII("WAVE", to: &data)
+        appendASCII("fmt ", to: &data)
+        appendUInt32(16, to: &data)
+        appendUInt16(1, to: &data)
+        appendUInt16(channelCount, to: &data)
+        appendUInt32(sampleRate, to: &data)
+        appendUInt32(byteRate, to: &data)
+        appendUInt16(blockAlign, to: &data)
+        appendUInt16(bitsPerSample, to: &data)
+        appendASCII("data", to: &data)
+        appendUInt32(dataSize, to: &data)
+        data.append(Data(repeating: 0, count: Int(dataSize)))
+
+        try data.write(to: whisperWarmUpAudioURL, options: .atomic)
+        return whisperWarmUpAudioURL
+    }
+
+    private func appendASCII(_ string: String, to data: inout Data) {
+        data.append(string.data(using: .ascii) ?? Data())
+    }
+
+    private func appendUInt16(_ value: UInt16, to data: inout Data) {
+        var littleEndianValue = value.littleEndian
+        withUnsafeBytes(of: &littleEndianValue) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+
+    private func appendUInt32(_ value: UInt32, to data: inout Data) {
+        var littleEndianValue = value.littleEndian
+        withUnsafeBytes(of: &littleEndianValue) { bytes in
+            data.append(contentsOf: bytes)
+        }
     }
 
     private func waitForWhisperDaemonReady(timeout: TimeInterval = 180) -> CommandResult {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -52,7 +52,7 @@ final class AgentCommandTests: XCTestCase {
 
         wait(for: [recorder.expectation], timeout: 2)
 
-        XCTAssertEqual(recorder.calls, [.init(requirement: .transcription, force: false)])
+        XCTAssertEqual(recorder.calls, [.init(requirement: .transcriptionModel, force: false)])
     }
 }
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -449,6 +449,7 @@ def test_macos_app_uses_bootstrap_requirement_model() -> None:
     assert "enum AgentBootstrapRequirement" in source
     assert "case cliRuntime" in source
     assert "case transcription" in source
+    assert "case transcriptionModel" in source
     assert "let bootstrapRequirement: AgentBootstrapRequirement" in source
     assert "AgentRuntime.shared.ensureReady(for: requirement, force: force)" in source
     assert "bootstrap(command.bootstrapRequirement, command.forceBootstrap)" in source
@@ -462,9 +463,27 @@ def test_macos_app_warms_transcription_on_launch() -> None:
     assert "AgentCommandRunner.shared.warmUpTranscription()" in source
     assert "private var hasStartedTranscriptionWarmUp = false" in source
     assert 'statusMessage = "Preparing voice service..."' in source
-    assert "let result = bootstrap(.transcription, false)" in source
+    assert "let result = bootstrap(.transcriptionModel, false)" in source
     assert 'recordFailure(title: "Startup Voice Service Warm-Up", result: result)' in source
     assert 'DispatchQueue(label: "lt.nijho.agent-cli.bootstrap")' in source
+
+
+def test_macos_app_warms_whisper_model_on_launch() -> None:
+    """Startup warm-up should force Whisper's lazily loaded model to initialize."""
+    source = swift_source()
+
+    assert "case transcriptionModel" in source
+    assert "let result = bootstrap(.transcriptionModel, false)" in source
+    assert "warmUpWhisperModel()" in source
+    assert "writeWhisperWarmUpAudio()" in source
+    assert 'appendingPathComponent("whisper-model-warmup.wav")' in source
+    assert '"transcribe",' in source
+    assert '"--from-file",' in source
+    assert '"--asr-provider",' in source
+    assert '"wyoming",' in source
+    assert '"--no-llm",' in source
+    assert '"--no-clipboard",' in source
+    assert '"--quiet"' in source
 
 
 def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:


### PR DESCRIPTION
## Summary
- add a startup-only transcription model bootstrap requirement for the macOS app
- generate a tiny local 16 kHz mono WAV and transcribe it through Wyoming to trigger Whisper's lazy model load
- keep regular transcription commands on daemon-readiness bootstrap so they do not run the dummy transcription each time

## Test Plan
- uv run pytest tests/test_macos_app.py::test_macos_app_warms_whisper_model_on_launch
- uv run pytest tests/test_macos_app.py
- swift test
- swift build
- uv run pytest
- pre-commit run --all-files

Note:  still fails in this local Command Line Tools environment because  cannot resolve PlatformPath.