### PR TITLE
Fix uv installer subprocess input mode

### DIFF
--- a/agent_cli/install/service_config.py
+++ b/agent_cli/install/service_config.py
@@ -187,7 +187,6 @@ def install_uv() -> tuple[bool, str]:
             ["sh"],  # noqa: S607
             input=result.stdout,
             capture_output=True,
-            text=True,
             check=True,
         )
         return True, "uv installed successfully"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -226,6 +226,28 @@ class TestServiceConfig:
         assert "successfully" in msg
 
     @patch("subprocess.run")
+    def test_install_uv_pipes_binary_curl_output_to_shell(self, mock_run: MagicMock) -> None:
+        """Test uv installer output can be piped to sh as bytes."""
+
+        def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+            if args[0] == "curl":
+                return subprocess.CompletedProcess(args, 0, stdout=b"echo installing uv\n")
+            if args == ["sh"]:
+                if kwargs.get("text") is True and isinstance(kwargs.get("input"), bytes):
+                    msg = "'bytes' object has no attribute 'encode'"
+                    raise AttributeError(msg)
+                return subprocess.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+            msg = f"unexpected command: {args}"
+            raise AssertionError(msg)
+
+        mock_run.side_effect = fake_run
+
+        success, msg = install_uv()
+
+        assert success is True
+        assert "successfully" in msg
+
+    @patch("subprocess.run")
     def test_install_uv_failure(self, mock_run: MagicMock) -> None:
         """Test failed uv installation."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "curl")


### PR DESCRIPTION
## Summary
- Fix `install_uv()` so the bytes returned by `curl` are piped to `sh` without enabling text mode.
- Add a regression test for the `bytes` input plus `text=True` AttributeError seen during transcription service setup.

## Test Plan
- `uv run pytest tests/test_daemon.py::TestServiceConfig::test_install_uv_pipes_binary_curl_output_to_shell tests/test_daemon.py::TestServiceConfig::test_install_uv_success tests/test_daemon.py::TestServiceConfig::test_install_uv_failure -q`
- `uv run ruff check agent_cli/install/service_config.py tests/test_daemon.py`
- `uv run ruff format --check agent_cli/install/service_config.py tests/test_daemon.py`
- `uv run pytest tests/test_daemon.py -q`

## Notes
- `uv run pytest -q` currently fails during collection in this default environment because optional test dependencies are not installed (`numpy`, `wyoming`, `fastapi`, `watchfiles`, `torch`, and related extras).
