### PR TITLE
Fix shortcut recording hotkey dispatch

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -25,9 +25,11 @@ final class ConfigurableHotkeyController {
         registerFunctionAwareTranscriptionHotkeys(runner: runner)
 
         KeyboardShortcuts.onKeyUp(for: .autocorrect) {
+            guard !ShortcutRecordingState.shared.isRecording else { return }
             Task { @MainActor in runner.run(.autocorrect) }
         }
         KeyboardShortcuts.onKeyUp(for: .voiceEdit) {
+            guard !ShortcutRecordingState.shared.isRecording else { return }
             Task { @MainActor in runner.run(.voiceEdit) }
         }
 
@@ -82,6 +84,11 @@ final class ConfigurableHotkeyController {
             return Unmanaged.passUnretained(event)
         default:
             break
+        }
+
+        if ShortcutRecordingState.shared.isRecording {
+            cancelPendingHoldToTranscribe()
+            return Unmanaged.passUnretained(event)
         }
 
         if handleToggleTranscriptionShortcut(type: type, event: event) {

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -23,6 +23,33 @@ extension KeyboardShortcuts.Name {
     )
 }
 
+final class ShortcutRecordingState {
+    static let shared = ShortcutRecordingState()
+
+    private let lock = NSLock()
+    private var activeRecorderCount = 0
+
+    var isRecording: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeRecorderCount > 0
+    }
+
+    private init() {}
+
+    func beginRecording() {
+        lock.lock()
+        activeRecorderCount += 1
+        lock.unlock()
+    }
+
+    func endRecording() {
+        lock.lock()
+        activeRecorderCount = max(0, activeRecorderCount - 1)
+        lock.unlock()
+    }
+}
+
 final class ShortcutSummaryState: ObservableObject {
     static let shared = ShortcutSummaryState()
 
@@ -271,6 +298,7 @@ final class ShortcutRecorderButton: NSButton {
 
     private var isRecording = false
     private var eventMonitor: Any?
+    private var pendingFunctionShortcut = false
 
     init(name: KeyboardShortcuts.Name) {
         self.shortcutName = name
@@ -310,6 +338,7 @@ final class ShortcutRecorderButton: NSButton {
         }
 
         isRecording = true
+        ShortcutRecordingState.shared.beginRecording()
         title = "Press shortcut"
         window?.makeFirstResponder(self)
 
@@ -325,11 +354,16 @@ final class ShortcutRecorderButton: NSButton {
     private func capture(_ event: NSEvent) {
         switch Int(event.keyCode) {
         case kVK_Escape:
+            pendingFunctionShortcut = false
             stopRecording()
         case kVK_Delete, kVK_ForwardDelete:
+            pendingFunctionShortcut = false
             KeyboardShortcuts.setShortcut(nil, for: shortcutName)
             stopRecording()
+        case kVK_Function:
+            handleFunctionKeyChange(event)
         default:
+            pendingFunctionShortcut = false
             guard let shortcut = ShortcutDisplay.shortcut(from: event) else {
                 NSSound.beep()
                 return
@@ -339,12 +373,38 @@ final class ShortcutRecorderButton: NSButton {
         }
     }
 
+    private func handleFunctionKeyChange(_ event: NSEvent) {
+        guard event.type == .flagsChanged else {
+            return
+        }
+
+        if event.modifierFlags.contains(.function) {
+            pendingFunctionShortcut = true
+            return
+        }
+
+        if pendingFunctionShortcut {
+            captureBareFunctionShortcut()
+        }
+    }
+
+    private func captureBareFunctionShortcut() {
+        pendingFunctionShortcut = false
+        KeyboardShortcuts.setShortcut(KeyboardShortcuts.Shortcut(.function), for: shortcutName)
+        stopRecording()
+    }
+
     private func stopRecording() {
         if let eventMonitor {
             NSEvent.removeMonitor(eventMonitor)
             self.eventMonitor = nil
         }
+        pendingFunctionShortcut = false
+        let wasRecording = isRecording
         isRecording = false
+        if wasRecording {
+            ShortcutRecordingState.shared.endRecording()
+        }
         updateTitle()
         ShortcutSummaryState.shared.refresh()
     }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -834,6 +834,28 @@ def test_macos_app_registers_configurable_native_global_hotkeys() -> None:
     assert ".voiceEdit" in source
 
 
+def test_macos_app_pauses_global_hotkeys_while_recording_shortcuts() -> None:
+    """Recording a shortcut should not dispatch any already-configured shortcuts."""
+    source = swift_source()
+
+    assert "ShortcutRecordingState.shared.beginRecording()" in source
+    assert "ShortcutRecordingState.shared.endRecording()" in source
+    assert "guard !ShortcutRecordingState.shared.isRecording else" in source
+    assert "if ShortcutRecordingState.shared.isRecording" in source
+    assert "cancelPendingHoldToTranscribe()" in source
+
+
+def test_macos_app_records_fn_chords_before_bare_fn() -> None:
+    """Fn should not be saved as a shortcut until the recorder knows no chord follows."""
+    source = swift_source()
+
+    assert "pendingFunctionShortcut = true" in source
+    assert "pendingFunctionShortcut = false" in source
+    assert "captureBareFunctionShortcut()" in source
+    assert "event.modifierFlags.contains(.function)" in source
+    assert "case kVK_Function:" in source
+
+
 def test_macos_app_shows_actual_persisted_shortcuts_and_can_reset_them() -> None:
     """The menu should reflect stored shortcuts instead of claiming static defaults."""
     source = swift_source()


### PR DESCRIPTION
## Summary
- Pause all macOS global hotkey dispatch while a shortcut recorder is active.
- Let the recorder wait for a following key before saving bare Fn, so Fn+Space can be recorded.
- Add macOS wrapper regressions for recording-time dispatch suppression and Fn chord capture.

## Tests
- `uv run pytest tests/test_macos_app.py -q`
- `swift build --package-path macos/AgentCLI`

Note: `swift test --package-path macos/AgentCLI --enable-xctest` builds but cannot run XCTest in this local Command Line Tools environment because `xcrun --sdk macosx --show-sdk-platform-path` fails to resolve PlatformPath.
