### PR TITLE
Add macOS option to use user-installed agent-cli

### DIFF
--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -1,9 +1,12 @@
 # Agent CLI macOS app
 
 This directory contains a native SwiftUI menu bar wrapper for `agent-cli`.
-The app does not reimplement any agent behavior. It bundles `uv`, installs a
-private `agent-cli[audio,llm]` tool into the user's Application Support
-directory on first use, and shells out to that private executable.
+The app does not reimplement any agent behavior. By default, it bundles `uv`,
+installs a private `agent-cli[audio,llm]` tool into the user's Application
+Support directory on first use, and shells out to that private executable.
+Users who already manage their own `agent-cli` install can enable
+**Use User-Installed agent-cli** in Settings to run the `agent-cli` found on
+PATH with their normal config instead.
 
 Transcription is the default zero-config path. The first transcription action
 installs and starts the local Whisper launchd daemon with
@@ -18,13 +21,14 @@ The packaged app registers native macOS global hotkeys itself:
 - `Cmd+Shift+A` autocorrects clipboard text
 - `Cmd+Shift+V` starts voice edit
 
-Choose **Settings...** from the menu bar app to change these shortcuts or enable
-**Start at Login**. The settings UI uses the `KeyboardShortcuts` Swift package
-for shortcut parsing and `UserDefaults` storage. Transcription shortcuts are
-handled by a small CGEvent tap so `Fn`, `Fn+Space`, and plain Space remain
-distinct; the clipboard utility shortcuts still use `KeyboardShortcuts` global
-handlers. The login option uses Apple's login item API for the main app bundle,
-so macOS may require approval in System Settings → General → Login Items.
+Choose **Settings...** from the menu bar app to change these shortcuts, enable
+**Start at Login**, or switch between the bundled runtime and a user-installed
+`agent-cli`. The settings UI uses the `KeyboardShortcuts` Swift package for
+shortcut parsing and `UserDefaults` storage. Transcription shortcuts are handled
+by a small CGEvent tap so `Fn`, `Fn+Space`, and plain Space remain distinct; the
+clipboard utility shortcuts still use `KeyboardShortcuts` global handlers. The
+login option uses Apple's login item API for the main app bundle, so macOS may
+require approval in System Settings → General → Login Items.
 
 ## Build
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -8,6 +8,8 @@ struct AgentCLIApp: App {
     @StateObject private var runner = AgentCommandRunner.shared
     @StateObject private var loginItemController = LoginItemController.shared
     @StateObject private var shortcutSummary = ShortcutSummaryState.shared
+    @AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)
+    private var useUserInstalledAgentCLI = false
 
     var body: some Scene {
         MenuBarExtra {
@@ -85,7 +87,10 @@ struct AgentCLIApp: App {
                 Button {
                     runner.run(.installOrUpdateCLI)
                 } label: {
-                    Label("Update CLI Runtime", systemImage: "arrow.down.circle")
+                    Label(
+                        useUserInstalledAgentCLI ? "Check User CLI" : "Update CLI Runtime",
+                        systemImage: useUserInstalledAgentCLI ? "checkmark.circle" : "arrow.down.circle"
+                    )
                 }
 
                 Button {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -1,6 +1,17 @@
 import Darwin
 import Foundation
 
+private enum AgentCLIRuntimeMode: Equatable {
+    case bundled
+    case userInstalled
+
+    init(userDefaults: UserDefaults) {
+        self = userDefaults.bool(forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+            ? .userInstalled
+            : .bundled
+    }
+}
+
 struct AgentRuntime {
     static let shared = AgentRuntime()
 
@@ -9,7 +20,23 @@ struct AgentRuntime {
     private static let appSupportDisplayName = "Application Support"
     private static let fallbackPackageSource = "agent-cli"
     private static let bootstrapQueue = DispatchQueue(label: "lt.nijho.agent-cli.bootstrap")
+    private static let appPrivateEnvironmentKeys = [
+        "AGENTCLI_APP_SUPPORT_DIR",
+        "AGENTCLI_RUNTIME_DIR",
+        "AGENTCLI_BUNDLED_UV",
+        "AGENTCLI_PACKAGE_SOURCE",
+        "AGENTCLI_AGENT_CLI",
+        "AGENT_CLI_CONFIG_HOME",
+        "UV_CACHE_DIR",
+        "UV_PYTHON_INSTALL_DIR",
+        "UV_PYTHON_BIN_DIR",
+        "UV_TOOL_DIR",
+        "UV_TOOL_BIN_DIR",
+        "UV_NO_PROGRESS",
+    ]
     private let fileManager = FileManager.default
+    private let baseEnvironment: [String: String]
+    private let userDefaults: UserDefaults
     let appSupportURL: URL
     let bundledUVURL: URL
     let bundledWheelsURL: URL
@@ -28,8 +55,12 @@ struct AgentRuntime {
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        bundle: Bundle = .main
+        bundle: Bundle = .main,
+        userDefaults: UserDefaults = .standard
     ) {
+        self.baseEnvironment = environment
+        self.userDefaults = userDefaults
+
         if let override = environment["AGENTCLI_APP_SUPPORT_DIR"], !override.isEmpty {
             appSupportURL = URL(fileURLWithPath: override, isDirectory: true)
         } else {
@@ -55,6 +86,26 @@ struct AgentRuntime {
         lastErrorURL = appSupportURL.appendingPathComponent("last-error.txt")
         logsURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Logs", isDirectory: true)
+    }
+
+    var usesUserInstalledAgentCLI: Bool {
+        runtimeMode == .userInstalled
+    }
+
+    private var runtimeMode: AgentCLIRuntimeMode {
+        AgentCLIRuntimeMode(userDefaults: userDefaults)
+    }
+
+    var agentCLIExecutableURL: URL {
+        usesUserInstalledAgentCLI
+            ? URL(fileURLWithPath: "/usr/bin/env")
+            : agentCLIURL
+    }
+
+    func agentCLIProcessArguments(_ arguments: [String]) -> [String] {
+        usesUserInstalledAgentCLI
+            ? ["agent-cli"] + arguments
+            : arguments
     }
 
     private static func resolveBundledWheel(in wheelsURL: URL) -> String? {
@@ -120,10 +171,15 @@ struct AgentRuntime {
     }
 
     func ensureInstalled(force: Bool = false) -> CommandResult {
+        let mode = runtimeMode
         do {
-            try prepareDirectories()
+            try prepareDirectories(for: mode)
         } catch {
             return CommandResult(exitCode: 1, output: "Could not create app support directories: \(error.localizedDescription)")
+        }
+
+        if mode == .userInstalled {
+            return ensureUserInstalledCLIAvailable()
         }
 
         if !force,
@@ -166,6 +222,23 @@ struct AgentRuntime {
         return result
     }
 
+    private func ensureUserInstalledCLIAvailable() -> CommandResult {
+        let result = Self.runProcess(
+            executableURL: agentCLIExecutableURL,
+            arguments: agentCLIProcessArguments(["--version"]),
+            environment: commandEnvironment()
+        )
+        guard result.exitCode != 127 else {
+            return CommandResult(
+                exitCode: 127,
+                output: "User-installed agent-cli was not found on PATH. Install it with uv, or disable Use User-Installed agent-cli in Settings."
+            )
+        }
+        return result.exitCode == 0
+            ? CommandResult(exitCode: 0, output: "")
+            : result
+    }
+
     private var agentCLIInstallMarkerContents: String {
         "packageSource=\(agentCLIPackageSource)\ninstallRequirement=\(agentCLIInstallRequirement)\n"
     }
@@ -196,7 +269,6 @@ struct AgentRuntime {
     }
 
     private func ensureWhisperDaemon(force: Bool = false) -> CommandResult {
-        let whisperDaemonMarkerContents = "packageSource=\(agentCLIPackageSource)\n"
         if !force, (try? String(contentsOf: whisperDaemonMarkerURL)) == whisperDaemonMarkerContents {
             return waitForWhisperDaemonReady()
         }
@@ -212,6 +284,11 @@ struct AgentRuntime {
             encoding: .utf8
         )
         return waitForWhisperDaemonReady()
+    }
+
+    private var whisperDaemonMarkerContents: String {
+        let modeName = runtimeMode == .userInstalled ? "user-installed" : "bundled"
+        return "runtimeMode=\(modeName)\npackageSource=\(agentCLIPackageSource)\n"
     }
 
     private func warmUpWhisperModel() -> CommandResult {
@@ -335,12 +412,32 @@ struct AgentRuntime {
     }
 
     func commandEnvironment() -> [String: String] {
-        var environment = ProcessInfo.processInfo.environment
+        switch runtimeMode {
+        case .userInstalled:
+            return userInstalledCLIEnvironment()
+        case .bundled:
+            return bundledCLIEnvironment()
+        }
+    }
+
+    private func userInstalledCLIEnvironment() -> [String: String] {
+        var environment = baseEnvironment
+        for key in Self.appPrivateEnvironmentKeys {
+            environment.removeValue(forKey: key)
+        }
+        let existingPATH = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        environment["PATH"] = userInstalledCLIPath(existingPATH: existingPATH)
+        return environment
+    }
+
+    private func bundledCLIEnvironment() -> [String: String] {
+        var environment = baseEnvironment
+        let existingPATH = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         environment["AGENTCLI_APP_SUPPORT_DIR"] = appSupportURL.path
-        environment["AGENTCLI_AGENT_CLI"] = agentCLIURL.path
         environment["AGENTCLI_RUNTIME_DIR"] = runtimeURL.path
         environment["AGENTCLI_BUNDLED_UV"] = bundledUVURL.path
         environment["AGENTCLI_PACKAGE_SOURCE"] = agentCLIPackageSource
+        environment["AGENTCLI_AGENT_CLI"] = agentCLIURL.path
         environment["AGENT_CLI_CONFIG_HOME"] = appSupportURL.appendingPathComponent("config", isDirectory: true).path
         environment["UV_CACHE_DIR"] = appSupportURL.appendingPathComponent("cache/uv", isDirectory: true).path
         environment["UV_PYTHON_INSTALL_DIR"] = appSupportURL.appendingPathComponent("uv/python", isDirectory: true).path
@@ -352,7 +449,6 @@ struct AgentRuntime {
         environment["TERM"] = "dumb"
 
         let resourceBinURL = bundledUVURL.deletingLastPathComponent()
-        let existingPATH = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         environment["PATH"] = [
             binURL.path,
             resourceBinURL.path,
@@ -364,9 +460,22 @@ struct AgentRuntime {
         return environment
     }
 
-    private func prepareDirectories() throws {
-        try fileManager.createDirectory(at: binURL, withIntermediateDirectories: true)
+    private func userInstalledCLIPath(existingPATH: String) -> String {
+        [
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".local/bin", isDirectory: true)
+                .path,
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            existingPATH
+        ].joined(separator: ":")
+    }
+
+    private func prepareDirectories(for mode: AgentCLIRuntimeMode = .bundled) throws {
         try fileManager.createDirectory(at: runtimeURL, withIntermediateDirectories: true)
+        guard mode == .bundled else { return }
+
+        try fileManager.createDirectory(at: binURL, withIntermediateDirectories: true)
         try fileManager.createDirectory(
             at: appSupportURL.appendingPathComponent("cache/uv", isDirectory: true),
             withIntermediateDirectories: true
@@ -395,8 +504,8 @@ struct AgentRuntime {
 
     func runAgentCLI(arguments: [String]) -> CommandResult {
         Self.runProcess(
-            executableURL: agentCLIURL,
-            arguments: arguments,
+            executableURL: agentCLIExecutableURL,
+            arguments: agentCLIProcessArguments(arguments),
             environment: commandEnvironment()
         )
     }

--- a/macos/AgentCLI/Sources/AgentCLI/RuntimeSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RuntimeSettings.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum RuntimeSettings {
+    static let useUserInstalledAgentCLIKey = "useUserInstalledAgentCLI"
+}

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -150,6 +150,8 @@ enum ShortcutDefaultsMigrator {
 
 struct SettingsView: View {
     @ObservedObject private var loginItemController = LoginItemController.shared
+    @AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)
+    private var useUserInstalledAgentCLI = false
     @AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)
     private var transcriptionExtraInstructions = ""
     @State private var shortcutRevision = 0
@@ -171,8 +173,12 @@ struct SettingsView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
+
+                Toggle("Use User-Installed agent-cli", isOn: $useUserInstalledAgentCLI)
             } header: {
                 Text("General")
+            } footer: {
+                Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime.")
             }
 
             Section {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -53,6 +53,51 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(AgentCommand.autocorrect.bootstrapRequirement, .cliRuntime)
     }
 
+    func testRuntimeUsesBundledCLIByDefault() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.default-runtime")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.default-runtime")
+        let runtime = AgentRuntime(
+            environment: ["AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support"],
+            userDefaults: defaults
+        )
+
+        XCTAssertFalse(runtime.usesUserInstalledAgentCLI)
+        XCTAssertEqual(runtime.agentCLIExecutableURL.path, "/tmp/agentcli-test-support/bin/agent-cli")
+        XCTAssertEqual(runtime.agentCLIProcessArguments(["--version"]), ["--version"])
+        XCTAssertEqual(runtime.commandEnvironment()["AGENT_CLI_CONFIG_HOME"], "/tmp/agentcli-test-support/config")
+        XCTAssertEqual(runtime.commandEnvironment()["UV_TOOL_BIN_DIR"], "/tmp/agentcli-test-support/bin")
+    }
+
+    func testRuntimeCanUseUserInstalledCLIWithoutPrivateConfig() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime")
+        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+        let runtime = AgentRuntime(
+            environment: [
+                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
+                "AGENTCLI_RUNTIME_DIR": "/tmp/agentcli-test-support/runtime",
+                "AGENTCLI_BUNDLED_UV": "/tmp/agentcli-test-support/bin/uv",
+                "AGENTCLI_PACKAGE_SOURCE": "agent-cli",
+                "AGENTCLI_AGENT_CLI": "/tmp/agentcli-test-support/bin/agent-cli",
+                "AGENT_CLI_CONFIG_HOME": "/tmp/agentcli-test-support/config",
+                "UV_TOOL_BIN_DIR": "/tmp/agentcli-test-support/bin",
+                "PATH": "/custom/bin",
+            ],
+            userDefaults: defaults
+        )
+
+        XCTAssertTrue(runtime.usesUserInstalledAgentCLI)
+        XCTAssertEqual(runtime.agentCLIExecutableURL.path, "/usr/bin/env")
+        XCTAssertEqual(runtime.agentCLIProcessArguments(["--version"]), ["agent-cli", "--version"])
+        XCTAssertNil(runtime.commandEnvironment()["AGENTCLI_APP_SUPPORT_DIR"])
+        XCTAssertNil(runtime.commandEnvironment()["AGENTCLI_RUNTIME_DIR"])
+        XCTAssertNil(runtime.commandEnvironment()["AGENTCLI_BUNDLED_UV"])
+        XCTAssertNil(runtime.commandEnvironment()["AGENTCLI_PACKAGE_SOURCE"])
+        XCTAssertNil(runtime.commandEnvironment()["AGENT_CLI_CONFIG_HOME"])
+        XCTAssertNil(runtime.commandEnvironment()["UV_TOOL_BIN_DIR"])
+        XCTAssertTrue(runtime.commandEnvironment()["PATH"]?.contains("/custom/bin") == true)
+    }
+
     @MainActor
     func testStartupWarmUpBootstrapsTranscriptionOnce() {
         let recorder = BootstrapRecorder()

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -126,7 +126,8 @@ def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
     assert "holdStopShell" not in source
     assert "runShell(Self.holdStopShell)" not in source
     assert "transcribe.pid" not in source
-    assert 'arguments: ["transcribe", "--toggle", "--quiet"]' in source
+    assert '"transcribe",\n            "--toggle",\n            "--quiet",' in source
+    assert '"--transcription-log",\n            RecentTranscriptionReader.defaultLogPath' in source
     assert "transcribe --toggle --llm --quiet" not in source
     assert 'arguments: ["voice-edit", "--toggle", "--quiet"]' in source
     assert 'arguments: ["autocorrect", "--quiet"]' in source
@@ -160,6 +161,34 @@ def test_macos_app_settings_pass_extra_instructions_to_transcription() -> None:
     assert "appliesTranscriptionExtraInstructions: true" in source
 
 
+def test_macos_app_can_use_user_installed_agent_cli() -> None:
+    """Settings should let configured users bypass the bundled uv runtime."""
+    source = swift_source()
+
+    assert 'static let useUserInstalledAgentCLIKey = "useUserInstalledAgentCLI"' in source
+    assert "Use User-Installed agent-cli" in source
+    assert "@AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)" in source
+    assert "var usesUserInstalledAgentCLI: Bool" in source
+    assert '? URL(fileURLWithPath: "/usr/bin/env")' in source
+    assert '? ["agent-cli"] + arguments' in source
+    assert "ensureUserInstalledCLIAvailable()" in source
+    assert "private enum AgentCLIRuntimeMode: Equatable" in source
+    assert (
+        "switch runtimeMode {\n"
+        "        case .userInstalled:\n"
+        "            return userInstalledCLIEnvironment()\n"
+        "        case .bundled:\n"
+        "            return bundledCLIEnvironment()\n"
+        "        }" in source
+    )
+    assert "private func userInstalledCLIEnvironment() -> [String: String]" in source
+    assert "private static let appPrivateEnvironmentKeys" in source
+    assert "environment.removeValue(forKey: key)" in source
+    assert "private func bundledCLIEnvironment() -> [String: String]" in source
+    assert "AGENT_CLI_CONFIG_HOME" in source
+    assert "UV_TOOL_BIN_DIR" in source
+
+
 def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     """Daily actions should stay top-level; diagnostics belong in troubleshooting."""
     source = swift_source()
@@ -184,7 +213,10 @@ def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     assert "Text(runner.statusMessage)" not in source
     assert "if !runner.lastOutput.isEmpty" in source
     assert "if runner.hasLastError" in source
-    assert 'Label("Update CLI Runtime", systemImage: "arrow.down.circle")' in source
+    assert 'useUserInstalledAgentCLI ? "Check User CLI" : "Update CLI Runtime"' in source
+    assert (
+        'systemImage: useUserInstalledAgentCLI ? "checkmark.circle" : "arrow.down.circle"' in source
+    )
     assert 'Label("Reinstall Voice Service", systemImage: "waveform.badge.plus")' in source
     assert 'Label("Voice Service Status", systemImage: "waveform.path.ecg")' in source
     assert 'identifier: "voice-service-status"' in source


### PR DESCRIPTION
## Summary
- Add a persisted macOS setting to use the user-installed agent-cli instead of bootstrapping the app private bundled-uv runtime.
- Keep bundled UV as the default zero-config path.
- Model runtime selection explicitly with bundled vs user-installed modes.
- In user-installed mode, run agent-cli from PATH with inherited user environment plus GUI PATH discovery, while scrubbing app-private runtime/config variables so config resolution matches normal terminal use.
- Document the runtime option and cover it with Swift/source tests.

## Verification
- swift build from macos/AgentCLI
- swift test from macos/AgentCLI; CLT links the test bundle here, but XCTest runtime is unavailable locally
- ./macos/test-macos-app-e2e.sh
- uv run pytest: 1318 passed, 4 skipped
- pre-commit run --all-files
