### PR TITLE
Fix macOS Fn+Space transcription default

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -5,10 +5,7 @@ import KeyboardShortcuts
 import SwiftUI
 
 extension KeyboardShortcuts.Name {
-    static let toggleTranscription = Self(
-        "toggleTranscription",
-        default: KeyboardShortcuts.Shortcut(carbonKeyCode: kVK_Space, carbonModifiers: kEventKeyModifierFnMask)
-    )
+    static let toggleTranscription = Self("toggleTranscription")
     static let holdToTranscribe = Self(
         "holdToTranscribe",
         default: KeyboardShortcuts.Shortcut(.function)
@@ -21,6 +18,68 @@ extension KeyboardShortcuts.Name {
         "voiceEdit",
         default: KeyboardShortcuts.Shortcut(.v, modifiers: [.command, .shift])
     )
+}
+
+enum AppShortcutDefaults {
+    static let toggleTranscription = ShortcutStorage.shortcut(
+        carbonKeyCode: kVK_Space,
+        carbonModifiers: kEventKeyModifierFnMask
+    )
+}
+
+enum ShortcutStorage {
+    static func shortcut(carbonKeyCode: Int, carbonModifiers: Int = 0) -> KeyboardShortcuts.Shortcut {
+        // KeyboardShortcuts' public initializer normalizes away Fn, but Codable preserves raw Carbon modifiers.
+        let shortcutJSON = """
+        {"carbonKeyCode":\(carbonKeyCode),"carbonModifiers":\(carbonModifiers)}
+        """
+        guard let data = shortcutJSON.data(using: .utf8),
+              let shortcut = try? JSONDecoder().decode(KeyboardShortcuts.Shortcut.self, from: data) else {
+            return KeyboardShortcuts.Shortcut(
+                carbonKeyCode: carbonKeyCode,
+                carbonModifiers: carbonModifiers
+            )
+        }
+        return shortcut
+    }
+
+    static func setShortcut(_ shortcut: KeyboardShortcuts.Shortcut?, for name: KeyboardShortcuts.Name) {
+        guard let shortcut else {
+            KeyboardShortcuts.setShortcut(nil, for: name)
+            UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
+            postShortcutChange(for: name)
+            return
+        }
+
+        guard shortcut.carbonModifiers & kEventKeyModifierFnMask != 0 else {
+            KeyboardShortcuts.setShortcut(shortcut, for: name)
+            return
+        }
+
+        KeyboardShortcuts.setShortcut(nil, for: name)
+        guard let encoded = try? JSONEncoder().encode(shortcut),
+              let encodedString = String(data: encoded, encoding: .utf8) else {
+            return
+        }
+        UserDefaults.standard.set(encodedString, forKey: userDefaultsKey(for: name))
+        postShortcutChange(for: name)
+    }
+
+    static func userDefaultsContains(name: KeyboardShortcuts.Name) -> Bool {
+        UserDefaults.standard.object(forKey: userDefaultsKey(for: name)) != nil
+    }
+
+    private static func userDefaultsKey(for name: KeyboardShortcuts.Name) -> String {
+        "KeyboardShortcuts_\(name.rawValue)"
+    }
+
+    private static func postShortcutChange(for name: KeyboardShortcuts.Name) {
+        NotificationCenter.default.post(
+            name: Notification.Name("KeyboardShortcuts_shortcutByNameDidChange"),
+            object: nil,
+            userInfo: ["name": name]
+        )
+    }
 }
 
 final class ShortcutRecordingState {
@@ -64,8 +123,8 @@ final class ShortcutSummaryState: ObservableObject {
     }
 
     func resetDefaults() {
+        ShortcutStorage.setShortcut(AppShortcutDefaults.toggleTranscription, for: .toggleTranscription)
         KeyboardShortcuts.reset(
-            .toggleTranscription,
             .holdToTranscribe,
             .autocorrect,
             .voiceEdit
@@ -118,7 +177,7 @@ private enum ShortcutDisplay {
         if event.modifierFlags.contains(.function) {
             carbonModifiers |= kEventKeyModifierFnMask
         }
-        return KeyboardShortcuts.Shortcut(
+        return ShortcutStorage.shortcut(
             carbonKeyCode: shortcut.carbonKeyCode,
             carbonModifiers: carbonModifiers
         )
@@ -154,13 +213,19 @@ enum ShortcutDefaultsMigrator {
         migrateDefault(
             name: .toggleTranscription,
             from: KeyboardShortcuts.Shortcut(.r, modifiers: [.command, .shift]),
-            to: KeyboardShortcuts.Shortcut(carbonKeyCode: kVK_Space, carbonModifiers: kEventKeyModifierFnMask)
+            to: AppShortcutDefaults.toggleTranscription
+        )
+        migrateDefault(
+            name: .toggleTranscription,
+            from: KeyboardShortcuts.Shortcut(.space),
+            to: AppShortcutDefaults.toggleTranscription
         )
         migrateDefault(
             name: .holdToTranscribe,
             from: KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option]),
             to: KeyboardShortcuts.Shortcut(.function)
         )
+        seedDefault(name: .toggleTranscription, shortcut: AppShortcutDefaults.toggleTranscription)
     }
 
     private static func migrateDefault(
@@ -171,7 +236,17 @@ enum ShortcutDefaultsMigrator {
         guard KeyboardShortcuts.getShortcut(for: name) == oldShortcut else {
             return
         }
-        KeyboardShortcuts.setShortcut(newShortcut, for: name)
+        ShortcutStorage.setShortcut(newShortcut, for: name)
+    }
+
+    private static func seedDefault(
+        name: KeyboardShortcuts.Name,
+        shortcut: KeyboardShortcuts.Shortcut
+    ) {
+        guard !ShortcutStorage.userDefaultsContains(name: name) else {
+            return
+        }
+        ShortcutStorage.setShortcut(shortcut, for: name)
     }
 }
 
@@ -358,7 +433,7 @@ final class ShortcutRecorderButton: NSButton {
             stopRecording()
         case kVK_Delete, kVK_ForwardDelete:
             pendingFunctionShortcut = false
-            KeyboardShortcuts.setShortcut(nil, for: shortcutName)
+            ShortcutStorage.setShortcut(nil, for: shortcutName)
             stopRecording()
         case kVK_Function:
             handleFunctionKeyChange(event)
@@ -368,7 +443,7 @@ final class ShortcutRecorderButton: NSButton {
                 NSSound.beep()
                 return
             }
-            KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
+            ShortcutStorage.setShortcut(shortcut, for: shortcutName)
             stopRecording()
         }
     }
@@ -390,7 +465,7 @@ final class ShortcutRecorderButton: NSButton {
 
     private func captureBareFunctionShortcut() {
         pendingFunctionShortcut = false
-        KeyboardShortcuts.setShortcut(KeyboardShortcuts.Shortcut(.function), for: shortcutName)
+        ShortcutStorage.setShortcut(KeyboardShortcuts.Shortcut(.function), for: shortcutName)
         stopRecording()
     }
 

--- a/macos/AgentCLI/Tests/AgentCLITests/ShortcutDefaultsTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/ShortcutDefaultsTests.swift
@@ -1,0 +1,55 @@
+#if canImport(XCTest)
+import Carbon.HIToolbox
+import KeyboardShortcuts
+import XCTest
+@testable import AgentCLI
+
+final class ShortcutDefaultsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        clearShortcutDefaults()
+    }
+
+    override func tearDown() {
+        clearShortcutDefaults()
+        super.tearDown()
+    }
+
+    func testMigratesPlainSpaceToggleShortcutToFunctionSpace() {
+        KeyboardShortcuts.setShortcut(
+            KeyboardShortcuts.Shortcut(.space),
+            for: .toggleTranscription
+        )
+
+        ShortcutDefaultsMigrator.migrate()
+
+        let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription)
+        XCTAssertEqual(shortcut?.carbonKeyCode, kVK_Space)
+        XCTAssertEqual((shortcut?.carbonModifiers ?? 0) & kEventKeyModifierFnMask, kEventKeyModifierFnMask)
+    }
+
+    func testResetDefaultsRestoresFunctionSpaceToggleShortcut() {
+        KeyboardShortcuts.setShortcut(
+            KeyboardShortcuts.Shortcut(.space),
+            for: .toggleTranscription
+        )
+
+        ShortcutSummaryState.shared.resetDefaults()
+
+        let shortcut = KeyboardShortcuts.getShortcut(for: .toggleTranscription)
+        XCTAssertEqual(shortcut?.carbonKeyCode, kVK_Space)
+        XCTAssertEqual((shortcut?.carbonModifiers ?? 0) & kEventKeyModifierFnMask, kEventKeyModifierFnMask)
+    }
+
+    private func clearShortcutDefaults() {
+        for name in [
+            "toggleTranscription",
+            "holdToTranscribe",
+            "autocorrect",
+            "voiceEdit",
+        ] {
+            UserDefaults.standard.removeObject(forKey: "KeyboardShortcuts_\(name)")
+        }
+    }
+}
+#endif

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -564,14 +564,25 @@ def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:
     source = swift_source()
 
     assert "kEventKeyModifierFnMask" in source
-    assert (
-        "KeyboardShortcuts.Shortcut(carbonKeyCode: kVK_Space, carbonModifiers: kEventKeyModifierFnMask)"
-        in source
-    )
+    assert "static let toggleTranscription = ShortcutStorage.shortcut(" in source
+    assert "carbonKeyCode: kVK_Space" in source
+    assert "carbonModifiers: kEventKeyModifierFnMask" in source
     assert "event.modifierFlags.contains(.function)" in source
     assert "carbonModifiers |= kEventKeyModifierFnMask" in source
     assert ".flagsChanged" in source
     assert "Fn+Space" in source
+
+
+def test_macos_app_persists_fn_space_without_keyboardshortcuts_normalization() -> None:
+    """KeyboardShortcuts' public Shortcut initializer drops Fn, so app storage must preserve it."""
+    source = swift_source()
+
+    assert "enum ShortcutStorage" in source
+    assert "JSONEncoder().encode(shortcut)" in source
+    assert "JSONDecoder().decode(KeyboardShortcuts.Shortcut.self" in source
+    assert '"KeyboardShortcuts_\\(name.rawValue)"' in source
+    assert "ShortcutStorage.setShortcut(AppShortcutDefaults.toggleTranscription" in source
+    assert "static let toggleTranscription = ShortcutStorage.shortcut(" in source
 
 
 def test_macos_app_uses_fn_aware_event_tap_for_transcription_shortcuts() -> None:
@@ -633,14 +644,16 @@ def test_macos_app_migrates_old_default_shortcuts_to_fn_defaults() -> None:
     assert "ShortcutDefaultsMigrator.migrate()" in source
     assert "migrateDefault(" in source
     assert "from: KeyboardShortcuts.Shortcut(.r, modifiers: [.command, .shift])" in source
+    assert "from: KeyboardShortcuts.Shortcut(.space)" in source
+    assert "to: AppShortcutDefaults.toggleTranscription" in source
     assert (
-        "to: KeyboardShortcuts.Shortcut(carbonKeyCode: kVK_Space, carbonModifiers: kEventKeyModifierFnMask)"
+        "seedDefault(name: .toggleTranscription, shortcut: AppShortcutDefaults.toggleTranscription)"
         in source
     )
     assert "from: KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option])" in source
     assert "to: KeyboardShortcuts.Shortcut(.function)" in source
     assert "KeyboardShortcuts.getShortcut(for: name) == oldShortcut" in source
-    assert "KeyboardShortcuts.setShortcut(newShortcut, for: name)" in source
+    assert "ShortcutStorage.setShortcut(newShortcut, for: name)" in source
 
 
 def test_macos_app_pastes_hold_transcription_into_focused_field() -> None:


### PR DESCRIPTION
## Summary
- Preserve raw Fn Carbon modifiers when storing macOS shortcuts instead of letting KeyboardShortcuts normalize Fn away.
- Migrate existing plain Space toggle shortcuts to the intended Fn+Space default and seed Fn+Space on fresh installs.
- Add regression coverage for migration, reset defaults, and source-shape shortcut storage.

## Test Plan
- uv run pytest tests/test_macos_app.py
- swift build --package-path macos/AgentCLI

Note: swift test --package-path macos/AgentCLI --enable-xctest --filter ShortcutDefaultsTests compiles here but XCTest execution is blocked by the local Command Line Tools SDK: xcrun --show-sdk-platform-path fails.