### PR TITLE
Fix function-key transcription shortcuts

### DIFF
--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -20,9 +20,11 @@ The packaged app registers native macOS global hotkeys itself:
 
 Choose **Settings...** from the menu bar app to change these shortcuts or enable
 **Start at Login**. The settings UI uses the `KeyboardShortcuts` Swift package
-for shortcut parsing, `UserDefaults` storage, and global key-up handlers. The
-login option uses Apple's login item API for the main app bundle, so macOS may
-require approval in System Settings → General → Login Items.
+for shortcut parsing and `UserDefaults` storage. Transcription shortcuts are
+handled by a small CGEvent tap so `Fn`, `Fn+Space`, and plain Space remain
+distinct; the clipboard utility shortcuts still use `KeyboardShortcuts` global
+handlers. The login option uses Apple's login item API for the main app bundle,
+so macOS may require approval in System Settings → General → Login Items.
 
 ## Build
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -111,22 +111,24 @@ final class AgentCommandRunner: ObservableObject {
         }
     }
 
-    func beginHoldToTranscribe() {
+    @discardableResult
+    func beginHoldToTranscribe() -> Bool {
         guard holdTranscriptionState == .idle else {
             if holdTranscriptionState.isFinishing {
                 statusMessage = "Finishing previous hold-to-transcribe request"
             }
-            return
+            return false
         }
         guard !recordingIndicator.isRecordingCommand(.toggleTranscription), !isStopPending(for: .toggleTranscription) else {
             statusMessage = "Transcription is already recording"
-            return
+            return false
         }
 
         holdTranscriptionState = .recording
         holdToTranscribePasteTarget = FocusedTextTarget.capture()
         pasteAfterRecordingCommands.insert(AgentCommand.toggleTranscription.identifier)
         run(.toggleTranscription)
+        return true
     }
 
     func endHoldToTranscribe() {
@@ -141,6 +143,18 @@ final class AgentCommandRunner: ObservableObject {
             statusMessage = "Stopping transcription as soon as it starts..."
         }
         stopHeldTranscriptionWhenReady()
+    }
+
+    @discardableResult
+    func stopTranscriptionFromFunctionKeyIfNeeded() -> Bool {
+        guard holdTranscriptionState == .idle,
+              recordingIndicator.isRecordingCommand(.toggleTranscription),
+              !isStopPending(for: .toggleTranscription) else {
+            return false
+        }
+
+        run(.toggleTranscription)
+        return true
     }
 
     func run(_ command: AgentCommand) {

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -1,3 +1,5 @@
+import ApplicationServices
+import Carbon.HIToolbox
 import Foundation
 import KeyboardShortcuts
 
@@ -5,21 +7,23 @@ final class ConfigurableHotkeyController {
     static let shared = ConfigurableHotkeyController()
 
     private var registered = false
+    private weak var runner: AgentCommandRunner?
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var functionKeyIsDown = false
+    private var suppressNextFunctionKeyRelease = false
+    private var holdToTranscribeIsRecording = false
+    private var pendingHoldToTranscribeWorkItem: DispatchWorkItem?
+    private let holdToTranscribeDelay: TimeInterval = 0.16
 
     private init() {}
 
     func registerDefaultHotkeys(runner: AgentCommandRunner) {
         guard !registered else { return }
 
-        KeyboardShortcuts.onKeyUp(for: .toggleTranscription) {
-            Task { @MainActor in runner.run(.toggleTranscription) }
-        }
-        KeyboardShortcuts.onKeyDown(for: .holdToTranscribe) {
-            Task { @MainActor in runner.beginHoldToTranscribe() }
-        }
-        KeyboardShortcuts.onKeyUp(for: .holdToTranscribe) {
-            Task { @MainActor in runner.endHoldToTranscribe() }
-        }
+        self.runner = runner
+        registerFunctionAwareTranscriptionHotkeys(runner: runner)
+
         KeyboardShortcuts.onKeyUp(for: .autocorrect) {
             Task { @MainActor in runner.run(.autocorrect) }
         }
@@ -28,5 +32,252 @@ final class ConfigurableHotkeyController {
         }
 
         registered = true
+    }
+
+    private func registerFunctionAwareTranscriptionHotkeys(runner: AgentCommandRunner) {
+        let eventMask =
+            CGEventMask(1 << CGEventType.keyDown.rawValue) |
+            CGEventMask(1 << CGEventType.keyUp.rawValue) |
+            CGEventMask(1 << CGEventType.flagsChanged.rawValue)
+
+        let userInfo = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: { _, type, event, userInfo in
+                guard let userInfo else {
+                    return Unmanaged.passUnretained(event)
+                }
+
+                let controller = Unmanaged<ConfigurableHotkeyController>
+                    .fromOpaque(userInfo)
+                    .takeUnretainedValue()
+                return controller.handleFunctionAwareHotkey(type: type, event: event)
+            },
+            userInfo: userInfo
+        ) else {
+            requestAccessibilityPermissionForFunctionHotkeys()
+            Task { @MainActor in
+                runner.statusMessage = "Allow Accessibility permission for Fn transcription shortcuts"
+            }
+            return
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    private func handleFunctionAwareHotkey(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        switch type {
+        case .tapDisabledByTimeout, .tapDisabledByUserInput:
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        default:
+            break
+        }
+
+        if handleToggleTranscriptionShortcut(type: type, event: event) {
+            return nil
+        }
+        if handleHoldToTranscribeShortcut(type: type, event: event) {
+            return nil
+        }
+        if handleFunctionKeyChanged(type: type, event: event) {
+            return nil
+        }
+
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func handleToggleTranscriptionShortcut(type: CGEventType, event: CGEvent) -> Bool {
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription),
+              shortcutMatches(type: type, event: event, shortcut: shortcut) else {
+            return false
+        }
+
+        if type == .keyDown {
+            cancelPendingHoldToTranscribe()
+            suppressNextFunctionKeyRelease = usesFunctionModifier(shortcut)
+
+            if !isAutorepeat(event) && !holdToTranscribeIsRecording {
+                Task { @MainActor in
+                    self.runner?.run(.toggleTranscription)
+                }
+            }
+        }
+
+        return true
+    }
+
+    private func handleHoldToTranscribeShortcut(type: CGEventType, event: CGEvent) -> Bool {
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: .holdToTranscribe) else {
+            return false
+        }
+        guard !isBareFunctionShortcut(shortcut),
+              shortcutMatches(type: type, event: event, shortcut: shortcut) else {
+            return false
+        }
+
+        if type == .keyDown {
+            if !isAutorepeat(event) && !holdToTranscribeIsRecording {
+                Task { @MainActor in
+                    guard let runner = self.runner else { return }
+                    if runner.beginHoldToTranscribe() {
+                        self.holdToTranscribeIsRecording = true
+                    }
+                }
+            }
+            return true
+        }
+
+        if type == .keyUp {
+            if holdToTranscribeIsRecording {
+                holdToTranscribeIsRecording = false
+                Task { @MainActor in
+                    guard let runner = self.runner else { return }
+                    runner.endHoldToTranscribe()
+                }
+            }
+            return true
+        }
+
+        return false
+    }
+
+    private func handleFunctionKeyChanged(type: CGEventType, event: CGEvent) -> Bool {
+        guard type == .flagsChanged,
+              Int(event.getIntegerValueField(.keyboardEventKeycode)) == kVK_Function,
+              let shortcut = KeyboardShortcuts.getShortcut(for: .holdToTranscribe),
+              isBareFunctionShortcut(shortcut) else {
+            return false
+        }
+
+        let isFunctionDown = event.flags.contains(CGEventFlags.maskSecondaryFn)
+        if isFunctionDown {
+            guard !functionKeyIsDown else { return true }
+            functionKeyIsDown = true
+            schedulePendingHoldToTranscribe()
+            return true
+        }
+
+        functionKeyIsDown = false
+        cancelPendingHoldToTranscribe()
+        guard !suppressNextFunctionKeyRelease else {
+            suppressNextFunctionKeyRelease = false
+            return true
+        }
+
+        if holdToTranscribeIsRecording {
+            holdToTranscribeIsRecording = false
+            Task { @MainActor in
+                guard let runner = self.runner else { return }
+                runner.endHoldToTranscribe()
+            }
+        } else {
+            Task { @MainActor in
+                _ = self.runner?.stopTranscriptionFromFunctionKeyIfNeeded()
+            }
+        }
+
+        return true
+    }
+
+    private func schedulePendingHoldToTranscribe() {
+        cancelPendingHoldToTranscribe()
+
+        var workItem: DispatchWorkItem?
+        workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  workItem?.isCancelled == false else {
+                return
+            }
+
+            self.pendingHoldToTranscribeWorkItem = nil
+            Task { @MainActor in
+                if self.runner?.stopTranscriptionFromFunctionKeyIfNeeded() == true {
+                    return
+                }
+
+                guard let runner = self.runner else { return }
+                if runner.beginHoldToTranscribe() {
+                    self.holdToTranscribeIsRecording = true
+                }
+            }
+        }
+
+        pendingHoldToTranscribeWorkItem = workItem
+        if let workItem {
+            DispatchQueue.main.asyncAfter(deadline: .now() + holdToTranscribeDelay, execute: workItem)
+        }
+    }
+
+    private func cancelPendingHoldToTranscribe() {
+        pendingHoldToTranscribeWorkItem?.cancel()
+        pendingHoldToTranscribeWorkItem = nil
+    }
+
+    private func shortcutMatches(type: CGEventType, event: CGEvent, shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        guard type == .keyDown || type == .keyUp else {
+            return false
+        }
+
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        guard keyCode == shortcut.carbonKeyCode else {
+            return false
+        }
+
+        return carbonModifiers(from: event.flags) == shortcut.carbonModifiers
+    }
+
+    private func usesFunctionModifier(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        shortcut.carbonModifiers & kEventKeyModifierFnMask != 0
+    }
+
+    private func isBareFunctionShortcut(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        shortcut.carbonKeyCode == kVK_Function && shortcut.carbonModifiers == 0
+    }
+
+    private func carbonModifiers(from flags: CGEventFlags) -> Int {
+        var modifiers = 0
+        if flags.contains(.maskCommand) {
+            modifiers |= cmdKey
+        }
+        if flags.contains(.maskShift) {
+            modifiers |= shiftKey
+        }
+        if flags.contains(.maskAlternate) {
+            modifiers |= optionKey
+        }
+        if flags.contains(.maskControl) {
+            modifiers |= controlKey
+        }
+        if flags.contains(.maskAlphaShift) {
+            modifiers |= alphaLock
+        }
+        if flags.contains(CGEventFlags.maskSecondaryFn) {
+            modifiers |= kEventKeyModifierFnMask
+        }
+        return modifiers
+    }
+
+    private func isAutorepeat(_ event: CGEvent) -> Bool {
+        event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+    }
+
+    private func requestAccessibilityPermissionForFunctionHotkeys() {
+        guard !AXIsProcessTrusted() else { return }
+
+        // Equivalent to kAXTrustedCheckOptionPrompt as String, but Swift exposes it unmanaged.
+        let promptOption = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let options = [promptOption: true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
     }
 }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -341,11 +341,10 @@ def test_macos_app_supports_configurable_hold_to_transcribe_shortcut() -> None:
     assert "default: KeyboardShortcuts.Shortcut(.function)" in source
     assert 'title: "Hold to Transcribe"' in source
     assert "name: .holdToTranscribe" in source
-    assert "KeyboardShortcuts.onKeyDown(for: .holdToTranscribe)" in source
+    assert "handleFunctionKeyChanged" in source
     assert "runner.beginHoldToTranscribe()" in source
-    assert "KeyboardShortcuts.onKeyUp(for: .holdToTranscribe)" in source
     assert "runner.endHoldToTranscribe()" in source
-    assert "func beginHoldToTranscribe()" in source
+    assert "func beginHoldToTranscribe() -> Bool" in source
     assert "func endHoldToTranscribe()" in source
     assert "private var holdTranscriptionState: HoldTranscriptionState = .idle" in source
     assert "private var pasteAfterRecordingCommands: Set<String> = []" in source
@@ -480,6 +479,48 @@ def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:
     assert "carbonModifiers |= kEventKeyModifierFnMask" in source
     assert ".flagsChanged" in source
     assert "Fn+Space" in source
+
+
+def test_macos_app_uses_fn_aware_event_tap_for_transcription_shortcuts() -> None:
+    """Fn transcription shortcuts must not be registered as plain Space Carbon hotkeys."""
+    source = swift_source()
+
+    assert "CGEvent.tapCreate" in source
+    assert "CGEventType.keyDown" in source
+    assert "CGEventType.keyUp" in source
+    assert "CGEventType.flagsChanged" in source
+    assert "CGEventFlags.maskSecondaryFn" in source
+    assert "handleFunctionAwareHotkey" in source
+    assert "KeyboardShortcuts.onKeyUp(for: .toggleTranscription)" not in source
+    assert "KeyboardShortcuts.onKeyDown(for: .holdToTranscribe)" not in source
+    assert "KeyboardShortcuts.onKeyUp(for: .holdToTranscribe)" not in source
+
+
+def test_macos_app_disambiguates_fn_hold_from_fn_space_toggle() -> None:
+    """Bare Fn should be delayed so an Fn+Space chord can start hands-free mode."""
+    source = swift_source()
+
+    assert "holdToTranscribeDelay" in source
+    assert "pendingHoldToTranscribeWorkItem" in source
+    assert "cancelPendingHoldToTranscribe()" in source
+    assert "handleToggleTranscriptionShortcut" in source
+    assert "handleFunctionKeyChanged" in source
+    assert "stopTranscriptionFromFunctionKeyIfNeeded" in source
+    assert "runner.beginHoldToTranscribe()" in source
+    assert "runner.endHoldToTranscribe()" in source
+
+
+def test_macos_app_event_tap_preserves_custom_hold_to_transcribe_shortcuts() -> None:
+    """Moving off KeyboardShortcuts handlers should still support non-Fn hold shortcuts."""
+    source = swift_source()
+
+    assert "handleHoldToTranscribeShortcut" in source
+    assert "isBareFunctionShortcut" in source
+    assert "guard !isBareFunctionShortcut(shortcut)" in source
+    assert "type == .keyDown" in source
+    assert "type == .keyUp" in source
+    assert "runner.beginHoldToTranscribe()" in source
+    assert "runner.endHoldToTranscribe()" in source
 
 
 def test_macos_app_migrates_old_default_shortcuts_to_fn_defaults() -> None:
@@ -720,7 +761,7 @@ def test_macos_app_makes_command_errors_discoverable() -> None:
 
 
 def test_macos_app_registers_configurable_native_global_hotkeys() -> None:
-    """KeyboardShortcuts source documents setShortcut/getShortcut and onKeyUp handlers."""
+    """Shortcuts should be recorded in settings and registered by native hotkey handlers."""
     source = swift_source()
 
     assert "import KeyboardShortcuts" in source
@@ -728,7 +769,8 @@ def test_macos_app_registers_configurable_native_global_hotkeys() -> None:
     assert "KeyboardShortcuts.Shortcut(event:" in source
     assert "KeyboardShortcuts.setShortcut" in source
     assert "KeyboardShortcuts.getShortcut" in source
-    assert "KeyboardShortcuts.onKeyDown" in source
+    assert "CGEvent.tapCreate" in source
+    assert "handleFunctionAwareHotkey" in source
     assert "KeyboardShortcuts.onKeyUp" in source
     assert "ShortcutRecorderButton" in source
     assert "Fn+Space" in source


### PR DESCRIPTION
## Summary
- Route transcription hotkeys through a function-aware event tap so Fn, Fn+Space, and plain Space remain distinct.
- Delay bare-Fn hold-to-transcribe startup so the Fn+Space toggle chord can be recognized first.
- Preserve custom hold-to-transcribe shortcuts and document the shortcut handling path.

## Test Plan
- uv run pytest tests/test_macos_app.py -q
- swift build --package-path macos/AgentCLI
- swift test --package-path macos/AgentCLI