### PR TITLE
Fix non-Fn macOS transcription hotkeys

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -22,6 +22,7 @@ final class ConfigurableHotkeyController {
         guard !registered else { return }
 
         self.runner = runner
+        registerStandardTranscriptionHotkeys(runner: runner)
         registerFunctionAwareTranscriptionHotkeys(runner: runner)
 
         KeyboardShortcuts.onKeyUp(for: .autocorrect) {
@@ -34,6 +35,35 @@ final class ConfigurableHotkeyController {
         }
 
         registered = true
+    }
+
+    private func registerStandardTranscriptionHotkeys(runner: AgentCommandRunner) {
+        KeyboardShortcuts.onKeyUp(for: .toggleTranscription) {
+            guard !ShortcutRecordingState.shared.isRecording,
+                  let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription),
+                  !self.usesFunctionShortcut(shortcut) else {
+                return
+            }
+            Task { @MainActor in runner.run(.toggleTranscription) }
+        }
+        KeyboardShortcuts.onKeyDown(for: .holdToTranscribe) {
+            guard !ShortcutRecordingState.shared.isRecording,
+                  let shortcut = KeyboardShortcuts.getShortcut(for: .holdToTranscribe),
+                  !self.usesFunctionShortcut(shortcut) else {
+                return
+            }
+            Task { @MainActor in
+                _ = runner.beginHoldToTranscribe()
+            }
+        }
+        KeyboardShortcuts.onKeyUp(for: .holdToTranscribe) {
+            guard !ShortcutRecordingState.shared.isRecording,
+                  let shortcut = KeyboardShortcuts.getShortcut(for: .holdToTranscribe),
+                  !self.usesFunctionShortcut(shortcut) else {
+                return
+            }
+            Task { @MainActor in runner.endHoldToTranscribe() }
+        }
     }
 
     private func registerFunctionAwareTranscriptionHotkeys(runner: AgentCommandRunner) {
@@ -106,13 +136,14 @@ final class ConfigurableHotkeyController {
 
     private func handleToggleTranscriptionShortcut(type: CGEventType, event: CGEvent) -> Bool {
         guard let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription),
+              usesFunctionShortcut(shortcut),
               shortcutMatches(type: type, event: event, shortcut: shortcut) else {
             return false
         }
 
         if type == .keyDown {
             cancelPendingHoldToTranscribe()
-            suppressNextFunctionKeyRelease = usesFunctionModifier(shortcut)
+            suppressNextFunctionKeyRelease = usesFunctionShortcut(shortcut)
 
             if !isAutorepeat(event) && !holdToTranscribeIsRecording {
                 Task { @MainActor in
@@ -129,6 +160,7 @@ final class ConfigurableHotkeyController {
             return false
         }
         guard !isBareFunctionShortcut(shortcut),
+              usesFunctionShortcut(shortcut),
               shortcutMatches(type: type, event: event, shortcut: shortcut) else {
             return false
         }
@@ -244,8 +276,8 @@ final class ConfigurableHotkeyController {
         return carbonModifiers(from: event.flags) == shortcut.carbonModifiers
     }
 
-    private func usesFunctionModifier(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
-        shortcut.carbonModifiers & kEventKeyModifierFnMask != 0
+    private func usesFunctionShortcut(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        isBareFunctionShortcut(shortcut) || shortcut.carbonModifiers & kEventKeyModifierFnMask != 0
     }
 
     private func isBareFunctionShortcut(_ shortcut: KeyboardShortcuts.Shortcut) -> Bool {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -545,9 +545,19 @@ def test_macos_app_uses_fn_aware_event_tap_for_transcription_shortcuts() -> None
     assert "CGEventType.flagsChanged" in source
     assert "CGEventFlags.maskSecondaryFn" in source
     assert "handleFunctionAwareHotkey" in source
-    assert "KeyboardShortcuts.onKeyUp(for: .toggleTranscription)" not in source
-    assert "KeyboardShortcuts.onKeyDown(for: .holdToTranscribe)" not in source
-    assert "KeyboardShortcuts.onKeyUp(for: .holdToTranscribe)" not in source
+    assert "usesFunctionShortcut(shortcut)" in source
+
+
+def test_macos_app_preserves_carbon_transcription_hotkeys_without_fn() -> None:
+    """Non-Fn transcription shortcuts should work without Accessibility event-tap permission."""
+    source = swift_source()
+
+    assert "registerStandardTranscriptionHotkeys(runner: runner)" in source
+    assert "KeyboardShortcuts.onKeyUp(for: .toggleTranscription)" in source
+    assert "KeyboardShortcuts.onKeyDown(for: .holdToTranscribe)" in source
+    assert "KeyboardShortcuts.onKeyUp(for: .holdToTranscribe)" in source
+    assert "guard let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription)" in source
+    assert "!self.usesFunctionShortcut(shortcut)" in source
 
 
 def test_macos_app_disambiguates_fn_hold_from_fn_space_toggle() -> None:


### PR DESCRIPTION
## Summary
- restore standard KeyboardShortcuts registration for non-Fn transcription shortcuts
- keep Fn and Fn+Space transcription shortcuts on the CG event-tap path
- add regression coverage for non-Fn hotkeys working without Accessibility event-tap permission

## Test Plan
- [x] swift test --package-path macos/AgentCLI
- [x] uv run pytest tests/test_macos_app.py
