### PR TITLE
Refactor macOS Fn shortcut default storage

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -20,15 +20,34 @@ extension KeyboardShortcuts.Name {
     )
 }
 
-enum AppShortcutDefaults {
-    static let toggleTranscription = ShortcutStorage.shortcut(
+enum ToggleTranscriptionDefault {
+    static let shortcut = FunctionShortcutPersistence.rawShortcut(
         carbonKeyCode: kVK_Space,
         carbonModifiers: kEventKeyModifierFnMask
     )
+
+    static func set() {
+        FunctionShortcutPersistence.set(shortcut, for: .toggleTranscription)
+    }
+
+    static func seedIfNeeded() {
+        guard !userDefaultsContainsShortcut else {
+            return
+        }
+        set()
+    }
+
+    private static var userDefaultsContainsShortcut: Bool {
+        UserDefaults.standard.object(forKey: userDefaultsKey) != nil
+    }
+
+    private static var userDefaultsKey: String {
+        "KeyboardShortcuts_\(KeyboardShortcuts.Name.toggleTranscription.rawValue)"
+    }
 }
 
-enum ShortcutStorage {
-    static func shortcut(carbonKeyCode: Int, carbonModifiers: Int = 0) -> KeyboardShortcuts.Shortcut {
+enum FunctionShortcutPersistence {
+    static func rawShortcut(carbonKeyCode: Int, carbonModifiers: Int) -> KeyboardShortcuts.Shortcut {
         // KeyboardShortcuts' public initializer normalizes away Fn, but Codable preserves raw Carbon modifiers.
         let shortcutJSON = """
         {"carbonKeyCode":\(carbonKeyCode),"carbonModifiers":\(carbonModifiers)}
@@ -43,42 +62,23 @@ enum ShortcutStorage {
         return shortcut
     }
 
-    static func setShortcut(_ shortcut: KeyboardShortcuts.Shortcut?, for name: KeyboardShortcuts.Name) {
-        guard let shortcut else {
-            KeyboardShortcuts.setShortcut(nil, for: name)
-            UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
-            postShortcutChange(for: name)
-            return
-        }
-
-        guard shortcut.carbonModifiers & kEventKeyModifierFnMask != 0 else {
-            KeyboardShortcuts.setShortcut(shortcut, for: name)
-            return
-        }
-
+    static func set(_ shortcut: KeyboardShortcuts.Shortcut, for name: KeyboardShortcuts.Name) {
         KeyboardShortcuts.setShortcut(nil, for: name)
         guard let encoded = try? JSONEncoder().encode(shortcut),
               let encodedString = String(data: encoded, encoding: .utf8) else {
             return
         }
         UserDefaults.standard.set(encodedString, forKey: userDefaultsKey(for: name))
-        postShortcutChange(for: name)
-    }
-
-    static func userDefaultsContains(name: KeyboardShortcuts.Name) -> Bool {
-        UserDefaults.standard.object(forKey: userDefaultsKey(for: name)) != nil
     }
 
     private static func userDefaultsKey(for name: KeyboardShortcuts.Name) -> String {
         "KeyboardShortcuts_\(name.rawValue)"
     }
+}
 
-    private static func postShortcutChange(for name: KeyboardShortcuts.Name) {
-        NotificationCenter.default.post(
-            name: Notification.Name("KeyboardShortcuts_shortcutByNameDidChange"),
-            object: nil,
-            userInfo: ["name": name]
-        )
+private extension KeyboardShortcuts.Shortcut {
+    var usesFunctionModifier: Bool {
+        carbonModifiers & kEventKeyModifierFnMask != 0
     }
 }
 
@@ -123,7 +123,7 @@ final class ShortcutSummaryState: ObservableObject {
     }
 
     func resetDefaults() {
-        ShortcutStorage.setShortcut(AppShortcutDefaults.toggleTranscription, for: .toggleTranscription)
+        ToggleTranscriptionDefault.set()
         KeyboardShortcuts.reset(
             .holdToTranscribe,
             .autocorrect,
@@ -177,7 +177,15 @@ private enum ShortcutDisplay {
         if event.modifierFlags.contains(.function) {
             carbonModifiers |= kEventKeyModifierFnMask
         }
-        return ShortcutStorage.shortcut(
+
+        guard carbonModifiers & kEventKeyModifierFnMask != 0 else {
+            return KeyboardShortcuts.Shortcut(
+                carbonKeyCode: shortcut.carbonKeyCode,
+                carbonModifiers: carbonModifiers
+            )
+        }
+
+        return FunctionShortcutPersistence.rawShortcut(
             carbonKeyCode: shortcut.carbonKeyCode,
             carbonModifiers: carbonModifiers
         )
@@ -213,19 +221,19 @@ enum ShortcutDefaultsMigrator {
         migrateDefault(
             name: .toggleTranscription,
             from: KeyboardShortcuts.Shortcut(.r, modifiers: [.command, .shift]),
-            to: AppShortcutDefaults.toggleTranscription
+            to: ToggleTranscriptionDefault.shortcut
         )
         migrateDefault(
             name: .toggleTranscription,
             from: KeyboardShortcuts.Shortcut(.space),
-            to: AppShortcutDefaults.toggleTranscription
+            to: ToggleTranscriptionDefault.shortcut
         )
         migrateDefault(
             name: .holdToTranscribe,
             from: KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option]),
             to: KeyboardShortcuts.Shortcut(.function)
         )
-        seedDefault(name: .toggleTranscription, shortcut: AppShortcutDefaults.toggleTranscription)
+        ToggleTranscriptionDefault.seedIfNeeded()
     }
 
     private static func migrateDefault(
@@ -236,17 +244,19 @@ enum ShortcutDefaultsMigrator {
         guard KeyboardShortcuts.getShortcut(for: name) == oldShortcut else {
             return
         }
-        ShortcutStorage.setShortcut(newShortcut, for: name)
+        setShortcut(newShortcut, for: name)
     }
 
-    private static func seedDefault(
-        name: KeyboardShortcuts.Name,
-        shortcut: KeyboardShortcuts.Shortcut
+    private static func setShortcut(
+        _ shortcut: KeyboardShortcuts.Shortcut,
+        for name: KeyboardShortcuts.Name
     ) {
-        guard !ShortcutStorage.userDefaultsContains(name: name) else {
+        guard name == .toggleTranscription,
+              shortcut == ToggleTranscriptionDefault.shortcut else {
+            KeyboardShortcuts.setShortcut(shortcut, for: name)
             return
         }
-        ShortcutStorage.setShortcut(shortcut, for: name)
+        ToggleTranscriptionDefault.set()
     }
 }
 
@@ -436,7 +446,7 @@ final class ShortcutRecorderButton: NSButton {
             stopRecording()
         case kVK_Delete, kVK_ForwardDelete:
             pendingFunctionShortcut = false
-            ShortcutStorage.setShortcut(nil, for: shortcutName)
+            KeyboardShortcuts.setShortcut(nil, for: shortcutName)
             stopRecording()
         case kVK_Function:
             handleFunctionKeyChange(event)
@@ -446,7 +456,15 @@ final class ShortcutRecorderButton: NSButton {
                 NSSound.beep()
                 return
             }
-            ShortcutStorage.setShortcut(shortcut, for: shortcutName)
+            if shortcut.usesFunctionModifier {
+                guard supportsFunctionChord(shortcutName) else {
+                    NSSound.beep()
+                    return
+                }
+                FunctionShortcutPersistence.set(shortcut, for: shortcutName)
+            } else {
+                KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
+            }
             stopRecording()
         }
     }
@@ -468,8 +486,12 @@ final class ShortcutRecorderButton: NSButton {
 
     private func captureBareFunctionShortcut() {
         pendingFunctionShortcut = false
-        ShortcutStorage.setShortcut(KeyboardShortcuts.Shortcut(.function), for: shortcutName)
+        KeyboardShortcuts.setShortcut(KeyboardShortcuts.Shortcut(.function), for: shortcutName)
         stopRecording()
+    }
+
+    private func supportsFunctionChord(_ name: KeyboardShortcuts.Name) -> Bool {
+        name == .toggleTranscription || name == .holdToTranscribe
     }
 
     private func stopRecording() {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -586,7 +586,8 @@ def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:
     source = swift_source()
 
     assert "kEventKeyModifierFnMask" in source
-    assert "static let toggleTranscription = ShortcutStorage.shortcut(" in source
+    assert "enum ToggleTranscriptionDefault" in source
+    assert "static let shortcut = FunctionShortcutPersistence.rawShortcut(" in source
     assert "carbonKeyCode: kVK_Space" in source
     assert "carbonModifiers: kEventKeyModifierFnMask" in source
     assert "event.modifierFlags.contains(.function)" in source
@@ -596,15 +597,17 @@ def test_macos_app_defaults_clipboard_transcription_to_fn_space() -> None:
 
 
 def test_macos_app_persists_fn_space_without_keyboardshortcuts_normalization() -> None:
-    """KeyboardShortcuts' public Shortcut initializer drops Fn, so app storage must preserve it."""
+    """Fn shortcuts should bypass KeyboardShortcuts normalization only where the app can dispatch them."""
     source = swift_source()
 
-    assert "enum ShortcutStorage" in source
+    assert "enum ToggleTranscriptionDefault" in source
+    assert "enum ShortcutStorage" not in source
     assert "JSONEncoder().encode(shortcut)" in source
     assert "JSONDecoder().decode(KeyboardShortcuts.Shortcut.self" in source
     assert '"KeyboardShortcuts_\\(name.rawValue)"' in source
-    assert "ShortcutStorage.setShortcut(AppShortcutDefaults.toggleTranscription" in source
-    assert "static let toggleTranscription = ShortcutStorage.shortcut(" in source
+    assert "ToggleTranscriptionDefault.set()" in source
+    assert "FunctionShortcutPersistence.set(shortcut, for: shortcutName)" in source
+    assert "ShortcutStorage.setShortcut(" not in source
 
 
 def test_macos_app_uses_fn_aware_event_tap_for_transcription_shortcuts() -> None:
@@ -667,15 +670,12 @@ def test_macos_app_migrates_old_default_shortcuts_to_fn_defaults() -> None:
     assert "migrateDefault(" in source
     assert "from: KeyboardShortcuts.Shortcut(.r, modifiers: [.command, .shift])" in source
     assert "from: KeyboardShortcuts.Shortcut(.space)" in source
-    assert "to: AppShortcutDefaults.toggleTranscription" in source
-    assert (
-        "seedDefault(name: .toggleTranscription, shortcut: AppShortcutDefaults.toggleTranscription)"
-        in source
-    )
+    assert "to: ToggleTranscriptionDefault.shortcut" in source
+    assert "ToggleTranscriptionDefault.seedIfNeeded()" in source
     assert "from: KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option])" in source
     assert "to: KeyboardShortcuts.Shortcut(.function)" in source
     assert "KeyboardShortcuts.getShortcut(for: name) == oldShortcut" in source
-    assert "ShortcutStorage.setShortcut(newShortcut, for: name)" in source
+    assert "setShortcut(newShortcut, for: name)" in source
 
 
 def test_macos_app_pastes_hold_transcription_into_focused_field() -> None:
@@ -941,6 +941,10 @@ def test_macos_app_records_fn_chords_before_bare_fn() -> None:
     assert "captureBareFunctionShortcut()" in source
     assert "event.modifierFlags.contains(.function)" in source
     assert "case kVK_Function:" in source
+    assert "shortcut.usesFunctionModifier" in source
+    assert "supportsFunctionChord(shortcutName)" in source
+    assert "FunctionShortcutPersistence.set(shortcut, for: shortcutName)" in source
+    assert "KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)" in source
 
 
 def test_macos_app_shows_actual_persisted_shortcuts_and_can_reset_them() -> None:


### PR DESCRIPTION
## Summary
- Replace the broad ShortcutStorage abstraction with a narrow ToggleTranscriptionDefault helper.
- Keep Fn-preserving raw storage only for the built-in toggle transcription Fn+Space default.
- Route ordinary shortcut recording/deletion back through KeyboardShortcuts.setShortcut.

## Test Plan
- uv run pytest tests/test_macos_app.py
- swift build --package-path macos/AgentCLI

Note: swift test --package-path macos/AgentCLI --enable-xctest --filter ShortcutDefaultsTests compiles locally, then XCTest execution is blocked by the local Command Line Tools SDK xcrun --show-sdk-platform-path failure.