### PR TITLE
Fix macOS user CLI uv discovery

### DIFF
--- a/agent_cli/install/service_config.py
+++ b/agent_cli/install/service_config.py
@@ -152,6 +152,12 @@ def build_service_command(
 
 def find_uv(extra_paths: list[Path] | None = None) -> Path | None:
     """Find uv executable, preferring system paths over virtualenv."""
+    explicit_uv = os.environ.get("AGENTCLI_UV_PATH")
+    if explicit_uv:
+        explicit_uv_path = Path(explicit_uv).expanduser()
+        if explicit_uv_path.is_file() and os.access(explicit_uv_path, os.X_OK):
+            return explicit_uv_path
+
     bundled_uv = os.environ.get("AGENTCLI_BUNDLED_UV")
     if bundled_uv:
         bundled_uv_path = Path(bundled_uv).expanduser()

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -425,8 +425,12 @@ struct AgentRuntime {
         for key in Self.appPrivateEnvironmentKeys {
             environment.removeValue(forKey: key)
         }
+        // Preserve AGENTCLI_UV_PATH so GUI launches can point at a user-managed uv.
         let existingPATH = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
-        environment["PATH"] = userInstalledCLIPath(existingPATH: existingPATH)
+        environment["PATH"] = userInstalledCLIPath(
+            existingPATH: existingPATH,
+            loginShellPATH: Self.loginShellPATH(environment: baseEnvironment)
+        )
         return environment
     }
 
@@ -460,15 +464,47 @@ struct AgentRuntime {
         return environment
     }
 
-    private func userInstalledCLIPath(existingPATH: String) -> String {
-        [
-            FileManager.default.homeDirectoryForCurrentUser
+    func userInstalledCLIPath(existingPATH: String, loginShellPATH: String? = nil) -> String {
+        let homeURL = FileManager.default.homeDirectoryForCurrentUser
+        var pathValues: [String] = []
+        if let loginShellPATH {
+            pathValues.append(loginShellPATH)
+        }
+        pathValues.append(contentsOf: [
+            homeURL
                 .appendingPathComponent(".local/bin", isDirectory: true)
+                .path,
+            homeURL
+                .appendingPathComponent(".cargo/bin", isDirectory: true)
                 .path,
             "/opt/homebrew/bin",
             "/usr/local/bin",
             existingPATH
-        ].joined(separator: ":")
+        ])
+
+        var seen = Set<String>()
+        return pathValues
+            .flatMap { $0.split(separator: ":").map(String.init) }
+            .filter { !$0.isEmpty }
+            .filter { seen.insert($0).inserted }
+            .joined(separator: ":")
+    }
+
+    private static func loginShellPATH(environment: [String: String]) -> String? {
+        let shellPath = environment["SHELL"].flatMap { $0.isEmpty ? nil : $0 } ?? "/bin/zsh"
+        guard FileManager.default.isExecutableFile(atPath: shellPath) else { return nil }
+
+        let result = runProcess(
+            executableURL: URL(fileURLWithPath: shellPath),
+            arguments: ["-lic", "printf '%s\\n' \"$PATH\""],
+            environment: environment
+        )
+        guard result.exitCode == 0 else { return nil }
+
+        return result.output
+            .split(separator: "\n")
+            .last
+            .map(String.init)
     }
 
     private func prepareDirectories(for mode: AgentCLIRuntimeMode = .bundled) throws {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -80,8 +80,10 @@ final class AgentCommandTests: XCTestCase {
                 "AGENTCLI_PACKAGE_SOURCE": "agent-cli",
                 "AGENTCLI_AGENT_CLI": "/tmp/agentcli-test-support/bin/agent-cli",
                 "AGENT_CLI_CONFIG_HOME": "/tmp/agentcli-test-support/config",
+                "AGENTCLI_UV_PATH": "/custom/uv",
                 "UV_TOOL_BIN_DIR": "/tmp/agentcli-test-support/bin",
                 "PATH": "/custom/bin",
+                "SHELL": "/no/such/shell",
             ],
             userDefaults: defaults
         )
@@ -95,7 +97,35 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertNil(runtime.commandEnvironment()["AGENTCLI_PACKAGE_SOURCE"])
         XCTAssertNil(runtime.commandEnvironment()["AGENT_CLI_CONFIG_HOME"])
         XCTAssertNil(runtime.commandEnvironment()["UV_TOOL_BIN_DIR"])
+        XCTAssertEqual(runtime.commandEnvironment()["AGENTCLI_UV_PATH"], "/custom/uv")
         XCTAssertTrue(runtime.commandEnvironment()["PATH"]?.contains("/custom/bin") == true)
+    }
+
+    func testUserInstalledCLIPathUsesLoginShellPathAndCommonUvBins() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-path")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-path")
+        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+        let runtime = AgentRuntime(
+            environment: [
+                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/no/such/shell",
+            ],
+            userDefaults: defaults
+        )
+
+        let shellPath = "/Users/example/.dotbins/macos/arm64/bin:/usr/bin"
+        let path = runtime.userInstalledCLIPath(
+            existingPATH: "/usr/bin:/bin",
+            loginShellPATH: shellPath
+        )
+        let components = path.split(separator: ":").map(String.init)
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+
+        XCTAssertEqual(components.first, "/Users/example/.dotbins/macos/arm64/bin")
+        XCTAssertTrue(components.contains("\(home)/.local/bin"))
+        XCTAssertTrue(components.contains("\(home)/.cargo/bin"))
+        XCTAssertEqual(components.filter { $0 == "/usr/bin" }.count, 1)
     }
 
     @MainActor

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -209,6 +209,27 @@ class TestServiceConfig:
 
         assert result == bundled_uv
 
+    def test_find_uv_prefers_explicit_uv_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Users can override uv discovery with AGENTCLI_UV_PATH."""
+        explicit_uv = tmp_path / "explicit" / "uv"
+        explicit_uv.parent.mkdir()
+        explicit_uv.touch()
+        explicit_uv.chmod(0o755)
+
+        bundled_uv = tmp_path / "bundled" / "uv"
+        bundled_uv.parent.mkdir()
+        bundled_uv.touch()
+        bundled_uv.chmod(0o755)
+
+        monkeypatch.setenv("AGENTCLI_UV_PATH", str(explicit_uv))
+        monkeypatch.setenv("AGENTCLI_BUNDLED_UV", str(bundled_uv))
+
+        result = find_uv()
+
+        assert result == explicit_uv
+
     def test_find_uv_not_found(self) -> None:
         """Test find_uv returns None when uv is not found."""
         # Use paths that definitely don't exist

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -184,6 +184,9 @@ def test_macos_app_can_use_user_installed_agent_cli() -> None:
     assert "private func userInstalledCLIEnvironment() -> [String: String]" in source
     assert "private static let appPrivateEnvironmentKeys" in source
     assert "environment.removeValue(forKey: key)" in source
+    assert "AGENTCLI_UV_PATH" in source
+    assert "loginShellPATH" in source
+    assert 'appendingPathComponent(".cargo/bin"' in source
     assert "private func bundledCLIEnvironment() -> [String: String]" in source
     assert "AGENT_CLI_CONFIG_HOME" in source
     assert "UV_TOOL_BIN_DIR" in source


### PR DESCRIPTION
## Summary
- Add `AGENTCLI_UV_PATH` as an explicit uv discovery override before bundled/common path lookup.
- In macOS user-installed CLI mode, build PATH from the user’s interactive login shell plus common uv install dirs (`~/.local/bin`, `~/.cargo/bin`, Homebrew, `/usr/local/bin`).
- Preserve a user-provided `AGENTCLI_UV_PATH` while still stripping app-private bundled runtime variables in user-installed mode.

## Test Plan
- `uv run pytest tests/test_daemon.py::TestServiceConfig::test_find_uv_prefers_explicit_uv_path tests/test_macos_app.py::test_macos_app_can_use_user_installed_agent_cli -q`
- `uv run pytest tests/test_daemon.py tests/test_macos_app.py -q`
- `uv run ruff check agent_cli/install/service_config.py tests/test_daemon.py tests/test_macos_app.py`
- `uv run ruff format --check agent_cli/install/service_config.py tests/test_daemon.py tests/test_macos_app.py`
- `swift test --package-path macos/AgentCLI`
- `git diff --check`

## Notes
- `uv run pytest -q` still fails during collection in this default environment because optional test dependencies are not installed (`numpy`, `wyoming`, `fastapi`, `watchfiles`, `torch`, and related extras).
