### PR TITLE
Fix function-row shortcut recording

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -174,7 +174,8 @@ private enum ShortcutDisplay {
         }
 
         var carbonModifiers = shortcut.carbonModifiers
-        if event.modifierFlags.contains(.function) {
+        if event.modifierFlags.contains(.function),
+           shouldTreatFunctionFlagAsModifier(for: shortcut.carbonKeyCode) {
             carbonModifiers |= kEventKeyModifierFnMask
         }
 
@@ -189,6 +190,19 @@ private enum ShortcutDisplay {
             carbonKeyCode: shortcut.carbonKeyCode,
             carbonModifiers: carbonModifiers
         )
+    }
+
+    private static func shouldTreatFunctionFlagAsModifier(for carbonKeyCode: Int) -> Bool {
+        !isFunctionRowKey(carbonKeyCode)
+    }
+
+    private static func isFunctionRowKey(_ carbonKeyCode: Int) -> Bool {
+        switch carbonKeyCode {
+        case kVK_F1...kVK_F20:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func label(for shortcut: KeyboardShortcuts.Shortcut, fallback: String) -> String {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -947,6 +947,16 @@ def test_macos_app_records_fn_chords_before_bare_fn() -> None:
     assert "KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)" in source
 
 
+def test_macos_app_does_not_record_function_row_keys_as_fn_chords() -> None:
+    """F1/F2 key events can carry .function in modifierFlags but should remain plain keys."""
+    source = swift_source()
+
+    assert "shouldTreatFunctionFlagAsModifier(for: shortcut.carbonKeyCode)" in source
+    assert "isFunctionRowKey(" in source
+    assert "case kVK_F1...kVK_F20:" in source
+    assert "!isFunctionRowKey(carbonKeyCode)" in source
+
+
 def test_macos_app_shows_actual_persisted_shortcuts_and_can_reset_them() -> None:
     """The menu should reflect stored shortcuts instead of claiming static defaults."""
     source = swift_source()


### PR DESCRIPTION
## Summary
- avoid treating F1-F20 key events as Fn-modified chords when recording shortcuts
- keep Fn modifier preservation for actual Fn shortcut chords
- add regression coverage for function-row shortcut recording

## Test Plan
- uv run pytest tests/test_macos_app.py
- swift build --package-path macos/AgentCLI