### PR TITLE
Add Sparkle updater to macOS app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,34 +58,76 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APP_VERSION: ${{ github.event.release.tag_name }}
           BUILD_VERSION: ${{ github.run_number }}
-        run: NOTARIZE=1 macos/build-macos-app.sh --dmg
+          SPARKLE_PUBLIC_ED_KEY: ${{ vars.SPARKLE_PUBLIC_ED_KEY }}
+        run: |
+          if [[ -z "$SPARKLE_PUBLIC_ED_KEY" ]]; then
+            echo "SPARKLE_PUBLIC_ED_KEY repository variable is required to enable Sparkle updates." >&2
+            exit 1
+          fi
+          NOTARIZE=1 macos/build-macos-app.sh --dmg
+          ditto -c -k --keepParent dist/macos/AgentCLI.app dist/macos/AgentCLI.zip
       - name: Upload macOS app to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG_NAME" dist/macos/AgentCLI.dmg --clobber
-      - name: Update Homebrew cask
+        run: gh release upload "$TAG_NAME" dist/macos/AgentCLI.dmg dist/macos/AgentCLI.zip --clobber
+      - name: Update Sparkle appcast
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+        run: |
+          git fetch origin main
+          git switch --force-create release-metadata origin/main
+
+          if [[ -z "$SPARKLE_PRIVATE_ED_KEY" ]]; then
+            echo "SPARKLE_PRIVATE_ED_KEY is required to sign Sparkle updates." >&2
+            exit 1
+          fi
+
+          SPARKLE_GENERATE_APPCAST="macos/AgentCLI/.build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+          if [[ ! -x "$SPARKLE_GENERATE_APPCAST" ]]; then
+            echo "Sparkle generate_appcast not found: $SPARKLE_GENERATE_APPCAST" >&2
+            exit 1
+          fi
+
+          APPCAST_DIR="$RUNNER_TEMP/agentcli-appcast"
+          rm -rf "$APPCAST_DIR"
+          mkdir -p "$APPCAST_DIR"
+          cp dist/macos/AgentCLI.zip "$APPCAST_DIR/AgentCLI.zip"
+          cp macos/appcast.xml "$APPCAST_DIR/appcast.xml"
+          gh release view "$TAG_NAME" --json body --jq .body >"$APPCAST_DIR/AgentCLI.md"
+
+          printf '%s' "$SPARKLE_PRIVATE_ED_KEY" |
+            "$SPARKLE_GENERATE_APPCAST" \
+              --ed-key-file - \
+              --download-url-prefix "https://github.com/basnijholt/agent-cli/releases/download/${TAG_NAME}/" \
+              --link "https://github.com/basnijholt/agent-cli" \
+              --embed-release-notes \
+              --maximum-versions 10 \
+              -o "$APPCAST_DIR/appcast.xml" \
+              "$APPCAST_DIR"
+
+          cp "$APPCAST_DIR/appcast.xml" macos/appcast.xml
+      - name: Update Homebrew cask and Sparkle appcast
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           VERSION="${TAG_NAME#v}"
           SHA256=$(shasum -a 256 dist/macos/AgentCLI.dmg | awk '{ print $1 }')
 
-          git fetch origin main
-          git switch --force-create cask-update origin/main
-
           python3 .github/scripts/update_cask.py \
             --version "$VERSION" \
             --sha256 "$SHA256"
 
-          if git diff --quiet -- Casks/agent-cli.rb; then
-            echo "Casks/agent-cli.rb is already up to date."
+          if git diff --quiet -- Casks/agent-cli.rb macos/appcast.xml; then
+            echo "Casks/agent-cli.rb and macos/appcast.xml are already up to date."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/agent-cli.rb
-          git commit -m "Update AgentCLI cask to ${TAG_NAME}"
+          git add Casks/agent-cli.rb macos/appcast.xml
+          git commit -m "Update AgentCLI release metadata to ${TAG_NAME}"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/macos/AgentCLI/Package.resolved
+++ b/macos/AgentCLI/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "70caa8dea43e2d273cd5ab78885d7eff01df550c",
         "version" : "1.10.0"
       }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
     }
   ],
   "version" : 2

--- a/macos/AgentCLI/Package.swift
+++ b/macos/AgentCLI/Package.swift
@@ -12,12 +12,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", exact: "1.10.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2"),
     ],
     targets: [
         .executableTarget(
             name: "AgentCLI",
             dependencies: [
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
+                .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/AgentCLI"
         ),

--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -30,6 +30,12 @@ clipboard utility shortcuts still use `KeyboardShortcuts` global handlers. The
 login option uses Apple's login item API for the main app bundle, so macOS may
 require approval in System Settings → General → Login Items.
 
+The app uses Sparkle for direct app updates. Release builds stamp
+`SUPublicEDKey` into `Info.plist`, publish signed updates in `macos/appcast.xml`,
+upload `AgentCLI.zip` for Sparkle, and expose **Check for Updates...** from the
+menu bar and Settings. Local builds without a Sparkle public key still run, but
+update checks are disabled.
+
 ## Build
 
 From the repository root:
@@ -86,6 +92,7 @@ NOTARIZE=1 \
 APPLE_ID="you@example.com" \
 APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx" \
 APPLE_TEAM_ID="TEAMID" \
+SPARKLE_PUBLIC_ED_KEY="public-ed25519-key" \
 ./macos/build-macos-app.sh --dmg
 ```
 
@@ -103,3 +110,8 @@ workflow expects these repository secrets:
 - `APPLE_ID`: Apple ID email for notarization
 - `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for `notarytool`
 - `APPLE_TEAM_ID`: Apple Developer Team ID
+- `SPARKLE_PRIVATE_ED_KEY`: private Sparkle EdDSA key for signing updates
+
+The workflow also expects the repository variable `SPARKLE_PUBLIC_ED_KEY`.
+Generate the key pair with Sparkle's `generate_keys` tool and store only the
+private key as a GitHub secret.

--- a/macos/AgentCLI/Resources/Info.plist
+++ b/macos/AgentCLI/Resources/Info.plist
@@ -28,5 +28,9 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Agent CLI uses microphone access when you start transcription or voice editing from the menu bar.</string>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/basnijholt/agent-cli/main/macos/appcast.xml</string>
 </dict>
 </plist>

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -6,6 +6,7 @@ struct AgentCLIApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @Environment(\.openWindow) private var openWindow
     @StateObject private var runner = AgentCommandRunner.shared
+    @StateObject private var appUpdater = AppUpdater.shared
     @StateObject private var loginItemController = LoginItemController.shared
     @StateObject private var shortcutSummary = ShortcutSummaryState.shared
     @AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)
@@ -75,6 +76,13 @@ struct AgentCLIApp: App {
             } label: {
                 Label("Settings...", systemImage: "gearshape")
             }
+
+            Button {
+                appUpdater.checkForUpdates()
+            } label: {
+                Label("Check for Updates...", systemImage: "arrow.down.circle")
+            }
+            .disabled(!appUpdater.canCheckForUpdates)
 
             Menu {
                 Button {

--- a/macos/AgentCLI/Sources/AgentCLI/AppMetadata.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppMetadata.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+struct SparkleConfiguration: Equatable {
+    let feedURL: String
+    let publicEDKey: String
+
+    var isConfigured: Bool {
+        !feedURL.isEmpty && !publicEDKey.isEmpty
+    }
+}
+
+enum AppMetadata {
+    static var versionDisplayString: String {
+        versionDisplayString(infoDictionary: Bundle.main.infoDictionary ?? [:])
+    }
+
+    static var sparkleConfiguration: SparkleConfiguration {
+        sparkleConfiguration(infoDictionary: Bundle.main.infoDictionary ?? [:])
+    }
+
+    static func versionDisplayString(infoDictionary: [String: Any]) -> String {
+        let shortVersion = stringValue(
+            infoDictionary["CFBundleShortVersionString"],
+            fallback: "Unknown"
+        )
+        let buildVersion = stringValue(infoDictionary["CFBundleVersion"])
+
+        guard !buildVersion.isEmpty, buildVersion != shortVersion else {
+            return shortVersion
+        }
+        return "\(shortVersion) (\(buildVersion))"
+    }
+
+    static func sparkleConfiguration(infoDictionary: [String: Any]) -> SparkleConfiguration {
+        SparkleConfiguration(
+            feedURL: stringValue(infoDictionary["SUFeedURL"]),
+            publicEDKey: stringValue(infoDictionary["SUPublicEDKey"])
+        )
+    }
+
+    private static func stringValue(_ value: Any?, fallback: String = "") -> String {
+        guard let string = value as? String else { return fallback }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+}

--- a/macos/AgentCLI/Sources/AgentCLI/AppUpdater.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppUpdater.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Sparkle
+
+@MainActor
+final class AppUpdater: ObservableObject {
+    static let shared = AppUpdater()
+
+    private let updaterController: SPUStandardUpdaterController?
+
+    var canCheckForUpdates: Bool {
+        updaterController != nil
+    }
+
+    private init(configuration: SparkleConfiguration = AppMetadata.sparkleConfiguration) {
+        guard configuration.isConfigured else {
+            updaterController = nil
+            return
+        }
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    func checkForUpdates() {
+        guard let updaterController else {
+            AgentCommandRunner.shared.statusMessage = "App updates are not configured for this build"
+            return
+        }
+        updaterController.checkForUpdates(nil)
+    }
+}

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -276,6 +276,7 @@ enum ShortcutDefaultsMigrator {
 
 struct SettingsView: View {
     @ObservedObject private var loginItemController = LoginItemController.shared
+    @ObservedObject private var appUpdater = AppUpdater.shared
     @AppStorage(RuntimeSettings.useUserInstalledAgentCLIKey)
     private var useUserInstalledAgentCLI = false
     @AppStorage(RecordingSoundSettings.enabledKey)
@@ -319,6 +320,28 @@ struct SettingsView: View {
                 Text("Transcription Instructions")
             } footer: {
                 Text("Names, vocabulary, and guidance to pass as initial transcription context.")
+            }
+
+            Section {
+                HStack {
+                    Text("Version")
+                    Spacer()
+                    Text(AppMetadata.versionDisplayString)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button("Check for Updates...") {
+                    appUpdater.checkForUpdates()
+                }
+                .disabled(!appUpdater.canCheckForUpdates)
+            } header: {
+                Text("Updates")
+            } footer: {
+                Text(
+                    appUpdater.canCheckForUpdates
+                        ? "Uses Sparkle to install signed Agent CLI app updates."
+                        : "App updates are not configured for this build."
+                )
             }
 
             Section {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -201,6 +201,41 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(phases, [.waitingForVoiceService, .installingVoiceService, .waitingForVoiceService])
     }
 
+    func testAppVersionDisplayIncludesShortVersionAndBuild() {
+        XCTAssertEqual(
+            AppMetadata.versionDisplayString(infoDictionary: [
+                "CFBundleShortVersionString": "0.95.9",
+                "CFBundleVersion": "528",
+            ]),
+            "0.95.9 (528)"
+        )
+    }
+
+    func testAppVersionDisplayOmitsDuplicateBuildVersion() {
+        XCTAssertEqual(
+            AppMetadata.versionDisplayString(infoDictionary: [
+                "CFBundleShortVersionString": "0.95.9",
+                "CFBundleVersion": "0.95.9",
+            ]),
+            "0.95.9"
+        )
+    }
+
+    func testSparkleConfigurationRequiresFeedURLAndPublicKey() {
+        XCTAssertFalse(AppMetadata.sparkleConfiguration(infoDictionary: [:]).isConfigured)
+        XCTAssertFalse(
+            AppMetadata.sparkleConfiguration(infoDictionary: [
+                "SUFeedURL": "https://raw.githubusercontent.com/basnijholt/agent-cli/main/macos/appcast.xml",
+            ]).isConfigured
+        )
+        XCTAssertTrue(
+            AppMetadata.sparkleConfiguration(infoDictionary: [
+                "SUFeedURL": "https://raw.githubusercontent.com/basnijholt/agent-cli/main/macos/appcast.xml",
+                "SUPublicEDKey": "base64-public-key",
+            ]).isConfigured
+        )
+    }
+
     @MainActor
     func testStartupWarmUpBootstrapsTranscriptionOnce() {
         let recorder = BootstrapRecorder()

--- a/macos/appcast.xml
+++ b/macos/appcast.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Agent CLI Updates</title>
+    <link>https://github.com/basnijholt/agent-cli</link>
+    <description>Signed Agent CLI macOS app updates.</description>
+  </channel>
+</rss>

--- a/macos/build-macos-app.sh
+++ b/macos/build-macos-app.sh
@@ -24,6 +24,9 @@ Environment:
                      Defaults to the built wheel version.
   BUILD_VERSION      CFBundleVersion to stamp into the app. Defaults to
                      GITHUB_RUN_NUMBER, then the git commit count.
+  SPARKLE_PUBLIC_ED_KEY
+                     Public EdDSA key for Sparkle updates. If unset, the app
+                     builds without enabling Sparkle update checks.
   UV_BINARY          uv binary to bundle. Defaults to the uv found on PATH.
   INSTALL_DIR        Install destination. Defaults to /Applications.
   AGENTCLI_SKIP_OPEN Set to 1 to skip opening the app after --install.
@@ -85,6 +88,7 @@ INSTALL_DIR=${INSTALL_DIR:-/Applications}
 NOTARIZE=${NOTARIZE:-0}
 NOTARY_TIMEOUT_SECONDS=${NOTARY_TIMEOUT_SECONDS:-1800}
 NOTARY_POLL_INTERVAL_SECONDS=${NOTARY_POLL_INTERVAL_SECONDS:-30}
+SPARKLE_PUBLIC_ED_KEY=${SPARKLE_PUBLIC_ED_KEY:-}
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "This script builds a macOS .app bundle and must run on macOS." >&2
@@ -223,6 +227,12 @@ stamp_info_plist() {
         "$APP_DIR/Contents/Info.plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_version" \
         "$APP_DIR/Contents/Info.plist"
+    if [[ -n "$SPARKLE_PUBLIC_ED_KEY" ]]; then
+        /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" \
+            "$APP_DIR/Contents/Info.plist" >/dev/null 2>&1 || true
+        /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $SPARKLE_PUBLIC_ED_KEY" \
+            "$APP_DIR/Contents/Info.plist"
+    fi
     echo "Stamped app bundle version $app_version ($build_version)"
 }
 
@@ -413,6 +423,8 @@ APPLESCRIPT
 create_drag_install_dmg() {
     local dmg_path="$1"
     local attach_output
+    local image_size_mb
+    local staging_size_kb
     local volume_path
 
     hdiutil detach "/Volumes/$DISPLAY_NAME" >/dev/null 2>&1 || true
@@ -424,11 +436,13 @@ create_drag_install_dmg() {
     render_dmg_background || return
     cp "$DMG_BACKGROUND_PNG" "$DMG_STAGING_DIR/.background/dmg-background.png" || return
 
+    staging_size_kb=$(du -sk "$DMG_STAGING_DIR" | awk '{ print $1 }')
+    image_size_mb=$((staging_size_kb / 1024 + 64))
     hdiutil create "$DMG_RW_PATH" \
         -volname "$DISPLAY_NAME" \
-        -srcfolder "$DMG_STAGING_DIR" \
-        -ov \
-        -format UDRW || return
+        -size "${image_size_mb}m" \
+        -fs HFS+ \
+        -ov || return
     attach_output=$(hdiutil attach "$DMG_RW_PATH" \
         -nobrowse \
         -noautoopen) || return
@@ -438,11 +452,15 @@ create_drag_install_dmg() {
         printf '%s\n' "$attach_output" >&2
         return 1
     fi
-    if ! set_dmg_finder_layout "$volume_path"; then
+    ditto "$DMG_STAGING_DIR" "$volume_path" || {
         hdiutil detach "$volume_path" >/dev/null 2>&1 || true
         return 1
+    }
+    if ! set_dmg_finder_layout "$volume_path"; then
+        hdiutil detach "$volume_path" -force >/dev/null 2>&1 || true
+        return 1
     fi
-    hdiutil detach "$volume_path" >/dev/null || return
+    hdiutil detach "$volume_path" -force >/dev/null || return
     hdiutil convert "$DMG_RW_PATH" \
         -format UDZO \
         -imagekey zlib-level=9 \
@@ -501,11 +519,19 @@ build_app_icon
 rm -rf "$APP_DIR"
 mkdir -p \
     "$APP_DIR/Contents/MacOS" \
+    "$APP_DIR/Contents/Frameworks" \
     "$APP_DIR/Contents/Resources/bin" \
     "$APP_DIR/Contents/Resources/wheels"
 
+SPARKLE_FRAMEWORK="$BIN_DIR/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FRAMEWORK" ]]; then
+    echo "Built Sparkle framework not found: $SPARKLE_FRAMEWORK" >&2
+    exit 1
+fi
+
 cp "$BINARY" "$APP_DIR/Contents/MacOS/$APP_NAME"
 cp "$INFO_PLIST" "$APP_DIR/Contents/Info.plist"
+ditto "$SPARKLE_FRAMEWORK" "$APP_DIR/Contents/Frameworks/Sparkle.framework"
 cp "$UV_BINARY" "$APP_DIR/Contents/Resources/bin/uv"
 cp "$WHEEL_PATH" "$APP_DIR/Contents/Resources/wheels/"
 cp "$MENU_BAR_LOGO_SVG" "$APP_DIR/Contents/Resources/logo-avatar.svg"
@@ -513,9 +539,19 @@ cp "$NOTIFICATION_LOGO_PNG" "$APP_DIR/Contents/Resources/logo-avatar.png"
 cp "$APP_ICON_ICNS" "$APP_DIR/Contents/Resources/AgentCLI.icns"
 chmod 755 "$APP_DIR/Contents/MacOS/$APP_NAME"
 chmod 755 "$APP_DIR/Contents/Resources/bin/uv"
+if ! otool -l "$APP_DIR/Contents/MacOS/$APP_NAME" |
+    grep -q '@executable_path/../Frameworks'; then
+    install_name_tool -add_rpath "@executable_path/../Frameworks" \
+        "$APP_DIR/Contents/MacOS/$APP_NAME"
+fi
 
 test -x "$APP_DIR/Contents/Resources/bin/uv" || {
     echo "Bundled uv is missing or not executable: $APP_DIR/Contents/Resources/bin/uv" >&2
+    exit 1
+}
+
+test -d "$APP_DIR/Contents/Frameworks/Sparkle.framework" || {
+    echo "Bundled Sparkle framework is missing: $APP_DIR/Contents/Frameworks/Sparkle.framework" >&2
     exit 1
 }
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -1107,10 +1107,12 @@ def test_macos_build_script_creates_drag_install_dmg() -> None:
     assert 'ln -s /Applications "$DMG_STAGING_DIR/Applications"' in script
     assert '"$DMG_STAGING_DIR/$APP_NAME.app"' in script
     assert 'hdiutil create "$DMG_RW_PATH"' in script
-    assert "-format UDRW" in script
+    assert '-size "${image_size_mb}m"' in script
+    assert "-fs HFS+" in script
     assert "hdiutil attach" in script
     assert "-mountpoint" not in script
     assert "volume_path=$(printf" in script
+    assert 'ditto "$DMG_STAGING_DIR" "$volume_path"' in script
     assert (
         'set background picture of theViewOptions to file ".background:dmg-background.png"'
         in script


### PR DESCRIPTION
## Summary
- Add Sparkle to the native macOS app and expose **Check for Updates...** in the menu bar and Settings.
- Show the current app version in Settings.
- Bundle Sparkle.framework in the custom app builder and stamp `SUPublicEDKey` from release builds.
- Publish `AgentCLI.zip` for Sparkle updates and update `macos/appcast.xml` from release CI while keeping the Homebrew DMG/cask flow.
- Rework DMG assembly to avoid `hdiutil create -srcfolder` failures with bundled frameworks.

## Release setup required
- Add repository variable `SPARKLE_PUBLIC_ED_KEY`.
- Add repository secret `SPARKLE_PRIVATE_ED_KEY`.
- Generate both with Sparkle's `generate_keys` tool; only the private key should be secret.

## Verification
- `swift build --package-path macos/AgentCLI`
- `swift test --package-path macos/AgentCLI`
- `SPARKLE_PUBLIC_ED_KEY=dummy-public-key AGENTCLI_SKIP_OPEN=1 ./macos/build-macos-app.sh --dmg`
- `codesign --verify --deep --strict --verbose=2 dist/macos/AgentCLI.app`
- `dist/macos/AgentCLI.app/Contents/MacOS/AgentCLI --agentcli-self-test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml parsed"'`
- `xmllint --noout macos/appcast.xml`
- Sparkle `generate_appcast` dry run against local `AgentCLI.zip`
