### PR TITLE
Remove uv Python 3.13 install workarounds

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -17,10 +17,10 @@ The plugin provides a skill that enables Claude Code to:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Or run directly without installing
-uvx --python 3.13 agent-cli dev new my-feature --agent --prompt "..."
+uvx agent-cli dev new my-feature --agent --prompt "..."
 ```
 
 ### Install the Claude Code plugin

--- a/.claude-plugin/skills/agent-cli-dev/SKILL.md
+++ b/.claude-plugin/skills/agent-cli-dev/SKILL.md
@@ -17,10 +17,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Or run directly without installing
-uvx --python 3.13 agent-cli dev new <branch-name> --prompt "..."
+uvx agent-cli dev new <branch-name> --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/.claude/skills/agent-cli-dev/SKILL.md
+++ b/.claude/skills/agent-cli-dev/SKILL.md
@@ -17,10 +17,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Or run directly without installing
-uvx --python 3.13 agent-cli dev new <branch-name> --prompt "..."
+uvx agent-cli dev new <branch-name> --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 - **[`rag-proxy`](docs/commands/rag-proxy.md)**: RAG proxy server for chatting with your documents.
 - **[`dev`](docs/commands/dev.md)**: Parallel development with git worktrees and AI coding agents.
 - **[`server`](docs/commands/server/index.md)**: Local ASR and TTS servers with dual-protocol (Wyoming & OpenAI-compatible APIs), TTL-based memory management, and multi-platform acceleration. Whisper uses MLX on Apple Silicon or Faster Whisper on Linux/CUDA. TTS supports Kokoro (GPU) or Piper (CPU).
-- **[`transcribe-live`](docs/commands/transcribe-live.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]" -p 3.13`.
+- **[`transcribe-live`](docs/commands/transcribe-live.md)**: Continuous background transcription with VAD. Install with `uv tool install "agent-cli[vad]"`.
 
 ## Quick Start
 
@@ -70,15 +70,11 @@ If you already have AI services running (or plan to use OpenAI), simply install:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Using pip
 pip install agent-cli
 ```
-
-> [!NOTE]
-> The `-p 3.13` flag is required because some dependencies (like `onnxruntime`) don't support Python 3.14 yet.
-> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then use it:
 ```bash
@@ -113,12 +109,12 @@ agent-cli autocorrect "this has an eror"
 
 > [!NOTE]
 > `agent-cli` uses `sounddevice` for real-time microphone/voice features.
-> On Linux only, you need to install the system-level PortAudio library  (`sudo apt install portaudio19-dev` / your distro's equivalent on Linux) **before** you run `uv tool install agent-cli -p 3.13`.
+> On Linux only, you need to install the system-level PortAudio library  (`sudo apt install portaudio19-dev` / your distro's equivalent on Linux) **before** you run `uv tool install agent-cli`.
 > On Windows and macOS, this is handled automatically.
 
 ```bash
 # 1. Install agent-cli
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # 2. Install all required services
 agent-cli install-services
@@ -203,7 +199,7 @@ If you already have AI services set up or plan to use cloud services (OpenAI/Gem
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Using pip
 pip install agent-cli
@@ -1039,7 +1035,7 @@ the `[defaults]` section of your configuration file.
 
 **Installation:** Requires the `vad` extra:
 ```bash
-uv tool install "agent-cli[vad]" -p 3.13
+uv tool install "agent-cli[vad]"
 ```
 
 **How to Use It:**

--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -103,7 +103,7 @@ def _format_install_commands(extras: list[str]) -> list[str]:
     extras_args = " ".join(extras)
     return [
         "Install with:",
-        f'  [bold cyan]uv tool install -p 3.13 "agent-cli\\[{combined}]"[/bold cyan]',
+        f'  [bold cyan]uv tool install "agent-cli\\[{combined}]"[/bold cyan]',
         "  # or",
         f"  [bold cyan]agent-cli install-extras {extras_args}[/bold cyan]",
     ]
@@ -122,8 +122,7 @@ def _get_install_hint(extra: str) -> str:
         lines.append("")
         lines.append("Install one with:")
         lines.extend(
-            f'  [bold cyan]uv tool install -p 3.13 "agent-cli\\[{alt}]"[/bold cyan]'
-            for alt in alternatives
+            f'  [bold cyan]uv tool install "agent-cli\\[{alt}]"[/bold cyan]' for alt in alternatives
         )
         lines.append("  # or")
         lines.extend(

--- a/agent_cli/dev/skill/SKILL.md
+++ b/agent_cli/dev/skill/SKILL.md
@@ -17,10 +17,10 @@ If `agent-cli` is not available, install it first:
 
 ```bash
 # Install globally
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Or run directly without installing
-uvx --python 3.13 agent-cli dev new <branch-name> --prompt "..."
+uvx agent-cli dev new <branch-name> --prompt "..."
 ```
 
 ## When to spawn parallel agents

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -75,7 +75,7 @@ docker run -d -p 3000:8080 \
   ghcr.io/open-webui/open-webui:main
 
 # 3. Start the memory proxy (runs in foreground so you can watch the logs)
-uvx -p 3.13 --from "agent-cli[memory]" agent-cli memory proxy \
+uvx --from "agent-cli[memory]" agent-cli memory proxy \
   --memory-path ./my-memories \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m
@@ -88,7 +88,7 @@ uvx -p 3.13 --from "agent-cli[memory]" agent-cli memory proxy \
 ```bash
 # Terminal 1: Pull models and start proxy
 ollama pull embeddinggemma:300m && ollama pull qwen3:4b
-uvx -p 3.13 --from "agent-cli[memory]" agent-cli memory proxy \
+uvx --from "agent-cli[memory]" agent-cli memory proxy \
   --memory-path ./my-memories \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m

--- a/docs/architecture/rag.md
+++ b/docs/architecture/rag.md
@@ -71,7 +71,7 @@ docker run -d -p 3000:8080 \
   ghcr.io/open-webui/open-webui:main
 
 # 3. Start the RAG proxy (runs in foreground so you can watch the logs)
-uvx -p 3.13 --from "agent-cli[rag]" agent-cli rag-proxy \
+uvx --from "agent-cli[rag]" agent-cli rag-proxy \
   --docs-folder ./my-docs \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m
@@ -84,7 +84,7 @@ uvx -p 3.13 --from "agent-cli[rag]" agent-cli rag-proxy \
 ```bash
 # Terminal 1: Pull models and start proxy
 ollama pull embeddinggemma:300m && ollama pull qwen3:4b
-uvx -p 3.13 --from "agent-cli[rag]" agent-cli rag-proxy \
+uvx --from "agent-cli[rag]" agent-cli rag-proxy \
   --docs-folder ./my-docs \
   --openai-base-url http://localhost:11434/v1 \
   --embedding-model embeddinggemma:300m

--- a/docs/commands/diarize-live-session.md
+++ b/docs/commands/diarize-live-session.md
@@ -31,7 +31,7 @@ Use `--retranscribe` if you want to re-run ASR on the combined audio instead of 
 Requires the `diarization` extra:
 
 ```bash
-uv tool install "agent-cli[diarization]" -p 3.13
+uv tool install "agent-cli[diarization]"
 # or
 pip install "agent-cli[diarization]"
 ```

--- a/docs/commands/transcribe-live.md
+++ b/docs/commands/transcribe-live.md
@@ -32,7 +32,7 @@ Saving MP3 files requires FFmpeg; if it's not available, audio saving is disable
 Requires the `vad` extra:
 
 ```bash
-uv tool install "agent-cli[vad]" -p 3.13
+uv tool install "agent-cli[vad]"
 # or
 pip install "agent-cli[vad]"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,15 +34,11 @@ If you already have AI services set up or plan to use cloud services (OpenAI/Gem
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Using pip
 pip install agent-cli
 ```
-
-> [!NOTE]
-> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
-> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 ### Option 3: Full Local Setup
 
@@ -65,7 +61,7 @@ For a complete local setup with all AI services:
 
     ```bash
     # 1. Install agent-cli
-    uv tool install agent-cli -p 3.13
+    uv tool install agent-cli
 
     # 2. Install all required services
     agent-cli install-services

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,15 +86,11 @@ If you already have AI services running (or plan to use OpenAI):
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Using pip
 pip install agent-cli
 ```
-
-> [!NOTE]
-> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
-> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then use it:
 
@@ -106,7 +102,7 @@ agent-cli autocorrect "this has an eror"
 
 ```bash
 # 1. Install agent-cli
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # 2. Install all required services
 agent-cli install-services

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -42,7 +42,7 @@ Universal Docker setup that works on any platform with Docker support.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli -p 3.13
+   uv tool install agent-cli
    # or: pip install agent-cli
    ```
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -97,15 +97,11 @@ Once services are running, install the agent-cli package:
 
 ```bash
 # Using uv (recommended)
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Using pip
 pip install agent-cli
 ```
-
-> [!NOTE]
-> The `-p 3.13` flag is required because some dependencies don't support Python 3.14 yet.
-> See [uv issue #8206](https://github.com/astral-sh/uv/issues/8206) for details.
 
 Then test with:
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -46,7 +46,7 @@ Native Linux setup with full NVIDIA GPU acceleration for optimal performance.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli -p 3.13
+   uv tool install agent-cli
    ```
 
 4. **Test the setup:**

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -38,7 +38,7 @@ Native macOS setup with full Metal GPU acceleration for optimal performance.
 3. **Install agent-cli:**
 
    ```bash
-   uv tool install agent-cli -p 3.13
+   uv tool install agent-cli
    # or: pip install agent-cli
    ```
 

--- a/docs/installation/nixos.md
+++ b/docs/installation/nixos.md
@@ -112,7 +112,7 @@ If you have an NVIDIA GPU, also add:
 3. **Install agent-cli:**
 
    ```bash
-   nix-shell -p portaudio pkg-config gcc python3 --run "uv tool install --upgrade agent-cli -p 3.13"
+   nix-shell -p portaudio pkg-config gcc python3 --run "uv tool install --upgrade agent-cli"
    # or add to your configuration:
    # environment.systemPackages = with pkgs; [ agent-cli ];
    ```

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -32,7 +32,7 @@ The fastest way to get started - no local services needed:
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # Install agent-cli
-uv tool install agent-cli -p 3.13
+uv tool install agent-cli
 
 # Use with cloud providers (requires API keys)
 $env:OPENAI_API_KEY = "sk-..."
@@ -93,7 +93,7 @@ If you prefer manual setup:
 3. **Install agent-cli:**
 
    ```powershell
-   uv tool install agent-cli -p 3.13
+   uv tool install agent-cli
    ```
 
 4. **Run services individually:**

--- a/zensical.toml
+++ b/zensical.toml
@@ -119,7 +119,7 @@ text = "Inter"
 code = "JetBrains Mono"
 
 [project.theme.icon]
-repo = "lucide/github"
+repo = "octicons/mark-github-24"
 
 [project.extra]
 generator = false


### PR DESCRIPTION
## Summary
- Revert the docs workaround from #295 that added explicit Python 3.13 selectors to uv install examples.
- Remove the remaining `-p 3.13` / `--python 3.13` examples from related docs, skill files, and runtime extra-install hints.

## Gate
This should stay draft until astral-sh/uv#19583 is merged and released, because agent-cli installs from PyPI need uv registry/distribution metadata inference before `uv tool install agent-cli` can reliably select a compatible Python from `requires-python`.

Blocked by astral-sh/uv#19583.

## Verification
- `git diff --cached --check`
- `uv run pytest tests/test_requires_extras.py`
- pre-commit hooks during commit: large files, whitespace, line endings, ruff, ruff format, mypy, jscpd, pylint duplicate-code, plugin skill sync