### PR TITLE
Update cask automatically after release

### DIFF
--- a/.github/scripts/update_cask.py
+++ b/.github/scripts/update_cask.py
@@ -1,0 +1,87 @@
+"""Update the Agent CLI Homebrew cask version and checksum."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_RE = re.compile(r'^(?P<indent>\s*)version "[^"]+"$')
+SHA256_RE = re.compile(r'^(?P<indent>\s*)sha256 "[0-9a-f]{64}"$')
+
+
+def _validate_sha256(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        msg = "sha256 must be 64 lowercase hexadecimal characters"
+        raise ValueError(msg)
+    return value
+
+
+def _validate_version(value: str) -> str:
+    value = value.removeprefix("v")
+    if not re.fullmatch(r"\d+(?:\.\d+)*(?:[-,._A-Za-z0-9]+)?", value):
+        msg = f"unsupported cask version: {value}"
+        raise ValueError(msg)
+    return value
+
+
+def update_cask_text(text: str, *, version: str, sha256: str) -> str:
+    """Replace the single version and sha256 stanzas in a cask."""
+    version = _validate_version(version)
+    sha256 = _validate_sha256(sha256)
+
+    version_count = 0
+    sha256_count = 0
+    lines: list[str] = []
+    for source_line in text.splitlines(keepends=True):
+        newline = "\n" if source_line.endswith("\n") else ""
+        content = source_line.removesuffix("\n")
+
+        if match := VERSION_RE.match(content):
+            output_line = f'{match.group("indent")}version "{version}"{newline}'
+            version_count += 1
+        elif match := SHA256_RE.match(content):
+            output_line = f'{match.group("indent")}sha256 "{sha256}"{newline}'
+            sha256_count += 1
+        else:
+            output_line = source_line
+        lines.append(output_line)
+
+    if version_count != 1:
+        msg = f"expected exactly one version stanza, found {version_count}"
+        raise ValueError(msg)
+    if sha256_count != 1:
+        msg = f"expected exactly one sha256 stanza, found {sha256_count}"
+        raise ValueError(msg)
+
+    return "".join(lines)
+
+
+def update_cask_file(path: Path, *, version: str, sha256: str) -> None:
+    """Update a cask file in place."""
+    path.write_text(
+        update_cask_text(path.read_text(), version=version, sha256=sha256),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    """Run the command-line cask updater."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cask",
+        type=Path,
+        default=Path("Casks/agent-cli.rb"),
+        help="Path to the cask file to update.",
+    )
+    parser.add_argument(
+        "--version", required=True, help="Release version, with or without v prefix."
+    )
+    parser.add_argument("--sha256", required=True, help="SHA-256 checksum for the release DMG.")
+    args = parser.parse_args()
+
+    update_cask_file(args.cask, version=args.version, sha256=args.sha256)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: gh release upload "$TAG_NAME" dist/macos/AgentCLI.dmg --clobber
+      - name: Update Homebrew cask
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          SHA256=$(shasum -a 256 dist/macos/AgentCLI.dmg | awk '{ print $1 }')
+
+          git fetch origin main
+          git switch --force-create cask-update origin/main
+
+          python3 .github/scripts/update_cask.py \
+            --version "$VERSION" \
+            --sha256 "$SHA256"
+
+          if git diff --quiet -- Casks/agent-cli.rb; then
+            echo "Casks/agent-cli.rb is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/agent-cli.rb
+          git commit -m "Update AgentCLI cask to ${TAG_NAME}"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/Casks/agent-cli.rb
+++ b/Casks/agent-cli.rb
@@ -1,6 +1,6 @@
 cask "agent-cli" do
-  version "0.95.7"
-  sha256 "9db4a8d9f44765e1197d687a46e4cde041ada2d5284e6a22324c706d2a40848e"
+  version "0.95.8"
+  sha256 "60273504f3c4bea181db64033790e0290bf1b53b86a1386afa3d41216a172029"
 
   url "https://github.com/basnijholt/agent-cli/releases/download/v#{version}/AgentCLI.dmg"
   name "Agent CLI"

--- a/tests/test_update_cask.py
+++ b/tests/test_update_cask.py
@@ -1,0 +1,51 @@
+"""Tests for the release cask updater."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "update_cask.py"
+spec = importlib.util.spec_from_file_location("update_cask", SCRIPT_PATH)
+assert spec is not None
+assert spec.loader is not None
+update_cask = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(update_cask)
+update_cask_text = update_cask.update_cask_text
+
+
+CASK = """cask "agent-cli" do
+  version "0.95.7"
+  sha256 "9db4a8d9f44765e1197d687a46e4cde041ada2d5284e6a22324c706d2a40848e"
+
+  url "https://github.com/basnijholt/agent-cli/releases/download/v#{version}/AgentCLI.dmg"
+end
+"""
+
+
+def test_update_cask_text_replaces_version_and_sha256() -> None:
+    updated = update_cask_text(
+        CASK,
+        version="v0.95.8",
+        sha256="60273504f3c4bea181db64033790e0290bf1b53b86a1386afa3d41216a172029",
+    )
+
+    assert '  version "0.95.8"' in updated
+    assert '  sha256 "60273504f3c4bea181db64033790e0290bf1b53b86a1386afa3d41216a172029"' in updated
+    assert "v#{version}" in updated
+
+
+def test_update_cask_text_rejects_invalid_sha256() -> None:
+    with pytest.raises(ValueError, match="sha256"):
+        update_cask_text(CASK, version="0.95.8", sha256="bad")
+
+
+def test_update_cask_text_requires_one_version_stanza() -> None:
+    with pytest.raises(ValueError, match="expected exactly one version"):
+        update_cask_text(
+            CASK.replace('  version "0.95.7"\n', ""),
+            version="0.95.8",
+            sha256="60273504f3c4bea181db64033790e0290bf1b53b86a1386afa3d41216a172029",
+        )


### PR DESCRIPTION
## Summary

- add a small `.github/scripts/update_cask.py` helper for deterministic cask version/checksum updates
- update the release workflow to bump `Casks/agent-cli.rb` on `main` after the notarized DMG is uploaded
- bump the checked-in cask to the current `v0.95.8` release

## Testing

- `uv run pytest tests/test_update_cask.py -q`
- `uv run ruff check .github/scripts/update_cask.py tests/test_update_cask.py`
- `uv run ruff format --check .github/scripts/update_cask.py tests/test_update_cask.py`
- workflow YAML smoke check with `uv run python`
- updater CLI smoke check against a temporary cask file
- `brew style --cask basnijholt/agent-cli/agent-cli`
- `brew audit --cask --strict --online basnijholt/agent-cli/agent-cli`
- `brew livecheck --cask basnijholt/agent-cli/agent-cli`
- `uv run pre-commit run --all-files`
- `uv run --all-extras pytest -vvv`
- `uv run python docs/run_markdown_code_runner.py`
