### PR TITLE
Add recording notification sounds

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/RecordingIndicatorController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecordingIndicatorController.swift
@@ -4,14 +4,14 @@ final class RecordingIndicatorController {
     private var recordingCommandCount = 0
     private var activeRecordingCommands: [String: Int] = [:]
     private let defaults: UserDefaults
-    private let soundPlayer: RecordingSoundPlaying
+    private let audioCuePlayer: RecordingCuePlaying
 
     init(
         defaults: UserDefaults = .standard,
-        soundPlayer: RecordingSoundPlaying = NativeRecordingSoundPlayer.shared
+        audioCuePlayer: RecordingCuePlaying = NativeRecordingCuePlayer.shared
     ) {
         self.defaults = defaults
-        self.soundPlayer = soundPlayer
+        self.audioCuePlayer = audioCuePlayer
     }
 
     var isRecording: Bool {
@@ -49,6 +49,6 @@ final class RecordingIndicatorController {
 
     private func play(_ event: RecordingSoundEvent) {
         guard RecordingSoundSettings.isEnabled(defaults: defaults) else { return }
-        soundPlayer.play(event)
+        audioCuePlayer.play(event)
     }
 }

--- a/macos/AgentCLI/Sources/AgentCLI/RecordingIndicatorController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecordingIndicatorController.swift
@@ -3,6 +3,16 @@ import Foundation
 final class RecordingIndicatorController {
     private var recordingCommandCount = 0
     private var activeRecordingCommands: [String: Int] = [:]
+    private let defaults: UserDefaults
+    private let soundPlayer: RecordingSoundPlaying
+
+    init(
+        defaults: UserDefaults = .standard,
+        soundPlayer: RecordingSoundPlaying = NativeRecordingSoundPlayer.shared
+    ) {
+        self.defaults = defaults
+        self.soundPlayer = soundPlayer
+    }
 
     var isRecording: Bool {
         recordingCommandCount > 0
@@ -13,12 +23,17 @@ final class RecordingIndicatorController {
     }
 
     func begin(for command: AgentCommand) {
+        let wasRecording = isRecording
         activeRecordingCommands[command.identifier, default: 0] += 1
         recordingCommandCount += 1
+        if !wasRecording {
+            play(.startedRecording)
+        }
         VoiceLevelOverlayController.shared.show()
     }
 
     func end(for command: AgentCommand) {
+        let wasRecording = isRecording
         let activeCommandCount = max(0, activeRecordingCommands[command.identifier, default: 0] - 1)
         if activeCommandCount > 0 {
             activeRecordingCommands[command.identifier] = activeCommandCount
@@ -26,8 +41,14 @@ final class RecordingIndicatorController {
             activeRecordingCommands.removeValue(forKey: command.identifier)
         }
         recordingCommandCount = max(0, recordingCommandCount - 1)
-        if !isRecording {
+        if wasRecording && !isRecording {
+            play(.finishedRecording)
             VoiceLevelOverlayController.shared.hide()
         }
+    }
+
+    private func play(_ event: RecordingSoundEvent) {
+        guard RecordingSoundSettings.isEnabled(defaults: defaults) else { return }
+        soundPlayer.play(event)
     }
 }

--- a/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Foundation
+
+enum RecordingSoundSettings {
+    static let enabledKey = "recordingNotificationSoundsEnabled"
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: enabledKey)
+    }
+}
+
+enum RecordingSoundEvent: Hashable {
+    case startedRecording
+    case finishedRecording
+
+    var soundName: NSSound.Name {
+        switch self {
+        case .startedRecording:
+            return NSSound.Name("Frog")
+        case .finishedRecording:
+            return NSSound.Name("Funk")
+        }
+    }
+}
+
+protocol RecordingSoundPlaying: AnyObject {
+    func play(_ event: RecordingSoundEvent)
+}
+
+final class NativeRecordingSoundPlayer: RecordingSoundPlaying {
+    static let shared = NativeRecordingSoundPlayer()
+
+    private var sounds: [RecordingSoundEvent: NSSound] = [:]
+
+    private init() {}
+
+    func play(_ event: RecordingSoundEvent) {
+        guard let sound = sound(for: event) else { return }
+        sound.stop()
+        sound.currentTime = 0
+        sound.play()
+    }
+
+    private func sound(for event: RecordingSoundEvent) -> NSSound? {
+        if let sound = sounds[event] {
+            return sound
+        }
+        guard let sound = NSSound(named: event.soundName) else {
+            return nil
+        }
+        sounds[event] = sound
+        return sound
+    }
+}

--- a/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
@@ -13,7 +13,7 @@ enum RecordingSoundEvent: Hashable {
     case startedRecording
     case finishedRecording
 
-    var soundName: NSSound.Name {
+    var cueName: NSSound.Name {
         switch self {
         case .startedRecording:
             return NSSound.Name("Frog")
@@ -23,12 +23,12 @@ enum RecordingSoundEvent: Hashable {
     }
 }
 
-protocol RecordingSoundPlaying: AnyObject {
+protocol RecordingCuePlaying: AnyObject {
     func play(_ event: RecordingSoundEvent)
 }
 
-final class NativeRecordingSoundPlayer: RecordingSoundPlaying {
-    static let shared = NativeRecordingSoundPlayer()
+final class NativeRecordingCuePlayer: RecordingCuePlaying {
+    static let shared = NativeRecordingCuePlayer()
 
     private var sounds: [RecordingSoundEvent: NSSound] = [:]
 
@@ -45,7 +45,7 @@ final class NativeRecordingSoundPlayer: RecordingSoundPlaying {
         if let sound = sounds[event] {
             return sound
         }
-        guard let sound = NSSound(named: event.soundName) else {
+        guard let sound = NSSound(named: event.cueName) else {
             return nil
         }
         sounds[event] = sound

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -179,6 +179,8 @@ struct SettingsView: View {
     @ObservedObject private var loginItemController = LoginItemController.shared
     @AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)
     private var useUserInstalledAgentCLI = false
+    @AppStorage(RecordingSoundSettings.enabledKey)
+    private var recordingSoundsEnabled = false
     @AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)
     private var transcriptionExtraInstructions = ""
     @State private var shortcutRevision = 0
@@ -202,10 +204,11 @@ struct SettingsView: View {
                 }
 
                 Toggle("Use User-Installed agent-cli", isOn: $useUserInstalledAgentCLI)
+                Toggle("Play Recording Sounds", isOn: $recordingSoundsEnabled)
             } header: {
                 Text("General")
             } footer: {
-                Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime.")
+                Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime. Recording sounds use Frog when recording starts and Funk when recording ends.")
             }
 
             Section {

--- a/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
@@ -1,11 +1,9 @@
-#if canImport(Testing)
-import Testing
+#if canImport(XCTest)
+import XCTest
 @testable import AgentCLI
 
-@Suite
-struct RecordingIndicatorControllerTests {
-    @Test
-    func recordingSoundsAreDisabledByDefault() {
+final class RecordingIndicatorControllerTests: XCTestCase {
+    func testRecordingSoundsAreDisabledByDefault() {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-default")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-default")
         let player = RecordingCuePlayerSpy()
@@ -14,11 +12,10 @@ struct RecordingIndicatorControllerTests {
         controller.begin(for: .toggleTranscription)
         controller.end(for: .toggleTranscription)
 
-        #expect(player.events == [])
+        XCTAssertEqual(player.events, [])
     }
 
-    @Test
-    func recordingSoundsPlayStartAndFinishWhenEnabled() {
+    func testRecordingSoundsPlayStartAndFinishWhenEnabled() {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-enabled")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-enabled")
         defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
@@ -28,11 +25,10 @@ struct RecordingIndicatorControllerTests {
         controller.begin(for: .toggleTranscription)
         controller.end(for: .toggleTranscription)
 
-        #expect(player.events == [.startedRecording, .finishedRecording])
+        XCTAssertEqual(player.events, [.startedRecording, .finishedRecording])
     }
 
-    @Test
-    func finishSoundPlaysOnlyWhenAllRecordingCommandsHaveEnded() {
+    func testFinishSoundPlaysOnlyWhenAllRecordingCommandsHaveEnded() {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-nested")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-nested")
         defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
@@ -42,10 +38,10 @@ struct RecordingIndicatorControllerTests {
         controller.begin(for: .toggleTranscription)
         controller.begin(for: .voiceEdit)
         controller.end(for: .toggleTranscription)
-        #expect(player.events == [.startedRecording])
+        XCTAssertEqual(player.events, [.startedRecording])
 
         controller.end(for: .voiceEdit)
-        #expect(player.events == [.startedRecording, .finishedRecording])
+        XCTAssertEqual(player.events, [.startedRecording, .finishedRecording])
     }
 }
 

--- a/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
@@ -8,8 +8,8 @@ struct RecordingIndicatorControllerTests {
     func recordingSoundsAreDisabledByDefault() {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-default")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-default")
-        let player = RecordingSoundPlayerSpy()
-        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+        let player = RecordingCuePlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, audioCuePlayer: player)
 
         controller.begin(for: .toggleTranscription)
         controller.end(for: .toggleTranscription)
@@ -22,8 +22,8 @@ struct RecordingIndicatorControllerTests {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-enabled")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-enabled")
         defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
-        let player = RecordingSoundPlayerSpy()
-        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+        let player = RecordingCuePlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, audioCuePlayer: player)
 
         controller.begin(for: .toggleTranscription)
         controller.end(for: .toggleTranscription)
@@ -36,8 +36,8 @@ struct RecordingIndicatorControllerTests {
         let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-nested")!
         defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-nested")
         defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
-        let player = RecordingSoundPlayerSpy()
-        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+        let player = RecordingCuePlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, audioCuePlayer: player)
 
         controller.begin(for: .toggleTranscription)
         controller.begin(for: .voiceEdit)
@@ -49,7 +49,7 @@ struct RecordingIndicatorControllerTests {
     }
 }
 
-private final class RecordingSoundPlayerSpy: RecordingSoundPlaying {
+private final class RecordingCuePlayerSpy: RecordingCuePlaying {
     private(set) var events: [RecordingSoundEvent] = []
 
     func play(_ event: RecordingSoundEvent) {

--- a/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
@@ -1,0 +1,59 @@
+#if canImport(Testing)
+import Testing
+@testable import AgentCLI
+
+@Suite
+struct RecordingIndicatorControllerTests {
+    @Test
+    func recordingSoundsAreDisabledByDefault() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-default")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-default")
+        let player = RecordingSoundPlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+
+        controller.begin(for: .toggleTranscription)
+        controller.end(for: .toggleTranscription)
+
+        #expect(player.events == [])
+    }
+
+    @Test
+    func recordingSoundsPlayStartAndFinishWhenEnabled() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-enabled")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-enabled")
+        defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
+        let player = RecordingSoundPlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+
+        controller.begin(for: .toggleTranscription)
+        controller.end(for: .toggleTranscription)
+
+        #expect(player.events == [.startedRecording, .finishedRecording])
+    }
+
+    @Test
+    func finishSoundPlaysOnlyWhenAllRecordingCommandsHaveEnded() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.recording-sounds-nested")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.recording-sounds-nested")
+        defaults.set(true, forKey: RecordingSoundSettings.enabledKey)
+        let player = RecordingSoundPlayerSpy()
+        let controller = RecordingIndicatorController(defaults: defaults, soundPlayer: player)
+
+        controller.begin(for: .toggleTranscription)
+        controller.begin(for: .voiceEdit)
+        controller.end(for: .toggleTranscription)
+        #expect(player.events == [.startedRecording])
+
+        controller.end(for: .voiceEdit)
+        #expect(player.events == [.startedRecording, .finishedRecording])
+    }
+}
+
+private final class RecordingSoundPlayerSpy: RecordingSoundPlaying {
+    private(set) var events: [RecordingSoundEvent] = []
+
+    func play(_ event: RecordingSoundEvent) {
+        events.append(event)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add a General setting to enable native recording sounds in the macOS app
- Play Frog when recording starts and Funk when the final recording ends
- Add focused tests for disabled/enabled and overlapping recording behavior

## Test Plan
- [x] swift build
- [x] swift test --enable-swift-testing --disable-xctest --filter RecordingIndicatorControllerTests
- [x] swift build -c release --package-path macos/AgentCLI
- [x] git diff --check