### PR TITLE
Fix macOS menu refresh during voice warmup

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -33,8 +33,7 @@ struct AgentCLIApp: App {
 
             Divider()
 
-            Text("Voice: \(runner.menuStatusMessage)")
-                .lineLimit(1)
+            VoiceStatusMenuItem(runner: runner)
 
             Text(shortcutSummary.summary)
                 .lineLimit(1)

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -29,8 +29,8 @@ final class AgentCommandRunner: ObservableObject {
     @Published private(set) var isRecording = false
     @Published private(set) var bootstrapPhase: BootstrapPhase = .idle
     @Published private var activeCommandCount = 0
-    @Published private var bootstrapAnimationTick = 0
-    @Published private var bootstrapElapsedSeconds = 0
+    private var bootstrapAnimationTick = 0
+    private var bootstrapElapsedSeconds = 0
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
     private let bootstrap: AgentBootstrap

--- a/macos/AgentCLI/Sources/AgentCLI/VoiceStatusMenuItem.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceStatusMenuItem.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+struct VoiceStatusMenuItem: View {
+    let runner: AgentCommandRunner
+
+    @State private var statusMessage: String
+    private let statusRefreshTimer = Timer.publish(every: 0.8, on: .main, in: .common).autoconnect()
+
+    init(runner: AgentCommandRunner) {
+        self.runner = runner
+        _statusMessage = State(initialValue: runner.menuStatusMessage)
+    }
+
+    var body: some View {
+        Text("Voice: \(statusMessage)")
+            .lineLimit(1)
+            .onAppear(perform: refreshStatusMessage)
+            .onReceive(statusRefreshTimer) { _ in
+                refreshStatusMessage()
+            }
+    }
+
+    private func refreshStatusMessage() {
+        statusMessage = runner.menuStatusMessage
+    }
+}

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -178,6 +178,7 @@ final class AgentCommandTests: XCTestCase {
             "Warming Whisper model ◒ (00:04)"
         )
     }
+
 }
 
 private struct BootstrapCall: Equatable {

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -73,6 +73,7 @@ def test_macos_app_package_files_exist() -> None:
         "RecordingIndicatorController.swift",
         "Shortcuts.swift",
         "TranscriptPasteController.swift",
+        "VoiceStatusMenuItem.swift",
         "VoiceLevelOverlay.swift",
     ):
         assert (SWIFT_SOURCE_DIR / filename).is_file()
@@ -230,7 +231,7 @@ def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     assert record_index < voice_edit_index < autocorrect_index < troubleshooting_menu_index
     assert troubleshooting_menu_index < copy_output_index < troubleshooting_label_index
     assert 'Menu("Setup")' not in source
-    assert 'Text("Voice: \\(runner.menuStatusMessage)")' in source
+    assert "VoiceStatusMenuItem(runner: runner)" in source
     assert "var menuBarIconState: MenuBarIconState" in source
     assert "AgentCLIMenuBarIcon(state: runner.menuBarIconState)" in source
     assert "var menuStatusMessage: String" in source
@@ -568,6 +569,21 @@ def test_macos_app_animates_all_preparing_statuses_with_fixed_width_timer() -> N
     assert "bootstrapPhase.statusMessage(" in source
     assert "animationTick: bootstrapAnimationTick" in source
     assert "elapsedSeconds: bootstrapElapsedSeconds" in source
+
+
+def test_macos_app_updates_bootstrap_status_without_rebuilding_menu_tree() -> None:
+    """Bootstrap animation should keep updating without refreshing the whole menu."""
+    source = swift_source()
+
+    assert "VoiceStatusMenuItem(runner: runner)" in source
+    assert 'Text("Voice: \\(runner.menuStatusMessage)")' not in source
+    assert "struct VoiceStatusMenuItem: View" in source
+    assert 'Text("Voice: \\(statusMessage)")' in source
+    assert ".onReceive(statusRefreshTimer)" in source
+    assert "@Published private var bootstrapAnimationTick" not in source
+    assert "@Published private var bootstrapElapsedSeconds" not in source
+    assert "private var bootstrapAnimationTick = 0" in source
+    assert "private var bootstrapElapsedSeconds = 0" in source
 
 
 def test_macos_app_shows_preparing_menu_bar_icon_state() -> None:


### PR DESCRIPTION
## Summary
- Move the voice status line into a dedicated menu item view that refreshes itself.
- Keep the waiting-for-voice-service counter and spinner updating while the menu is open, without publishing every tick through the full menu tree.
- Add regression coverage so the status counter is no longer rendered directly by `AgentCLIApp`.

## Test Plan
- uv run pytest tests/test_macos_app.py -q
- swift build
- swift test