### PR TITLE
Show macOS startup preparation state

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -167,7 +167,7 @@ struct AgentCLIApp: App {
                 Label("Quit", systemImage: "power")
             }
         } label: {
-            AgentCLIMenuBarIcon(isRecording: runner.isRecording)
+            AgentCLIMenuBarIcon(state: runner.menuBarIconState)
         }
         .menuBarExtraStyle(.menu)
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -6,6 +6,44 @@ enum AgentBootstrapRequirement: Equatable {
     case transcriptionModel
 }
 
+enum BootstrapPhase: Equatable {
+    case idle
+    case checkingRuntime
+    case installingRuntime
+    case installingVoiceService
+    case waitingForVoiceService
+    case warmingWhisperModel
+    case failed
+
+    var isPreparing: Bool {
+        switch self {
+        case .idle, .failed:
+            return false
+        case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:
+            return true
+        }
+    }
+
+    var statusMessage: String {
+        switch self {
+        case .idle:
+            return "Ready"
+        case .checkingRuntime:
+            return "Checking CLI runtime..."
+        case .installingRuntime:
+            return "Installing CLI runtime..."
+        case .installingVoiceService:
+            return "Installing voice service..."
+        case .waitingForVoiceService:
+            return "Waiting for voice service..."
+        case .warmingWhisperModel:
+            return "Warming Whisper model..."
+        case .failed:
+            return "Voice service warm-up failed"
+        }
+    }
+}
+
 struct AgentCommand {
     let identifier: String
     let title: String

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -1,49 +1,5 @@
 import Foundation
 
-enum AgentBootstrapRequirement: Equatable {
-    case cliRuntime
-    case transcription
-    case transcriptionModel
-}
-
-enum BootstrapPhase: Equatable {
-    case idle
-    case checkingRuntime
-    case installingRuntime
-    case installingVoiceService
-    case waitingForVoiceService
-    case warmingWhisperModel
-    case failed
-
-    var isPreparing: Bool {
-        switch self {
-        case .idle, .failed:
-            return false
-        case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:
-            return true
-        }
-    }
-
-    var statusMessage: String {
-        switch self {
-        case .idle:
-            return "Ready"
-        case .checkingRuntime:
-            return "Checking CLI runtime..."
-        case .installingRuntime:
-            return "Installing CLI runtime..."
-        case .installingVoiceService:
-            return "Installing voice service..."
-        case .waitingForVoiceService:
-            return "Waiting for voice service..."
-        case .warmingWhisperModel:
-            return "Warming Whisper model..."
-        case .failed:
-            return "Voice service warm-up failed"
-        }
-    }
-}
-
 struct AgentCommand {
     let identifier: String
     let title: String

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -19,9 +19,6 @@ private enum HoldTranscriptionState {
     }
 }
 
-typealias AgentBootstrapProgress = (BootstrapPhase) -> Void
-typealias AgentBootstrap = (AgentBootstrapRequirement, Bool, @escaping AgentBootstrapProgress) -> CommandResult
-
 @MainActor
 final class AgentCommandRunner: ObservableObject {
     static let shared = AgentCommandRunner()

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -19,7 +19,8 @@ private enum HoldTranscriptionState {
     }
 }
 
-typealias AgentBootstrap = @Sendable (AgentBootstrapRequirement, Bool) -> CommandResult
+typealias AgentBootstrapProgress = (BootstrapPhase) -> Void
+typealias AgentBootstrap = (AgentBootstrapRequirement, Bool, @escaping AgentBootstrapProgress) -> CommandResult
 
 @MainActor
 final class AgentCommandRunner: ObservableObject {
@@ -29,6 +30,7 @@ final class AgentCommandRunner: ObservableObject {
     @Published var lastOutput = ""
     @Published private(set) var hasLastError = false
     @Published private(set) var isRecording = false
+    @Published private(set) var bootstrapPhase: BootstrapPhase = .idle
     @Published private var activeCommandCount = 0
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
@@ -47,6 +49,9 @@ final class AgentCommandRunner: ObservableObject {
         if isRecording {
             return "Recording"
         }
+        if bootstrapPhase.isPreparing {
+            return bootstrapPhase.statusMessage
+        }
         if holdTranscriptionState.isFinishing {
             return "Transcribing..."
         }
@@ -56,10 +61,20 @@ final class AgentCommandRunner: ObservableObject {
         return Self.compactMenuStatus(statusMessage)
     }
 
+    var menuBarIconState: MenuBarIconState {
+        if isRecording {
+            return .recording
+        }
+        if bootstrapPhase.isPreparing {
+            return .preparing
+        }
+        return .idle
+    }
+
     init(
         pasteController: TranscriptPasteController = TranscriptPasteController(),
-        bootstrap: @escaping AgentBootstrap = { requirement, force in
-            AgentRuntime.shared.ensureReady(for: requirement, force: force)
+        bootstrap: @escaping AgentBootstrap = { requirement, force, progress in
+            AgentRuntime.shared.ensureReady(for: requirement, force: force, progress: progress)
         }
     ) {
         self.pasteController = pasteController
@@ -82,13 +97,12 @@ final class AgentCommandRunner: ObservableObject {
         hasStartedTranscriptionWarmUp = true
 
         activeCommandCount += 1
-        if statusMessage == "Ready" {
-            statusMessage = "Preparing voice service..."
-        }
+        reportBootstrapPhase(.checkingRuntime)
 
         let bootstrap = self.bootstrap
+        let reportBootstrapPhase = makeBootstrapProgressReporter()
         DispatchQueue.global(qos: .utility).async {
-            let result = bootstrap(.transcriptionModel, false)
+            let result = bootstrap(.transcriptionModel, false, reportBootstrapPhase)
 
             Task { @MainActor in
                 self.activeCommandCount = max(0, self.activeCommandCount - 1)
@@ -97,16 +111,27 @@ final class AgentCommandRunner: ObservableObject {
                 }
 
                 if result.exitCode == 0 {
-                    if self.statusMessage == "Preparing voice service..." {
-                        self.statusMessage = "Ready"
-                    }
+                    self.reportBootstrapPhase(.idle)
                     return
                 }
 
+                self.reportBootstrapPhase(.failed)
                 self.recordFailure(title: "Startup Voice Service Warm-Up", result: result)
                 self.statusMessage = result.output.isEmpty
                     ? "Voice service warm-up failed with exit code \(result.exitCode)"
                     : "Voice service warm-up failed: \(Self.summarize(result.output))"
+            }
+        }
+    }
+
+    private func reportBootstrapPhase(_ phase: BootstrapPhase) {
+        bootstrapPhase = phase
+    }
+
+    private func makeBootstrapProgressReporter() -> AgentBootstrapProgress {
+        { [weak self] phase in
+            Task { @MainActor in
+                self?.reportBootstrapPhase(phase)
             }
         }
     }
@@ -171,19 +196,23 @@ final class AgentCommandRunner: ObservableObject {
         }
 
         activeCommandCount += 1
-        statusMessage = isStopRequest
-            ? "Stopping \(command.title)..."
-            : "Running \(command.title)..."
+        if !self.bootstrapPhase.isPreparing {
+            statusMessage = isStopRequest
+                ? "Stopping \(command.title)..."
+                : "Running \(command.title)..."
+        }
 
         let bootstrap = self.bootstrap
+        let reportBootstrapPhase = makeBootstrapProgressReporter()
         let commandArguments = command.resolvedArguments(extraInstructions: TranscriptionSettings.extraInstructions)
         DispatchQueue.global(qos: .userInitiated).async {
-            let bootstrapResult = bootstrap(command.bootstrapRequirement, command.forceBootstrap)
+            let bootstrapResult = bootstrap(command.bootstrapRequirement, command.forceBootstrap, reportBootstrapPhase)
             guard bootstrapResult.exitCode == 0 else {
                 let message = Self.statusMessage(for: command, result: bootstrapResult)
                 let notificationTitle = Self.notificationTitle(for: command, result: bootstrapResult)
                 let notificationBody = Self.notificationBody(for: command, result: bootstrapResult, statusMessage: message)
                 Task { @MainActor in
+                    self.reportBootstrapPhase(.failed)
                     if isStopRequest {
                         self.clearStopRequested(for: command)
                     }
@@ -198,6 +227,10 @@ final class AgentCommandRunner: ObservableObject {
                     self.notify(title: notificationTitle, body: notificationBody)
                 }
                 return
+            }
+
+            Task { @MainActor in
+                self.reportBootstrapPhase(.idle)
             }
 
             if shouldStartRecording {
@@ -261,14 +294,17 @@ final class AgentCommandRunner: ObservableObject {
         statusMessage = "Stopping Toggle Transcription..."
 
         let bootstrap = self.bootstrap
+        let reportBootstrapPhase = makeBootstrapProgressReporter()
         DispatchQueue.global(qos: .userInitiated).async {
             let bootstrapResult = bootstrap(
                 AgentCommand.stopTranscription.bootstrapRequirement,
-                AgentCommand.stopTranscription.forceBootstrap
+                AgentCommand.stopTranscription.forceBootstrap,
+                reportBootstrapPhase
             )
             guard bootstrapResult.exitCode == 0 else {
                 let message = Self.statusMessage(for: AgentCommand.stopTranscription, result: bootstrapResult)
                 Task { @MainActor in
+                    self.reportBootstrapPhase(.failed)
                     self.holdTranscriptionState = .idle
                     self.lastOutput = bootstrapResult.output
                     self.recordFailure(command: AgentCommand.stopTranscription, result: bootstrapResult)
@@ -279,6 +315,10 @@ final class AgentCommandRunner: ObservableObject {
                     )
                 }
                 return
+            }
+
+            Task { @MainActor in
+                self.reportBootstrapPhase(.idle)
             }
 
             let result = AgentRuntime.shared.runAgentCLI(arguments: AgentCommand.stopTranscription.arguments)

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -170,7 +170,10 @@ struct AgentRuntime {
         exit(0)
     }
 
-    func ensureInstalled(force: Bool = false) -> CommandResult {
+    func ensureInstalled(
+        force: Bool = false,
+        progress: AgentBootstrapProgress = { _ in }
+    ) -> CommandResult {
         let mode = runtimeMode
         do {
             try prepareDirectories(for: mode)
@@ -179,6 +182,7 @@ struct AgentRuntime {
         }
 
         if mode == .userInstalled {
+            progress(.checkingRuntime)
             return ensureUserInstalledCLIAvailable()
         }
 
@@ -188,6 +192,7 @@ struct AgentRuntime {
             return CommandResult(exitCode: 0, output: "")
         }
 
+        progress(.installingRuntime)
         guard fileManager.isExecutableFile(atPath: bundledUVURL.path) else {
             return CommandResult(
                 exitCode: 127,
@@ -243,36 +248,54 @@ struct AgentRuntime {
         "packageSource=\(agentCLIPackageSource)\ninstallRequirement=\(agentCLIInstallRequirement)\n"
     }
 
-    func ensureReady(for requirement: AgentBootstrapRequirement, force: Bool = false) -> CommandResult {
+    func ensureReady(
+        for requirement: AgentBootstrapRequirement,
+        force: Bool = false,
+        progress: AgentBootstrapProgress = { _ in }
+    ) -> CommandResult {
         Self.bootstrapQueue.sync {
-            ensureReadyUnsynchronized(for: requirement, force: force)
+            ensureReadyUnsynchronized(for: requirement, force: force, progress: progress)
         }
     }
 
-    private func ensureReadyUnsynchronized(for requirement: AgentBootstrapRequirement, force: Bool = false) -> CommandResult {
+    private func ensureReadyUnsynchronized(
+        for requirement: AgentBootstrapRequirement,
+        force: Bool = false,
+        progress: AgentBootstrapProgress
+    ) -> CommandResult {
         switch requirement {
         case .cliRuntime:
-            return ensureInstalled(force: force)
+            return ensureInstalled(force: force, progress: progress)
         case .transcription:
-            let installResult = ensureInstalled(force: force)
+            let installResult = ensureInstalled(force: force, progress: progress)
             guard installResult.exitCode == 0 else {
                 return installResult
             }
-            return ensureWhisperDaemon(force: force)
+            return ensureWhisperDaemon(force: force, progress: progress)
         case .transcriptionModel:
-            let daemonResult = ensureReadyUnsynchronized(for: .transcription, force: force)
+            let daemonResult = ensureReadyUnsynchronized(
+                for: .transcription,
+                force: force,
+                progress: progress
+            )
             guard daemonResult.exitCode == 0 else {
                 return daemonResult
             }
+            progress(.warmingWhisperModel)
             return warmUpWhisperModel()
         }
     }
 
-    private func ensureWhisperDaemon(force: Bool = false) -> CommandResult {
+    private func ensureWhisperDaemon(
+        force: Bool = false,
+        progress: AgentBootstrapProgress
+    ) -> CommandResult {
         if !force, (try? String(contentsOf: whisperDaemonMarkerURL)) == whisperDaemonMarkerContents {
+            progress(.waitingForVoiceService)
             return waitForWhisperDaemonReady()
         }
 
+        progress(.installingVoiceService)
         let result = runAgentCLI(arguments: ["daemon", "install", "whisper", "-y"])
         guard result.exitCode == 0 else {
             return result
@@ -283,6 +306,7 @@ struct AgentRuntime {
             atomically: true,
             encoding: .utf8
         )
+        progress(.waitingForVoiceService)
         return waitForWhisperDaemonReady()
     }
 

--- a/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+enum AgentBootstrapRequirement: Equatable {
+    case cliRuntime
+    case transcription
+    case transcriptionModel
+}
+
+enum BootstrapPhase: Equatable {
+    case idle
+    case checkingRuntime
+    case installingRuntime
+    case installingVoiceService
+    case waitingForVoiceService
+    case warmingWhisperModel
+    case failed
+
+    var isPreparing: Bool {
+        switch self {
+        case .idle, .failed:
+            return false
+        case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:
+            return true
+        }
+    }
+
+    var statusMessage: String {
+        switch self {
+        case .idle:
+            return "Ready"
+        case .checkingRuntime:
+            return "Checking CLI runtime..."
+        case .installingRuntime:
+            return "Installing CLI runtime..."
+        case .installingVoiceService:
+            return "Installing voice service..."
+        case .waitingForVoiceService:
+            return "Waiting for voice service..."
+        case .warmingWhisperModel:
+            return "Warming Whisper model..."
+        case .failed:
+            return "Voice service warm-up failed"
+        }
+    }
+}
+
+typealias AgentBootstrapProgress = (BootstrapPhase) -> Void
+typealias AgentBootstrap = (AgentBootstrapRequirement, Bool, @escaping AgentBootstrapProgress) -> CommandResult

--- a/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
@@ -2,26 +2,61 @@ import AppKit
 import Foundation
 import SwiftUI
 
+enum MenuBarIconState: Equatable {
+    case idle
+    case preparing
+    case recording
+}
+
 struct AgentCLIMenuBarIcon: View {
-    let isRecording: Bool
+    let state: MenuBarIconState
 
     var body: some View {
-        if let image = Self.logoImage(isRecording: isRecording) {
+        if let image = Self.logoImage(state: state) {
             Image(nsImage: image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 22, height: 18)
-                .id(isRecording)
-                .accessibilityLabel(Text(isRecording ? "Agent CLI recording" : "Agent CLI"))
+                .id(state)
+                .accessibilityLabel(accessibilityLabel)
         } else {
-            Image(systemName: isRecording ? "record.circle.fill" : "person.crop.circle")
-                .id(isRecording)
-                .accessibilityLabel(Text(isRecording ? "Agent CLI recording" : "Agent CLI"))
+            Image(systemName: fallbackSystemImage)
+                .id(state)
+                .accessibilityLabel(accessibilityLabel)
         }
     }
 
-    private static func logoImage(isRecording: Bool) -> NSImage? {
-        isRecording ? recordingLogoImage : idleLogoImage
+    private var accessibilityLabel: Text {
+        switch state {
+        case .idle:
+            return Text("Agent CLI")
+        case .preparing:
+            return Text("Agent CLI preparing")
+        case .recording:
+            return Text("Agent CLI recording")
+        }
+    }
+
+    private var fallbackSystemImage: String {
+        switch state {
+        case .idle:
+            return "person.crop.circle"
+        case .preparing:
+            return "arrow.triangle.2.circlepath.circle.fill"
+        case .recording:
+            return "record.circle.fill"
+        }
+    }
+
+    private static func logoImage(state: MenuBarIconState) -> NSImage? {
+        switch state {
+        case .idle:
+            return idleLogoImage
+        case .preparing:
+            return preparingLogoImage
+        case .recording:
+            return recordingLogoImage
+        }
     }
 
     private static let idleLogoImage: NSImage? = {
@@ -36,8 +71,17 @@ struct AgentCLIMenuBarIcon: View {
     }()
 
     private static let recordingLogoImage: NSImage? = makeRecordingLogoImage()
+    private static let preparingLogoImage: NSImage? = makePreparingLogoImage()
 
     private static func makeRecordingLogoImage() -> NSImage? {
+        makeBadgedLogoImage(badgeColor: .systemRed, badgeDiameter: 7)
+    }
+
+    private static func makePreparingLogoImage() -> NSImage? {
+        makeBadgedLogoImage(badgeColor: .controlAccentColor, badgeDiameter: 7)
+    }
+
+    private static func makeBadgedLogoImage(badgeColor: NSColor, badgeDiameter: CGFloat) -> NSImage? {
         guard let url = Bundle.main.url(forResource: "logo-avatar", withExtension: "svg"),
               let avatar = NSImage(contentsOf: url)
         else {
@@ -57,8 +101,8 @@ struct AgentCLIMenuBarIcon: View {
 
         NSColor.white.setFill()
         NSBezierPath(ovalIn: NSRect(x: 12.5, y: 0.5, width: 10, height: 10)).fill()
-        NSColor.systemRed.setFill()
-        NSBezierPath(ovalIn: NSRect(x: 14, y: 2, width: 7, height: 7)).fill()
+        badgeColor.setFill()
+        NSBezierPath(ovalIn: NSRect(x: 14, y: 2, width: badgeDiameter, height: badgeDiameter)).fill()
         image.unlockFocus()
 
         image.isTemplate = false

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -156,7 +156,11 @@ private final class BootstrapRecorder {
         lock.withLock { storedCalls }
     }
 
-    func bootstrap(requirement: AgentBootstrapRequirement, force: Bool) -> CommandResult {
+    func bootstrap(
+        requirement: AgentBootstrapRequirement,
+        force: Bool,
+        progress: AgentBootstrapProgress
+    ) -> CommandResult {
         lock.withLock {
             storedCalls.append(.init(requirement: requirement, force: force))
         }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -211,6 +211,8 @@ def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     assert troubleshooting_menu_index < copy_output_index < troubleshooting_label_index
     assert 'Menu("Setup")' not in source
     assert 'Text("Voice: \\(runner.menuStatusMessage)")' in source
+    assert "var menuBarIconState: MenuBarIconState" in source
+    assert "AgentCLIMenuBarIcon(state: runner.menuBarIconState)" in source
     assert "var menuStatusMessage: String" in source
     assert "menuStatusMaxLength" in source
     assert "Text(runner.statusMessage)" not in source
@@ -252,18 +254,18 @@ def test_macos_app_uses_avatar_svg_as_menu_bar_icon() -> None:
     assert MENU_BAR_LOGO_SVG.is_file()
     avatar_svg = MENU_BAR_LOGO_SVG.read_text()
 
-    assert "AgentCLIMenuBarIcon(isRecording: runner.isRecording)" in source
-    assert "Self.logoImage(isRecording: isRecording)" in source
+    assert "AgentCLIMenuBarIcon(state: runner.menuBarIconState)" in source
+    assert "Self.logoImage(state: state)" in source
     assert "Image(nsImage: image)" in source
-    assert ".id(isRecording)" in source
-    assert "private static func logoImage(isRecording: Bool) -> NSImage?" in source
+    assert ".id(state)" in source
+    assert "private static func logoImage(state: MenuBarIconState) -> NSImage?" in source
     assert "private static let idleLogoImage" in source
     assert "private static let recordingLogoImage" in source
     assert "makeRecordingLogoImage" in source
     assert 'forResource: "logo-avatar", withExtension: "svg"' in source
     assert "NSImage(contentsOf:" in source
     assert "image.isTemplate = true" in source
-    assert "NSColor.systemRed.setFill()" in source
+    assert "badgeColor: .systemRed" in source
     assert 'MENU_BAR_LOGO_SVG="$ROOT_DIR/docs/logo-avatar.svg"' in build_script
     assert "Contents/Resources/logo-avatar.svg" in build_script
     assert 'test -f "$APP/Contents/Resources/logo-avatar.svg"' in e2e_script
@@ -485,8 +487,14 @@ def test_macos_app_uses_bootstrap_requirement_model() -> None:
     assert "case transcription" in source
     assert "case transcriptionModel" in source
     assert "let bootstrapRequirement: AgentBootstrapRequirement" in source
-    assert "AgentRuntime.shared.ensureReady(for: requirement, force: force)" in source
-    assert "bootstrap(command.bootstrapRequirement, command.forceBootstrap)" in source
+    assert (
+        "AgentRuntime.shared.ensureReady(for: requirement, force: force, progress: progress)"
+        in source
+    )
+    assert (
+        "bootstrap(command.bootstrapRequirement, command.forceBootstrap, reportBootstrapPhase)"
+        in source
+    )
     assert "requiresWhisperDaemon" not in source
 
 
@@ -496,10 +504,40 @@ def test_macos_app_warms_transcription_on_launch() -> None:
 
     assert "AgentCommandRunner.shared.warmUpTranscription()" in source
     assert "private var hasStartedTranscriptionWarmUp = false" in source
-    assert 'statusMessage = "Preparing voice service..."' in source
-    assert "let result = bootstrap(.transcriptionModel, false)" in source
+    assert "@Published private(set) var bootstrapPhase: BootstrapPhase = .idle" in source
+    assert "let result = bootstrap(.transcriptionModel, false, reportBootstrapPhase)" in source
     assert 'recordFailure(title: "Startup Voice Service Warm-Up", result: result)' in source
     assert 'DispatchQueue(label: "lt.nijho.agent-cli.bootstrap")' in source
+
+
+def test_macos_app_keeps_preparing_status_visible_during_command_bootstrap() -> None:
+    """A command started during launch warm-up should not hide preparation progress."""
+    source = swift_source()
+
+    assert "enum BootstrapPhase: Equatable" in source
+    assert "var isPreparing: Bool" in source
+    assert "var statusMessage: String" in source
+    assert (
+        "if bootstrapPhase.isPreparing {\n            return bootstrapPhase.statusMessage" in source
+    )
+    assert (
+        "if !self.bootstrapPhase.isPreparing {\n            statusMessage = isStopRequest" in source
+    )
+    assert "self.reportBootstrapPhase(.idle)" in source
+    assert 'statusMessage == "Preparing voice service..."' not in source
+
+
+def test_macos_app_shows_preparing_menu_bar_icon_state() -> None:
+    """Initial setup should be visible in the menu bar without opening the menu."""
+    source = swift_source()
+
+    assert "enum MenuBarIconState: Equatable" in source
+    assert "case preparing" in source
+    assert "if bootstrapPhase.isPreparing {\n            return .preparing" in source
+    assert "private static let preparingLogoImage" in source
+    assert "makePreparingLogoImage()" in source
+    assert "badgeColor: .controlAccentColor" in source
+    assert 'return Text("Agent CLI preparing")' in source
 
 
 def test_macos_app_warms_whisper_model_on_launch() -> None:
@@ -507,7 +545,7 @@ def test_macos_app_warms_whisper_model_on_launch() -> None:
     source = swift_source()
 
     assert "case transcriptionModel" in source
-    assert "let result = bootstrap(.transcriptionModel, false)" in source
+    assert "let result = bootstrap(.transcriptionModel, false, reportBootstrapPhase)" in source
     assert "warmUpWhisperModel()" in source
     assert "writeWhisperWarmUpAudio()" in source
     assert 'appendingPathComponent("whisper-model-warmup.wav")' in source

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -50,6 +50,7 @@ def test_macos_app_package_files_exist() -> None:
         "AgentCommandRunner.swift",
         "AgentRuntime.swift",
         "AppDelegate.swift",
+        "BootstrapState.swift",
         "CommandResult.swift",
         "ConfigurableHotkeyController.swift",
         "FocusedTextTarget.swift",


### PR DESCRIPTION
## Summary
- model macOS bootstrap progress as a typed `BootstrapPhase` instead of a transient status string
- keep preparation status visible when a transcription command is triggered during startup warm-up
- add a preparing menu bar icon state with an accent badge, distinct from the recording badge

## Verification
- `uv run pytest tests/test_macos_app.py -q`
- `swift build --package-path macos/AgentCLI`
- `uv run pre-commit run --all-files`
- `git diff --check`

## Notes
- `uv run pytest` is blocked in this local venv during collection by missing optional extras such as `numpy`, `wyoming`, `fastapi`, `watchfiles`, `torch`, and related integration dependencies.
- `swift test --package-path macos/AgentCLI --enable-xctest` builds, then this local Command Line Tools install fails XCTest startup with `xcrun: error: unable to lookup item PlatformPath`.
