### PR TITLE
Add recent recordings menu to macOS app

### DIFF
--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -252,6 +252,7 @@ def log_transcription(
     }
 
     # Append to log file
+    log_file.parent.mkdir(parents=True, exist_ok=True)
     with log_file.open("a", encoding="utf-8") as f:
         f.write(json.dumps(log_entry) + "\n")
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -39,6 +39,25 @@ struct AgentCLIApp: App {
 
             Divider()
 
+            Menu {
+                let recentTranscriptions = RecentTranscriptionReader.recentTranscriptions()
+                if recentTranscriptions.isEmpty {
+                    Text("No recent transcriptions")
+                } else {
+                    ForEach(recentTranscriptions) { transcription in
+                        Button {
+                            runner.copyRecentTranscription(transcription)
+                        } label: {
+                            Label(transcription.menuTitle, systemImage: "doc.on.clipboard")
+                        }
+                    }
+                }
+            } label: {
+                Label("Recent Recordings", systemImage: "clock.arrow.circlepath")
+            }
+
+            Divider()
+
             Button {
                 loginItemController.toggle()
             } label: {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -53,7 +53,13 @@ struct AgentCommand {
     static let toggleTranscription = AgentCommand(
         identifier: "transcribe",
         title: "Toggle Transcription",
-        arguments: ["transcribe", "--toggle", "--quiet"],
+        arguments: [
+            "transcribe",
+            "--toggle",
+            "--quiet",
+            "--transcription-log",
+            RecentTranscriptionReader.defaultLogPath,
+        ],
         appliesTranscriptionExtraInstructions: true,
         bootstrapRequirement: .transcription,
         showsRecordingIndicator: true,

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -339,6 +339,12 @@ final class AgentCommandRunner: ObservableObject {
         statusMessage = "Copied last output"
     }
 
+    func copyRecentTranscription(_ transcription: RecentTranscription) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(transcription.text, forType: .string)
+        statusMessage = "Copied recent transcription"
+    }
+
     func openLastError() {
         guard FileManager.default.fileExists(atPath: AgentRuntime.shared.lastErrorURL.path) else {
             hasLastError = false

--- a/macos/AgentCLI/Sources/AgentCLI/RecentTranscriptionReader.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecentTranscriptionReader.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+struct RecentTranscription: Equatable, Identifiable {
+    let id: String
+    let timestamp: Date?
+    let text: String
+
+    var menuTitle: String {
+        let snippet = Self.snippet(from: text, maxLength: 72)
+        guard let timestamp else { return snippet }
+        return "\(Self.menuDateFormatter.string(from: timestamp)) - \(snippet)"
+    }
+
+    private static let menuDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d HH:mm"
+        return formatter
+    }()
+
+    private static func snippet(from text: String, maxLength: Int) -> String {
+        let singleLine = text
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard singleLine.count > maxLength else { return singleLine }
+        return String(singleLine.prefix(maxLength)).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+}
+
+enum RecentTranscriptionReader {
+    static let defaultLimit = 20
+    static let defaultLogPath = "~/.config/agent-cli/transcriptions.jsonl"
+
+    static func recentTranscriptions(limit: Int = defaultLimit) -> [RecentTranscription] {
+        recentTranscriptions(from: defaultLogURL(), limit: limit)
+    }
+
+    static func recentTranscriptions(from logURL: URL, limit: Int = defaultLimit) -> [RecentTranscription] {
+        guard limit > 0,
+              let contents = try? String(contentsOf: logURL, encoding: .utf8) else {
+            return []
+        }
+
+        var entries: [RecentTranscription] = []
+        let lines = contents.components(separatedBy: .newlines)
+
+        for (lineIndex, line) in lines.enumerated().reversed() {
+            guard entries.count < limit,
+                  let entry = parseLine(line, lineIndex: lineIndex) else {
+                continue
+            }
+            entries.append(entry)
+        }
+
+        return entries
+    }
+
+    private static func defaultLogURL() -> URL {
+        URL(fileURLWithPath: NSString(string: defaultLogPath).expandingTildeInPath)
+    }
+
+    private static func parseLine(_ line: String, lineIndex: Int) -> RecentTranscription? {
+        let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLine.isEmpty,
+              let data = trimmedLine.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        guard let text = firstNonEmptyString(
+            object["processed_output"],
+            object["processed"],
+            object["raw_output"],
+            object["raw"]
+        ) else {
+            return nil
+        }
+
+        let timestampText = object["timestamp"] as? String
+        return RecentTranscription(
+            id: "\(lineIndex)-\(timestampText ?? "")",
+            timestamp: timestampText.flatMap(parseTimestamp),
+            text: text
+        )
+    }
+
+    private static func firstNonEmptyString(_ values: Any?...) -> String? {
+        for value in values {
+            guard let string = value as? String else { continue }
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    private static func parseTimestamp(_ text: String) -> Date? {
+        if let date = iso8601WithFractionalSeconds.date(from: text) {
+            return date
+        }
+        return iso8601.date(from: text)
+    }
+
+    private static let iso8601WithFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -4,7 +4,16 @@ import XCTest
 
 final class AgentCommandTests: XCTestCase {
     func testToggleTranscriptionUsesTypedArgumentsAndTranscriptionBootstrap() {
-        XCTAssertEqual(AgentCommand.toggleTranscription.arguments, ["transcribe", "--toggle", "--quiet"])
+        XCTAssertEqual(
+            AgentCommand.toggleTranscription.arguments,
+            [
+                "transcribe",
+                "--toggle",
+                "--quiet",
+                "--transcription-log",
+                "~/.config/agent-cli/transcriptions.jsonl",
+            ]
+        )
         XCTAssertEqual(AgentCommand.toggleTranscription.bootstrapRequirement, .transcription)
     }
 
@@ -17,6 +26,8 @@ final class AgentCommandTests: XCTestCase {
                 "transcribe",
                 "--toggle",
                 "--quiet",
+                "--transcription-log",
+                "~/.config/agent-cli/transcriptions.jsonl",
                 "--extra-instructions",
                 "Remember Bas and Henk.\nPrefer project names.",
             ]

--- a/macos/AgentCLI/Tests/AgentCLITests/RecentTranscriptionReaderTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecentTranscriptionReaderTests.swift
@@ -1,0 +1,34 @@
+#if canImport(XCTest)
+import XCTest
+@testable import AgentCLI
+
+final class RecentTranscriptionReaderTests: XCTestCase {
+    func testRecentTranscriptionsPreferProcessedTextNewestFirst() throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        let log = """
+        {"timestamp":"2026-05-28T10:00:00+00:00","raw_output":"first raw","processed_output":null}
+        {"timestamp":"2026-05-28T10:01:00+00:00","raw":"server raw","processed":"server processed"}
+        not json
+        {"timestamp":"2026-05-28T10:02:00+00:00","raw_output":"new raw","processed_output":"new processed"}
+        {"timestamp":"2026-05-28T10:03:00+00:00","raw_output":"   ","processed_output":""}
+        """
+        try log.write(to: logURL, atomically: true, encoding: .utf8)
+
+        let entries = RecentTranscriptionReader.recentTranscriptions(from: logURL, limit: 3)
+
+        XCTAssertEqual(entries.map(\.text), ["new processed", "server processed", "first raw"])
+    }
+
+    func testRecentTranscriptionsReturnEmptyForMissingFile() {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+
+        XCTAssertEqual(RecentTranscriptionReader.recentTranscriptions(from: logURL), [])
+    }
+}
+#endif

--- a/tests/agents/test_transcribe.py
+++ b/tests/agents/test_transcribe.py
@@ -230,6 +230,19 @@ def test_log_transcription(tmp_path: Path) -> None:
     assert "hostname" in second_entry
 
 
+def test_log_transcription_creates_parent_dirs(tmp_path: Path) -> None:
+    """Transcription logging should create missing parent directories."""
+    log_file = tmp_path / "missing" / "parents" / "transcriptions.jsonl"
+
+    transcribe.log_transcription(
+        log_file=log_file,
+        role="user",
+        raw_transcript="hello world",
+    )
+
+    assert log_file.exists()
+
+
 def test_gather_recent_transcription_context(tmp_path: Path) -> None:
     """Ensure only recent log entries are used for context."""
     log_file = tmp_path / "transcriptions.jsonl"


### PR DESCRIPTION
## Summary
- Add a macOS menu bar submenu for recent transcription recordings backed by the JSONL transcription log.
- Copy the selected recent transcript text to the clipboard, preferring processed text when present.
- Make macOS transcription write to the default JSONL log and ensure one-shot transcription creates missing log directories.

## Test Plan
- [x] `swift build`
- [x] `swift test`
- [x] `uv run --extra audio pytest tests/agents/test_transcribe.py::test_log_transcription_creates_parent_dirs -q`
