### PR TITLE
Fix blank macOS transcription instructions

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+private extension String {
+    var isVisiblyBlank: Bool {
+        unicodeScalars.allSatisfy { scalar in
+            CharacterSet.whitespacesAndNewlines.contains(scalar)
+                || scalar.properties.generalCategory == .format
+                || scalar.properties.generalCategory == .control
+        }
+    }
+}
+
 struct AgentCommand {
     let identifier: String
     let title: String
@@ -40,7 +50,7 @@ struct AgentCommand {
         guard appliesTranscriptionExtraInstructions else { return arguments }
 
         let trimmedInstructions = extraInstructions?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !trimmedInstructions.isEmpty else { return arguments }
+        guard !trimmedInstructions.isVisiblyBlank else { return arguments }
 
         return arguments + ["--extra-instructions", trimmedInstructions]
     }

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -41,6 +41,13 @@ final class AgentCommandTests: XCTestCase {
         )
     }
 
+    func testVisuallyBlankExtraInstructionsAreIgnored() {
+        XCTAssertEqual(
+            AgentCommand.toggleTranscription.resolvedArguments(extraInstructions: "\u{2060}\u{FEFF}"),
+            AgentCommand.toggleTranscription.arguments
+        )
+    }
+
     func testExtraInstructionsOnlyApplyToTranscription() {
         XCTAssertEqual(
             AgentCommand.autocorrect.resolvedArguments(extraInstructions: "Remember Bas."),

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -160,6 +160,8 @@ def test_macos_app_settings_pass_extra_instructions_to_transcription() -> None:
         in source
     )
     assert "appliesTranscriptionExtraInstructions: true" in source
+    assert "isVisiblyBlank" in source
+    assert "scalar.properties.generalCategory == .format" in source
 
 
 def test_macos_app_can_use_user_installed_agent_cli() -> None:


### PR DESCRIPTION
## Summary
- Treat visually blank macOS transcription instructions as empty before adding --extra-instructions.
- Preserve user-installed agent-cli config defaults when the app settings field only contains invisible characters.
- Add Swift and source-level coverage for the blank-instructions behavior.

## Test Plan
- uv run pytest tests/test_macos_app.py -q
- swift test --filter AgentCommandTests