### PR TITLE
Repair stale Whisper daemon bootstrap

### DIFF
--- a/agent_cli/daemon/cli.py
+++ b/agent_cli/daemon/cli.py
@@ -7,6 +7,7 @@ Manage agent-cli servers as background daemons:
 
 from __future__ import annotations
 
+import json
 import platform
 from typing import Annotated
 
@@ -17,6 +18,7 @@ from agent_cli.cli import app as main_app
 from agent_cli.core.utils import console, err_console
 from agent_cli.install.service_config import (
     SERVICES,
+    ServiceStatus,
     get_default_services,
     get_service_manager,
 )
@@ -42,6 +44,9 @@ Install, uninstall, and monitor agent-cli servers running as system daemons
 **Examples:**
 
 ```bash
+# Ensure whisper is installed and running
+agent-cli daemon ensure whisper
+
 # Install whisper as a background daemon
 agent-cli daemon install whisper
 
@@ -194,6 +199,110 @@ def _ensure_uv_installed(no_confirm: bool) -> None:
     else:
         console.print(f"  [red]✗[/red] {msg}")
         raise typer.Exit(1)
+
+
+def _service_status_payload(
+    *,
+    service: str,
+    action: str,
+    status: ServiceStatus,
+    message: str,
+) -> dict[str, object]:
+    installed = bool(status.installed)
+    running = bool(status.running)
+    return {
+        "service": service,
+        "action": action,
+        "installed": installed,
+        "running": running,
+        "pid": getattr(status, "pid", None) if running else None,
+        "message": message,
+    }
+
+
+@app.command("ensure")
+def ensure_cmd(
+    service: Annotated[
+        str,
+        typer.Argument(help="Service to ensure is installed and running"),
+    ],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output machine-readable status as JSON"),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress normal success output"),
+    ] = False,
+) -> None:
+    """Ensure one daemon is installed and running.
+
+    This is intended for app integrations that need a single repair command
+    instead of parsing human-oriented `daemon status` output.
+    """
+    if service not in SERVICES:
+        err_console.print(
+            f"[bold red]Error:[/bold red] Unknown service '{service}'. "
+            f"Available: {', '.join(SERVICES.keys())}",
+        )
+        raise typer.Exit(1)
+
+    try:
+        manager = get_service_manager()
+    except RuntimeError as e:
+        err_console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(1) from None
+
+    status = manager.get_service_status(service)
+    if status.installed and status.running:
+        payload = _service_status_payload(
+            service=service,
+            action="already_running",
+            status=status,
+            message="Already running",
+        )
+    else:
+        action = "installed" if not status.installed else "restarted"
+        result = manager.install_service(service)
+        if not result.success:
+            payload = _service_status_payload(
+                service=service,
+                action="failed",
+                status=status,
+                message=result.message,
+            )
+            if json_output:
+                console.print(json.dumps(payload))
+            else:
+                err_console.print(f"[bold red]Error:[/bold red] {service}: {result.message}")
+            raise typer.Exit(1)
+
+        status = manager.get_service_status(service)
+        if not status.installed or not status.running:
+            message = f"{result.message}, but service is not running"
+            payload = _service_status_payload(
+                service=service,
+                action="failed",
+                status=status,
+                message=message,
+            )
+            if json_output:
+                console.print(json.dumps(payload))
+            else:
+                err_console.print(f"[bold red]Error:[/bold red] {service}: {message}")
+            raise typer.Exit(1)
+
+        payload = _service_status_payload(
+            service=service,
+            action=action,
+            status=status,
+            message=result.message,
+        )
+
+    if json_output:
+        console.print(json.dumps(payload))
+    elif not quiet:
+        console.print(f"{service}: {payload['message']}")
 
 
 @app.command("install")

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -147,6 +147,9 @@ agent-cli daemon uninstall whisper
  Examples:
 
 
+  # Ensure whisper is installed and running
+  agent-cli daemon ensure whisper
+
   # Install whisper as a background daemon
   agent-cli daemon install whisper
 
@@ -167,6 +170,7 @@ agent-cli daemon uninstall whisper
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
 │ status      Check status of installed daemons.                                         │
+│ ensure      Ensure one daemon is installed and running.                                │
 │ install     Install server daemons as background processes.                            │
 │ uninstall   Uninstall server daemons.                                                  │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -33,8 +33,7 @@ struct AgentCLIApp: App {
 
             Divider()
 
-            Text("Voice: \(runner.menuStatusMessage)")
-                .lineLimit(1)
+            VoiceStatusMenuItem(runner: runner)
 
             Text(shortcutSummary.summary)
                 .lineLimit(1)

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -29,8 +29,8 @@ final class AgentCommandRunner: ObservableObject {
     @Published private(set) var isRecording = false
     @Published private(set) var bootstrapPhase: BootstrapPhase = .idle
     @Published private var activeCommandCount = 0
-    @Published private var bootstrapAnimationTick = 0
-    @Published private var bootstrapElapsedSeconds = 0
+    private var bootstrapAnimationTick = 0
+    private var bootstrapElapsedSeconds = 0
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
     private let bootstrap: AgentBootstrap

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -12,6 +12,16 @@ private enum AgentCLIRuntimeMode: Equatable {
     }
 }
 
+typealias AgentProcessRunner = (URL, [String], [String: String]) -> CommandResult
+typealias LocalhostConnector = (UInt16) -> Bool
+
+enum WhisperDaemonInstallState {
+    case running
+    case installedButNotRunning
+    case notInstalled
+    case unknown
+}
+
 struct AgentRuntime {
     static let shared = AgentRuntime()
 
@@ -37,6 +47,9 @@ struct AgentRuntime {
     private let fileManager = FileManager.default
     private let baseEnvironment: [String: String]
     private let userDefaults: UserDefaults
+    private let processRunner: AgentProcessRunner
+    private let localhostConnector: LocalhostConnector
+    private let whisperReadyTimeout: TimeInterval
     let appSupportURL: URL
     let bundledUVURL: URL
     let bundledWheelsURL: URL
@@ -56,10 +69,18 @@ struct AgentRuntime {
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         bundle: Bundle = .main,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        processRunner: @escaping AgentProcessRunner = {
+            AgentRuntime.runProcess(executableURL: $0, arguments: $1, environment: $2)
+        },
+        localhostConnector: @escaping LocalhostConnector = AgentRuntime.canConnectToLocalhost,
+        whisperReadyTimeout: TimeInterval = 180
     ) {
         self.baseEnvironment = environment
         self.userDefaults = userDefaults
+        self.processRunner = processRunner
+        self.localhostConnector = localhostConnector
+        self.whisperReadyTimeout = whisperReadyTimeout
 
         if let override = environment["AGENTCLI_APP_SUPPORT_DIR"], !override.isEmpty {
             appSupportURL = URL(fileURLWithPath: override, isDirectory: true)
@@ -201,9 +222,9 @@ struct AgentRuntime {
         }
 
         let installDescription = "uv tool install agent-cli[audio,llm]"
-        let result = Self.runProcess(
-            executableURL: bundledUVURL,
-            arguments: [
+        let result = processRunner(
+            bundledUVURL,
+            [
                 "tool",
                 "install",
                 "--managed-python",
@@ -212,7 +233,7 @@ struct AgentRuntime {
                 "--force",
                 agentCLIInstallRequirement
             ],
-            environment: commandEnvironment()
+            commandEnvironment()
         )
         if result.exitCode != 0, result.output.isEmpty {
             return CommandResult(exitCode: result.exitCode, output: "\(installDescription) failed")
@@ -228,10 +249,10 @@ struct AgentRuntime {
     }
 
     private func ensureUserInstalledCLIAvailable() -> CommandResult {
-        let result = Self.runProcess(
-            executableURL: agentCLIExecutableURL,
-            arguments: agentCLIProcessArguments(["--version"]),
-            environment: commandEnvironment()
+        let result = processRunner(
+            agentCLIExecutableURL,
+            agentCLIProcessArguments(["--version"]),
+            commandEnvironment()
         )
         guard result.exitCode != 127 else {
             return CommandResult(
@@ -292,9 +313,21 @@ struct AgentRuntime {
     ) -> CommandResult {
         if !force, (try? String(contentsOf: whisperDaemonMarkerURL)) == whisperDaemonMarkerContents {
             progress(.waitingForVoiceService)
-            return waitForWhisperDaemonReady()
+            if localhostConnector(10300) {
+                return CommandResult(exitCode: 0, output: "")
+            }
+            switch whisperDaemonInstallState() {
+            case .running, .unknown:
+                return waitForWhisperDaemonReady()
+            case .notInstalled, .installedButNotRunning:
+                return installWhisperDaemon(progress: progress)
+            }
         }
 
+        return installWhisperDaemon(progress: progress)
+    }
+
+    private func installWhisperDaemon(progress: AgentBootstrapProgress) -> CommandResult {
         progress(.installingVoiceService)
         let result = runAgentCLI(arguments: ["daemon", "install", "whisper", "-y"])
         guard result.exitCode == 0 else {
@@ -308,6 +341,33 @@ struct AgentRuntime {
         )
         progress(.waitingForVoiceService)
         return waitForWhisperDaemonReady()
+    }
+
+    private func whisperDaemonInstallState() -> WhisperDaemonInstallState {
+        let result = runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "0"])
+        guard result.exitCode == 0 else {
+            return .unknown
+        }
+        return Self.parseWhisperDaemonInstallState(result.output)
+    }
+
+    static func parseWhisperDaemonInstallState(_ output: String) -> WhisperDaemonInstallState {
+        let lines = output
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        guard let statusLine = lines.first(where: { $0.hasPrefix("whisper:") }) else {
+            return .unknown
+        }
+        if statusLine.contains("not installed") {
+            return .notInstalled
+        }
+        if statusLine.contains("installed but not running") {
+            return .installedButNotRunning
+        }
+        if statusLine.contains("running") {
+            return .running
+        }
+        return .unknown
     }
 
     private var whisperDaemonMarkerContents: String {
@@ -395,10 +455,14 @@ struct AgentRuntime {
         }
     }
 
-    private func waitForWhisperDaemonReady(timeout: TimeInterval = 180) -> CommandResult {
+    private func waitForWhisperDaemonReady() -> CommandResult {
+        waitForWhisperDaemonReady(timeout: whisperReadyTimeout)
+    }
+
+    private func waitForWhisperDaemonReady(timeout: TimeInterval) -> CommandResult {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if Self.canConnectToLocalhost(port: 10300) {
+            if localhostConnector(10300) {
                 return CommandResult(exitCode: 0, output: "")
             }
             Thread.sleep(forTimeInterval: 0.5)
@@ -555,18 +619,18 @@ struct AgentRuntime {
     }
 
     func runShell(_ shell: String) -> CommandResult {
-        Self.runProcess(
-            executableURL: URL(fileURLWithPath: "/bin/zsh"),
-            arguments: ["-lc", shell],
-            environment: commandEnvironment()
+        processRunner(
+            URL(fileURLWithPath: "/bin/zsh"),
+            ["-lc", shell],
+            commandEnvironment()
         )
     }
 
     func runAgentCLI(arguments: [String]) -> CommandResult {
-        Self.runProcess(
-            executableURL: agentCLIExecutableURL,
-            arguments: agentCLIProcessArguments(arguments),
-            environment: commandEnvironment()
+        processRunner(
+            agentCLIExecutableURL,
+            agentCLIProcessArguments(arguments),
+            commandEnvironment()
         )
     }
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -15,13 +15,6 @@ private enum AgentCLIRuntimeMode: Equatable {
 typealias AgentProcessRunner = (URL, [String], [String: String]) -> CommandResult
 typealias LocalhostConnector = (UInt16) -> Bool
 
-enum WhisperDaemonInstallState {
-    case running
-    case installedButNotRunning
-    case notInstalled
-    case unknown
-}
-
 struct AgentRuntime {
     static let shared = AgentRuntime()
 
@@ -316,12 +309,6 @@ struct AgentRuntime {
             if localhostConnector(10300) {
                 return CommandResult(exitCode: 0, output: "")
             }
-            switch whisperDaemonInstallState() {
-            case .running, .unknown:
-                return waitForWhisperDaemonReady()
-            case .notInstalled, .installedButNotRunning:
-                return installWhisperDaemon(progress: progress)
-            }
         }
 
         return installWhisperDaemon(progress: progress)
@@ -329,7 +316,7 @@ struct AgentRuntime {
 
     private func installWhisperDaemon(progress: AgentBootstrapProgress) -> CommandResult {
         progress(.installingVoiceService)
-        let result = runAgentCLI(arguments: ["daemon", "install", "whisper", "-y"])
+        let result = runAgentCLI(arguments: ["daemon", "ensure", "whisper", "--quiet"])
         guard result.exitCode == 0 else {
             return result
         }
@@ -341,33 +328,6 @@ struct AgentRuntime {
         )
         progress(.waitingForVoiceService)
         return waitForWhisperDaemonReady()
-    }
-
-    private func whisperDaemonInstallState() -> WhisperDaemonInstallState {
-        let result = runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "0"])
-        guard result.exitCode == 0 else {
-            return .unknown
-        }
-        return Self.parseWhisperDaemonInstallState(result.output)
-    }
-
-    static func parseWhisperDaemonInstallState(_ output: String) -> WhisperDaemonInstallState {
-        let lines = output
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-        guard let statusLine = lines.first(where: { $0.hasPrefix("whisper:") }) else {
-            return .unknown
-        }
-        if statusLine.contains("not installed") {
-            return .notInstalled
-        }
-        if statusLine.contains("installed but not running") {
-            return .installedButNotRunning
-        }
-        if statusLine.contains("running") {
-            return .running
-        }
-        return .unknown
     }
 
     private var whisperDaemonMarkerContents: String {

--- a/macos/AgentCLI/Sources/AgentCLI/VoiceStatusMenuItem.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceStatusMenuItem.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+struct VoiceStatusMenuItem: View {
+    let runner: AgentCommandRunner
+
+    @State private var statusMessage: String
+    private let statusRefreshTimer = Timer.publish(every: 0.8, on: .main, in: .common).autoconnect()
+
+    init(runner: AgentCommandRunner) {
+        self.runner = runner
+        _statusMessage = State(initialValue: runner.menuStatusMessage)
+    }
+
+    var body: some View {
+        Text("Voice: \(statusMessage)")
+            .lineLimit(1)
+            .onAppear(perform: refreshStatusMessage)
+            .onReceive(statusRefreshTimer) { _ in
+                refreshStatusMessage()
+            }
+    }
+
+    private func refreshStatusMessage() {
+        statusMessage = runner.menuStatusMessage
+    }
+}

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -178,6 +178,7 @@ final class AgentCommandTests: XCTestCase {
             "Warming Whisper model ◒ (00:04)"
         )
     }
+
 }
 
 private struct BootstrapCall: Equatable {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -135,6 +135,95 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(components.filter { $0 == "/usr/bin" }.count, 1)
     }
 
+    func testTranscriptionBootstrapRepairsStaleWhisperDaemonMarker() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentCLITests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let binURL = tempURL.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let agentCLIURL = binURL.appendingPathComponent("agent-cli")
+        _ = FileManager.default.createFile(atPath: agentCLIURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: agentCLIURL.path)
+
+        try """
+        packageSource=agent-cli
+        installRequirement=agent-cli[audio,llm]
+
+        """.write(
+            to: tempURL.appendingPathComponent(".agent-cli-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        runtimeMode=bundled
+        packageSource=agent-cli
+
+        """.write(
+            to: tempURL.appendingPathComponent(".whisper-daemon-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let defaults = UserDefaults(suiteName: "AgentCLITests.stale-whisper-marker")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.stale-whisper-marker")
+        var installedWhisper = false
+        var processArguments: [[String]] = []
+        let runtime = AgentRuntime(
+            environment: ["AGENTCLI_APP_SUPPORT_DIR": tempURL.path],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                processArguments.append(arguments)
+                if arguments == ["daemon", "status", "whisper", "--logs", "0"] {
+                    return CommandResult(exitCode: 0, output: "Service Status\n\n  whisper: not installed")
+                }
+                if arguments == ["daemon", "install", "whisper", "-y"] {
+                    installedWhisper = true
+                    return CommandResult(exitCode: 0, output: "Installed and started")
+                }
+                XCTFail("Unexpected process arguments: \(arguments)")
+                return CommandResult(exitCode: 1, output: "unexpected")
+            },
+            localhostConnector: { port in
+                XCTAssertEqual(port, 10300)
+                return installedWhisper
+            },
+            whisperReadyTimeout: 0.01
+        )
+
+        var phases: [BootstrapPhase] = []
+        let result = runtime.ensureReady(for: .transcription) { phases.append($0) }
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(
+            processArguments,
+            [
+                ["daemon", "status", "whisper", "--logs", "0"],
+                ["daemon", "install", "whisper", "-y"],
+            ]
+        )
+        XCTAssertEqual(phases, [.waitingForVoiceService, .installingVoiceService, .waitingForVoiceService])
+    }
+
+    func testWhisperDaemonStatusParsing() {
+        XCTAssertEqual(
+            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: running (pid 123)"),
+            .running
+        )
+        XCTAssertEqual(
+            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: installed but not running"),
+            .installedButNotRunning
+        )
+        XCTAssertEqual(
+            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: not installed"),
+            .notInstalled
+        )
+        XCTAssertEqual(
+            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  tts: running"),
+            .unknown
+        )
+    }
+
     @MainActor
     func testStartupWarmUpBootstrapsTranscriptionOnce() {
         let recorder = BootstrapRecorder()

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -174,10 +174,7 @@ final class AgentCommandTests: XCTestCase {
             userDefaults: defaults,
             processRunner: { _, arguments, _ in
                 processArguments.append(arguments)
-                if arguments == ["daemon", "status", "whisper", "--logs", "0"] {
-                    return CommandResult(exitCode: 0, output: "Service Status\n\n  whisper: not installed")
-                }
-                if arguments == ["daemon", "install", "whisper", "-y"] {
+                if arguments == ["daemon", "ensure", "whisper", "--quiet"] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
                 }
@@ -198,30 +195,10 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(
             processArguments,
             [
-                ["daemon", "status", "whisper", "--logs", "0"],
-                ["daemon", "install", "whisper", "-y"],
+                ["daemon", "ensure", "whisper", "--quiet"],
             ]
         )
         XCTAssertEqual(phases, [.waitingForVoiceService, .installingVoiceService, .waitingForVoiceService])
-    }
-
-    func testWhisperDaemonStatusParsing() {
-        XCTAssertEqual(
-            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: running (pid 123)"),
-            .running
-        )
-        XCTAssertEqual(
-            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: installed but not running"),
-            .installedButNotRunning
-        )
-        XCTAssertEqual(
-            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  whisper: not installed"),
-            .notInstalled
-        )
-        XCTAssertEqual(
-            AgentRuntime.parseWhisperDaemonInstallState("Service Status\n\n  tts: running"),
-            .unknown
-        )
     }
 
     @MainActor

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -464,6 +465,123 @@ class TestDaemonCLI:
         assert result.exit_code == 0
         # Should install default services (one TTS backend auto-selected)
         assert mock_manager.install_service.call_count == len(get_default_services())
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_ensure_running_skips_install(self, mock_get_manager: MagicMock) -> None:
+        """Ensure should be a no-op when the service is already running."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.get_service_status.return_value = ServiceStatus(
+            name="whisper",
+            installed=True,
+            running=True,
+            pid=12345,
+        )
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(app, ["daemon", "ensure", "whisper", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "service": "whisper",
+            "action": "already_running",
+            "installed": True,
+            "running": True,
+            "pid": 12345,
+            "message": "Already running",
+        }
+        mock_manager.install_service.assert_not_called()
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_ensure_installs_missing_service(self, mock_get_manager: MagicMock) -> None:
+        """Ensure should install a missing service without parsing status output."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.get_service_status.side_effect = [
+            ServiceStatus(name="whisper", installed=False, running=False),
+            ServiceStatus(name="whisper", installed=True, running=True, pid=12345),
+        ]
+        mock_manager.install_service.return_value = InstallResult(
+            success=True,
+            message="Installed and started",
+        )
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(app, ["daemon", "ensure", "whisper", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "service": "whisper",
+            "action": "installed",
+            "installed": True,
+            "running": True,
+            "pid": 12345,
+            "message": "Installed and started",
+        }
+        mock_manager.install_service.assert_called_once_with("whisper")
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_ensure_reinstalls_stopped_service(self, mock_get_manager: MagicMock) -> None:
+        """Ensure should repair an installed launchd/systemd service that is stopped."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.get_service_status.side_effect = [
+            ServiceStatus(name="whisper", installed=True, running=False),
+            ServiceStatus(name="whisper", installed=True, running=True, pid=12345),
+        ]
+        mock_manager.install_service.return_value = InstallResult(
+            success=True,
+            message="Installed and started",
+        )
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(app, ["daemon", "ensure", "whisper", "--quiet"])
+
+        assert result.exit_code == 0
+        assert result.stdout == ""
+        mock_manager.install_service.assert_called_once_with("whisper")
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_ensure_fails_when_service_stays_stopped(
+        self,
+        mock_get_manager: MagicMock,
+    ) -> None:
+        """Ensure should fail if repair does not leave the service running."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.get_service_status.side_effect = [
+            ServiceStatus(name="whisper", installed=True, running=False),
+            ServiceStatus(name="whisper", installed=True, running=False),
+        ]
+        mock_manager.install_service.return_value = InstallResult(
+            success=True,
+            message="Installed and started",
+        )
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(app, ["daemon", "ensure", "whisper", "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "service": "whisper",
+            "action": "failed",
+            "installed": True,
+            "running": False,
+            "pid": None,
+            "message": "Installed and started, but service is not running",
+        }
+        mock_manager.install_service.assert_called_once_with("whisper")
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_ensure_unknown_service(self, mock_get_manager: MagicMock) -> None:
+        """Ensure should reject unknown services before consulting the manager."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(app, ["daemon", "ensure", "unknown"])
+
+        assert result.exit_code == 1
+        assert "Unknown service" in result.output
+        mock_manager.get_service_status.assert_not_called()
 
     @patch("agent_cli.daemon.cli.get_service_manager")
     def test_daemon_uninstall_no_args(self, mock_get_manager: MagicMock) -> None:

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -149,8 +149,7 @@ def test_macos_app_source_exposes_expected_agent_cli_actions() -> None:
     assert "transcribe --toggle --llm --quiet" not in source
     assert 'arguments: ["voice-edit", "--toggle", "--quiet"]' in source
     assert 'arguments: ["autocorrect", "--quiet"]' in source
-    assert 'arguments: ["daemon", "status", "whisper", "--logs", "0"]' in source
-    assert 'arguments: ["daemon", "install", "whisper", "-y"]' in source
+    assert 'arguments: ["daemon", "ensure", "whisper", "--quiet"]' in source
     assert "let shell: String" not in source
     assert "command.shell" not in source
     assert "install-hotkeys" not in source
@@ -1177,7 +1176,7 @@ def test_macos_app_bootstraps_private_uv_runtime() -> None:
     assert "whisperDaemonMarkerURL" in source
     assert "whisperDaemonMarkerContents" in source
     assert "packageSource=" in source
-    assert 'runAgentCLI(arguments: ["daemon", "install", "whisper", "-y"])' in source
+    assert 'runAgentCLI(arguments: ["daemon", "ensure", "whisper", "--quiet"])' in source
     assert "--agentcli-bootstrap-self-test" in source
 
 
@@ -1193,9 +1192,8 @@ def test_macos_app_waits_for_whisper_daemon_readiness() -> None:
     assert "connect(socketFD" in source
     assert 'runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "80"])' in source
     assert "Whisper ASR service did not become ready at localhost:10300" in source
-    assert 'runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "0"])' in source
-    assert "parseWhisperDaemonInstallState" in source
-    assert "case .notInstalled, .installedButNotRunning:" in source
+    assert 'runAgentCLI(arguments: ["daemon", "ensure", "whisper", "--quiet"])' in source
+    assert "parseWhisperDaemonInstallState" not in source
 
 
 def test_macos_app_has_end_to_end_packaging_test() -> None:

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -1187,12 +1187,15 @@ def test_macos_app_waits_for_whisper_daemon_readiness() -> None:
 
     assert "waitForWhisperDaemonReady()" in source
     assert "return waitForWhisperDaemonReady()" in source
-    assert "canConnectToLocalhost(port: 10300)" in source
+    assert "localhostConnector(10300)" in source
     assert "Thread.sleep(forTimeInterval: 0.5)" in source
     assert "socket(AF_INET, SOCK_STREAM, 0)" in source
     assert "connect(socketFD" in source
     assert 'runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "80"])' in source
     assert "Whisper ASR service did not become ready at localhost:10300" in source
+    assert 'runAgentCLI(arguments: ["daemon", "status", "whisper", "--logs", "0"])' in source
+    assert "parseWhisperDaemonInstallState" in source
+    assert "case .notInstalled, .installedButNotRunning:" in source
 
 
 def test_macos_app_has_end_to_end_packaging_test() -> None:

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -73,6 +73,7 @@ def test_macos_app_package_files_exist() -> None:
         "RecordingIndicatorController.swift",
         "Shortcuts.swift",
         "TranscriptPasteController.swift",
+        "VoiceStatusMenuItem.swift",
         "VoiceLevelOverlay.swift",
     ):
         assert (SWIFT_SOURCE_DIR / filename).is_file()
@@ -230,7 +231,7 @@ def test_macos_app_menu_prioritizes_daily_voice_actions() -> None:
     assert record_index < voice_edit_index < autocorrect_index < troubleshooting_menu_index
     assert troubleshooting_menu_index < copy_output_index < troubleshooting_label_index
     assert 'Menu("Setup")' not in source
-    assert 'Text("Voice: \\(runner.menuStatusMessage)")' in source
+    assert "VoiceStatusMenuItem(runner: runner)" in source
     assert "var menuBarIconState: MenuBarIconState" in source
     assert "AgentCLIMenuBarIcon(state: runner.menuBarIconState)" in source
     assert "var menuStatusMessage: String" in source
@@ -568,6 +569,21 @@ def test_macos_app_animates_all_preparing_statuses_with_fixed_width_timer() -> N
     assert "bootstrapPhase.statusMessage(" in source
     assert "animationTick: bootstrapAnimationTick" in source
     assert "elapsedSeconds: bootstrapElapsedSeconds" in source
+
+
+def test_macos_app_updates_bootstrap_status_without_rebuilding_menu_tree() -> None:
+    """Bootstrap animation should keep updating without refreshing the whole menu."""
+    source = swift_source()
+
+    assert "VoiceStatusMenuItem(runner: runner)" in source
+    assert 'Text("Voice: \\(runner.menuStatusMessage)")' not in source
+    assert "struct VoiceStatusMenuItem: View" in source
+    assert 'Text("Voice: \\(statusMessage)")' in source
+    assert ".onReceive(statusRefreshTimer)" in source
+    assert "@Published private var bootstrapAnimationTick" not in source
+    assert "@Published private var bootstrapElapsedSeconds" not in source
+    assert "private var bootstrapAnimationTick = 0" in source
+    assert "private var bootstrapElapsedSeconds = 0" in source
 
 
 def test_macos_app_shows_preparing_menu_bar_icon_state() -> None:


### PR DESCRIPTION
## Summary
- Add `agent-cli daemon ensure <service>` as the daemon-layer repair command for app integrations.
- Have the macOS app call `daemon ensure whisper --quiet` instead of parsing human-oriented `daemon status` output.
- Cover missing, stopped, already-running, failed-repair, and unknown-service daemon ensure paths.

## Test Plan
- [x] `swift build --package-path macos/AgentCLI`
- [x] `uv run --all-extras pytest`
- [x] `pre-commit run --all-files`
- [x] `git diff --check`

## Notes
- Targeted XCTest builds but cannot run in this local environment because the active developer directory is Command Line Tools and `xcrun --sdk macosx --show-sdk-platform-path` fails with `unable to lookup item 'PlatformPath'`.
