### PR TITLE
Animate voice service setup status

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -29,9 +29,13 @@ final class AgentCommandRunner: ObservableObject {
     @Published private(set) var isRecording = false
     @Published private(set) var bootstrapPhase: BootstrapPhase = .idle
     @Published private var activeCommandCount = 0
+    @Published private var bootstrapAnimationTick = 0
+    @Published private var bootstrapElapsedSeconds = 0
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
     private let bootstrap: AgentBootstrap
+    private var bootstrapAnimationTimer: Timer?
+    private var bootstrapPhaseStartedAt: Date?
     private var pendingStopRecordingCommands: Set<String> = []
     private var holdTranscriptionState: HoldTranscriptionState = .idle
     private var holdToTranscribePasteTarget: FocusedTextTarget?
@@ -47,7 +51,10 @@ final class AgentCommandRunner: ObservableObject {
             return "Recording"
         }
         if bootstrapPhase.isPreparing {
-            return bootstrapPhase.statusMessage
+            return bootstrapPhase.statusMessage(
+                animationTick: bootstrapAnimationTick,
+                elapsedSeconds: bootstrapElapsedSeconds
+            )
         }
         if holdTranscriptionState.isFinishing {
             return "Transcribing..."
@@ -122,7 +129,19 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     private func reportBootstrapPhase(_ phase: BootstrapPhase) {
+        let wasPreparing = bootstrapPhase.isPreparing
+        let phaseChanged = bootstrapPhase != phase
         bootstrapPhase = phase
+        if phase.isPreparing {
+            if !wasPreparing || phaseChanged {
+                bootstrapAnimationTick = 0
+                bootstrapElapsedSeconds = 0
+                bootstrapPhaseStartedAt = Date()
+            }
+            startBootstrapAnimationTimer()
+        } else {
+            stopBootstrapAnimationTimer()
+        }
     }
 
     private func makeBootstrapProgressReporter() -> AgentBootstrapProgress {
@@ -131,6 +150,33 @@ final class AgentCommandRunner: ObservableObject {
                 self?.reportBootstrapPhase(phase)
             }
         }
+    }
+
+    private func startBootstrapAnimationTimer() {
+        guard bootstrapAnimationTimer == nil else { return }
+        let timer = Timer(timeInterval: 0.8, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                guard self.bootstrapPhase.isPreparing else {
+                    self.stopBootstrapAnimationTimer()
+                    return
+                }
+                self.bootstrapAnimationTick = (self.bootstrapAnimationTick + 1) % 3
+                if let startedAt = self.bootstrapPhaseStartedAt {
+                    self.bootstrapElapsedSeconds = max(0, Int(Date().timeIntervalSince(startedAt)))
+                }
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        bootstrapAnimationTimer = timer
+    }
+
+    private func stopBootstrapAnimationTimer() {
+        bootstrapAnimationTimer?.invalidate()
+        bootstrapAnimationTimer = nil
+        bootstrapAnimationTick = 0
+        bootstrapElapsedSeconds = 0
+        bootstrapPhaseStartedAt = nil
     }
 
     @discardableResult

--- a/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
@@ -42,6 +42,16 @@ enum BootstrapPhase: Equatable {
             return "Voice service warm-up failed"
         }
     }
+
+    func statusMessage(animationTick: Int, elapsedSeconds: Int) -> String {
+        switch self {
+        case .waitingForVoiceService:
+            let periodCount = (animationTick % 3) + 1
+            return "Waiting for voice service\(String(repeating: ".", count: periodCount)) (\(elapsedSeconds)s)"
+        case .idle, .checkingRuntime, .installingRuntime, .installingVoiceService, .warmingWhisperModel, .failed:
+            return statusMessage
+        }
+    }
 }
 
 typealias AgentBootstrapProgress = (BootstrapPhase) -> Void

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -140,6 +140,25 @@ final class AgentCommandTests: XCTestCase {
 
         XCTAssertEqual(recorder.calls, [.init(requirement: .transcriptionModel, force: false)])
     }
+
+    func testWaitingForVoiceServiceStatusAnimatesEllipsis() {
+        XCTAssertEqual(
+            BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 0, elapsedSeconds: 0),
+            "Waiting for voice service. (0s)"
+        )
+        XCTAssertEqual(
+            BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 1, elapsedSeconds: 12),
+            "Waiting for voice service.. (12s)"
+        )
+        XCTAssertEqual(
+            BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 2, elapsedSeconds: 123),
+            "Waiting for voice service... (123s)"
+        )
+        XCTAssertEqual(
+            BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 3, elapsedSeconds: 4),
+            "Waiting for voice service. (4s)"
+        )
+    }
 }
 
 private struct BootstrapCall: Equatable {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -518,14 +518,34 @@ def test_macos_app_keeps_preparing_status_visible_during_command_bootstrap() -> 
     assert "enum BootstrapPhase: Equatable" in source
     assert "var isPreparing: Bool" in source
     assert "var statusMessage: String" in source
-    assert (
-        "if bootstrapPhase.isPreparing {\n            return bootstrapPhase.statusMessage" in source
-    )
+    assert "if bootstrapPhase.isPreparing {" in source
+    assert "return bootstrapPhase.statusMessage(" in source
+    assert "animationTick: bootstrapAnimationTick" in source
+    assert "elapsedSeconds: bootstrapElapsedSeconds" in source
     assert (
         "if !self.bootstrapPhase.isPreparing {\n            statusMessage = isStopRequest" in source
     )
     assert "self.reportBootstrapPhase(.idle)" in source
     assert 'statusMessage == "Preparing voice service..."' not in source
+
+
+def test_macos_app_animates_waiting_for_voice_service_status() -> None:
+    """The waiting status should visibly indicate that setup is still progressing."""
+    source = swift_source()
+
+    assert "statusMessage(animationTick: Int, elapsedSeconds: Int)" in source
+    assert "let periodCount = (animationTick % 3) + 1" in source
+    assert (
+        '"Waiting for voice service\\(String(repeating: ".", count: periodCount)) '
+        '(\\(elapsedSeconds)s)"' in source
+    )
+    assert "bootstrapAnimationTimer" in source
+    assert "bootstrapPhaseStartedAt" in source
+    assert "bootstrapElapsedSeconds" in source
+    assert "RunLoop.main.add(timer, forMode: .common)" in source
+    assert "bootstrapPhase.statusMessage(" in source
+    assert "animationTick: bootstrapAnimationTick" in source
+    assert "elapsedSeconds: bootstrapElapsedSeconds" in source
 
 
 def test_macos_app_shows_preparing_menu_bar_icon_state() -> None:


### PR DESCRIPTION
## Summary
- Animate the waiting-for-voice-service menu status with cycling ellipsis text.
- Add elapsed seconds to the waiting status so setup progress is visibly ongoing.
- Reset and stop the animation timer as bootstrap phases change or complete.

## Test Plan
- uv run pytest tests/test_macos_app.py
- swift test --package-path macos/AgentCLI