### PR TITLE
Increase memory git integration test timeout

### DIFF
--- a/tests/memory/test_git_integration.py
+++ b/tests/memory/test_git_integration.py
@@ -35,6 +35,7 @@ def _git_log(path: Path) -> list[str]:
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git not installed")
+@pytest.mark.timeout(60)
 @pytest.mark.asyncio
 async def test_memory_client_git_versioning(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- give the memory git versioning integration test a 60-second per-test timeout
- keep the global pytest timeout at 10 seconds for the rest of the suite

## Context
Windows Python 3.13 CI timed out in `tests/memory/test_git_integration.py::test_memory_client_git_versioning` while the test was inside git subprocess handling. This test does real git initialization plus multiple commits, so it needs a larger integration-test budget on slower runners.

## Test Plan
- [x] uv run --extra memory --extra test pytest tests/memory/test_git_integration.py -vv
