### PR TITLE
Fix macOS settings lifecycle and live status timer

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCLIApp.swift
@@ -6,10 +6,8 @@ struct AgentCLIApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
-        Window("Agent CLI Settings", id: "settings") {
-            SettingsView()
-                .frame(width: 460)
+        Settings {
+            EmptyView()
         }
-        .windowResizability(.contentSize)
     }
 }

--- a/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
@@ -27,6 +27,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         releaseInstanceLock()
     }
 
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
     private func terminateIfAnotherInstanceIsRunning() -> Bool {
         let lockURL = Self.instanceLockURL()
         instanceLockFD = Darwin.open(lockURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)

--- a/macos/AgentCLI/Sources/AgentCLI/SettingsWindowController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/SettingsWindowController.swift
@@ -11,11 +11,13 @@ final class SettingsWindowController {
 
     func show() {
         if window == nil {
-            let controller = NSHostingController(rootView: SettingsView().frame(width: 460))
+            let contentSize = NSSize(width: 460, height: 640)
+            let controller = NSHostingController(rootView: SettingsView().frame(width: contentSize.width))
             let window = NSWindow(contentViewController: controller)
             window.title = "Agent CLI Settings"
             window.styleMask = [.titled, .closable]
             window.isReleasedWhenClosed = false
+            window.setContentSize(contentSize)
             window.center()
             self.window = window
         }

--- a/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
@@ -200,6 +200,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             }
         }
         RunLoop.main.add(timer, forMode: .common)
+        RunLoop.main.add(timer, forMode: .eventTracking)
         statusRefreshTimer = timer
     }
 

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -84,6 +84,26 @@ def test_macos_app_package_files_exist() -> None:
     assert MENU_BAR_LOGO_SVG.is_file()
 
 
+def test_macos_app_settings_window_does_not_own_app_lifecycle() -> None:
+    """The menu bar app should not auto-open or quit with the settings window."""
+    app_source = read_swift_source_file(SWIFT_SOURCE_DIR / "AgentCLIApp.swift")
+    delegate_source = read_swift_source_file(SWIFT_SOURCE_DIR / "AppDelegate.swift")
+    settings_window_source = read_swift_source_file(
+        SWIFT_SOURCE_DIR / "SettingsWindowController.swift"
+    )
+
+    assert 'Window("Agent CLI Settings"' not in app_source
+    assert "SettingsView()" not in app_source
+    assert "Settings {" in app_source
+    assert "EmptyView()" in app_source
+    assert "applicationShouldTerminateAfterLastWindowClosed" in delegate_source
+    assert "return false" in delegate_source
+    assert "NSHostingController(rootView: SettingsView()" in settings_window_source
+    assert "let contentSize = NSSize(width: 460, height: 640)" in settings_window_source
+    assert "window.setContentSize(contentSize)" in settings_window_source
+    assert "window.isReleasedWhenClosed = false" in settings_window_source
+
+
 def test_macos_app_depends_on_keyboardshortcuts_package() -> None:
     """KeyboardShortcuts README documents SPM install from this URL."""
     package = (MACOS_APP / "Package.swift").read_text(encoding="utf-8")
@@ -596,6 +616,7 @@ def test_macos_app_updates_bootstrap_status_without_rebuilding_menu_tree() -> No
     assert "private func startStatusRefreshTimer()" in source
     assert "Timer(timeInterval: 0.8, repeats: true)" in source
     assert "RunLoop.main.add(timer, forMode: .common)" in source
+    assert "RunLoop.main.add(timer, forMode: .eventTracking)" in source
     assert "self?.refreshDynamicStatus()" in source
     assert 'voiceStatusItem?.title = "Voice: \\(runner.menuStatusMessage)"' in source
     assert (


### PR DESCRIPTION
## Summary
- stop declaring the settings UI as a SwiftUI launch window so the menu bar app does not auto-open settings or quit when that window closes
- keep the AppKit settings window as the single settings entry point and give it an explicit content size
- run the live menu status refresh timer in event-tracking mode so the preparation counter can update while the menu is open

## Verification
- uv run pytest -q tests/test_macos_app.py
- swift build --package-path macos/AgentCLI
- uv run pre-commit run --all-files

## Notes
- Local `swift test --package-path macos/AgentCLI --enable-xctest --filter AgentCommandTests/testMenuStatusComputesElapsedPreparationTimeWhenRead` built and linked, then failed because this Command Line Tools install cannot resolve XCTest PlatformPath. CI should run XCTest on a full runner.
- Local bare `uv run pytest -q` fails during collection because this env lacks optional extras (`numpy`, `wyoming`, `fastapi`, `torch`, `watchfiles`). The macOS-targeted tests pass.