### PR TITLE
Stabilize macOS setup status animation

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -161,7 +161,7 @@ final class AgentCommandRunner: ObservableObject {
                     self.stopBootstrapAnimationTimer()
                     return
                 }
-                self.bootstrapAnimationTick = (self.bootstrapAnimationTick + 1) % 3
+                self.bootstrapAnimationTick = (self.bootstrapAnimationTick + 1) % 4
                 if let startedAt = self.bootstrapPhaseStartedAt {
                     self.bootstrapElapsedSeconds = max(0, Int(Date().timeIntervalSince(startedAt)))
                 }

--- a/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
@@ -45,10 +45,31 @@ enum BootstrapPhase: Equatable {
 
     func statusMessage(animationTick: Int, elapsedSeconds: Int) -> String {
         switch self {
+        case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:
+            let spinnerFrames = ["◐", "◓", "◑", "◒"]
+            let spinner = spinnerFrames[animationTick % spinnerFrames.count]
+            let minutes = elapsedSeconds / 60
+            let seconds = elapsedSeconds % 60
+            let elapsedTime = String(format: "%02d:%02d", minutes, seconds)
+            return "\(animatedStatusMessage) \(spinner) (\(elapsedTime))"
+        case .idle, .failed:
+            return statusMessage
+        }
+    }
+
+    private var animatedStatusMessage: String {
+        switch self {
+        case .checkingRuntime:
+            return "Checking CLI runtime"
+        case .installingRuntime:
+            return "Installing CLI runtime"
+        case .installingVoiceService:
+            return "Installing voice service"
         case .waitingForVoiceService:
-            let periodCount = (animationTick % 3) + 1
-            return "Waiting for voice service\(String(repeating: ".", count: periodCount)) (\(elapsedSeconds)s)"
-        case .idle, .checkingRuntime, .installingRuntime, .installingVoiceService, .warmingWhisperModel, .failed:
+            return "Waiting for voice service"
+        case .warmingWhisperModel:
+            return "Warming Whisper model"
+        case .idle, .failed:
             return statusMessage
         }
     }

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -148,22 +148,34 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(recorder.calls, [.init(requirement: .transcriptionModel, force: false)])
     }
 
-    func testWaitingForVoiceServiceStatusAnimatesEllipsis() {
+    func testPreparingStatusShowsFixedWidthSpinnerAndElapsedTime() {
+        XCTAssertEqual(
+            BootstrapPhase.checkingRuntime.statusMessage(animationTick: 0, elapsedSeconds: 0),
+            "Checking CLI runtime ◐ (00:00)"
+        )
+        XCTAssertEqual(
+            BootstrapPhase.installingRuntime.statusMessage(animationTick: 1, elapsedSeconds: 12),
+            "Installing CLI runtime ◓ (00:12)"
+        )
+        XCTAssertEqual(
+            BootstrapPhase.installingVoiceService.statusMessage(animationTick: 2, elapsedSeconds: 123),
+            "Installing voice service ◑ (02:03)"
+        )
         XCTAssertEqual(
             BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 0, elapsedSeconds: 0),
-            "Waiting for voice service. (0s)"
+            "Waiting for voice service ◐ (00:00)"
         )
         XCTAssertEqual(
             BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 1, elapsedSeconds: 12),
-            "Waiting for voice service.. (12s)"
+            "Waiting for voice service ◓ (00:12)"
         )
         XCTAssertEqual(
             BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 2, elapsedSeconds: 123),
-            "Waiting for voice service... (123s)"
+            "Waiting for voice service ◑ (02:03)"
         )
         XCTAssertEqual(
-            BootstrapPhase.waitingForVoiceService.statusMessage(animationTick: 3, elapsedSeconds: 4),
-            "Waiting for voice service. (4s)"
+            BootstrapPhase.warmingWhisperModel.statusMessage(animationTick: 3, elapsedSeconds: 4),
+            "Warming Whisper model ◒ (00:04)"
         )
     }
 }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -531,19 +531,22 @@ def test_macos_app_keeps_preparing_status_visible_during_command_bootstrap() -> 
     assert 'statusMessage == "Preparing voice service..."' not in source
 
 
-def test_macos_app_animates_waiting_for_voice_service_status() -> None:
-    """The waiting status should visibly indicate that setup is still progressing."""
+def test_macos_app_animates_all_preparing_statuses_with_fixed_width_timer() -> None:
+    """Every setup phase should show stable-width progress without shifting the timer."""
     source = swift_source()
 
     assert "statusMessage(animationTick: Int, elapsedSeconds: Int)" in source
-    assert "let periodCount = (animationTick % 3) + 1" in source
+    assert '["◐", "◓", "◑", "◒"]' in source
+    assert 'String(format: "%02d:%02d", minutes, seconds)' in source
+    assert '"\\(animatedStatusMessage) \\(spinner) (\\(elapsedTime))"' in source
     assert (
-        '"Waiting for voice service\\(String(repeating: ".", count: periodCount)) '
-        '(\\(elapsedSeconds)s)"' in source
+        "case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:"
+        in source
     )
     assert "bootstrapAnimationTimer" in source
     assert "bootstrapPhaseStartedAt" in source
     assert "bootstrapElapsedSeconds" in source
+    assert "bootstrapAnimationTick = (self.bootstrapAnimationTick + 1) % 4" in source
     assert "RunLoop.main.add(timer, forMode: .common)" in source
     assert "bootstrapPhase.statusMessage(" in source
     assert "animationTick: bootstrapAnimationTick" in source


### PR DESCRIPTION
## Summary
- Replace the growing setup ellipsis with a fixed-width four-frame spinner.
- Show a stable `mm:ss` elapsed counter for every preparing phase, including runtime setup and Whisper warm-up.
- Update macOS app regression coverage for all preparing statuses.

## Test Plan
- `uv run pytest`
- `pre-commit run --all-files`
- `swift test --package-path macos/AgentCLI`