### PR TITLE
Make voice level overlay frequency aware

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
@@ -93,16 +93,15 @@ final class VoiceLevelMeter: NSObject, ObservableObject {
 
     private static let barCount = 16
     private static let idleAmplitudes = Array(repeating: CGFloat(0.16), count: barCount)
-    private let minimumPower: Float = -55
-    private var recorder: AVAudioRecorder?
-    private var timer: Timer?
-    private var phase = 0.0
-    private var smoothedLevel = CGFloat(0.16)
+    private static let minimumDisplayAmplitude = CGFloat(0.12)
+    private var engine: AVAudioEngine?
+    private var analyzer: VoiceSpectrumAnalyzer?
+    private var smoothedAmplitudes = VoiceLevelMeter.idleAmplitudes
 
     private override init() {}
 
     func start() {
-        guard recorder == nil else { return }
+        guard engine == nil else { return }
 
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
@@ -123,58 +122,88 @@ final class VoiceLevelMeter: NSObject, ObservableObject {
     }
 
     func stop() {
-        timer?.invalidate()
-        timer = nil
-        recorder?.stop()
-        recorder = nil
-        smoothedLevel = 0.16
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
+        engine = nil
+        analyzer = nil
+        smoothedAmplitudes = Self.idleAmplitudes
         amplitudes = Self.idleAmplitudes
     }
 
     private func startMetering() {
-        smoothedLevel = 0.16
-        let url = URL(fileURLWithPath: "/dev/null")
-        let settings: [String: Any] = [
-            AVFormatIDKey: Int(kAudioFormatAppleLossless),
-            AVSampleRateKey: 44_100,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.min.rawValue
-        ]
+        smoothedAmplitudes = Self.idleAmplitudes
+        let engine = AVAudioEngine()
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            amplitudes = Self.idleAmplitudes
+            return
+        }
+        let analyzer = VoiceSpectrumAnalyzer(
+            sampleRate: format.sampleRate,
+            bandCount: Self.barCount
+        )
 
         do {
-            let recorder = try AVAudioRecorder(url: url, settings: settings)
-            recorder.isMeteringEnabled = true
-            guard recorder.record() else {
-                amplitudes = Self.idleAmplitudes
-                return
+            input.installTap(onBus: 0, bufferSize: 1_024, format: format) { [weak self] buffer, _ in
+                self?.process(buffer: buffer)
             }
-            self.recorder = recorder
-            timer = Timer.scheduledTimer(withTimeInterval: 0.06, repeats: true) { [weak self] _ in
-                self?.updateMeter()
-            }
+            try engine.start()
+            self.analyzer = analyzer
+            self.engine = engine
         } catch {
+            input.removeTap(onBus: 0)
             amplitudes = Self.idleAmplitudes
         }
     }
 
-    private func updateMeter() {
-        guard let recorder else { return }
-        recorder.updateMeters()
+    private func process(buffer: AVAudioPCMBuffer) {
+        guard let analyzer, let samples = Self.samples(from: buffer) else { return }
+        let rawAmplitudes = analyzer.amplitudes(from: samples)
 
-        let power = recorder.averagePower(forChannel: 0)
-        let normalized = Self.normalizedPower(power, minimumPower: minimumPower)
-        phase += 0.22
-        smoothedLevel = (smoothedLevel * 0.55) + (normalized * 0.45)
-        let displayLevel = smoothedLevel
-
-        amplitudes = (0..<Self.barCount).map { index in
-            let wave = 0.74 + 0.26 * sin(phase + Double(index) * 0.74)
-            return max(0.12, min(1, displayLevel * CGFloat(wave)))
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.engine != nil else { return }
+            self.amplitudes = self.smoothedDisplayAmplitudes(from: rawAmplitudes)
         }
     }
 
-    private static func normalizedPower(_ power: Float, minimumPower: Float) -> CGFloat {
-        guard power > minimumPower else { return 0.08 }
-        return CGFloat((power - minimumPower) / abs(minimumPower))
+    private func smoothedDisplayAmplitudes(from rawAmplitudes: [CGFloat]) -> [CGFloat] {
+        smoothedAmplitudes = zip(smoothedAmplitudes, rawAmplitudes).map { previous, current in
+            let smoothed = (previous * 0.62) + (current * 0.38)
+            return max(Self.minimumDisplayAmplitude, min(1, smoothed))
+        }
+        return smoothedAmplitudes
+    }
+
+    private static func samples(from buffer: AVAudioPCMBuffer) -> [Float]? {
+        guard let channelData = buffer.floatChannelData else { return nil }
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return nil }
+
+        let channelCount = Int(buffer.format.channelCount)
+        guard channelCount > 0 else { return nil }
+
+        if channelCount == 1 {
+            return Array(UnsafeBufferPointer(start: channelData[0], count: frameLength))
+        }
+
+        if buffer.format.isInterleaved {
+            return (0..<frameLength).map { frameIndex in
+                var mixedSample = Float(0)
+                let sampleIndex = frameIndex * channelCount
+                for channelIndex in 0..<channelCount {
+                    mixedSample += channelData[0][sampleIndex + channelIndex]
+                }
+                return mixedSample / Float(channelCount)
+            }
+        }
+
+        return (0..<frameLength).map { frameIndex in
+            var mixedSample = Float(0)
+            for channelIndex in 0..<channelCount {
+                mixedSample += channelData[channelIndex][frameIndex]
+            }
+            return mixedSample / Float(channelCount)
+        }
     }
 }

--- a/macos/AgentCLI/Sources/AgentCLI/VoiceSpectrumAnalyzer.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceSpectrumAnalyzer.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import Foundation
+
+final class VoiceSpectrumAnalyzer {
+    private let sampleRate: Double
+    private let bandCount: Int
+    private let centerFrequencies: [Double]
+
+    init(sampleRate: Double, bandCount: Int) {
+        self.sampleRate = sampleRate
+        self.bandCount = bandCount
+
+        let lowFrequency = 80.0
+        let highFrequency = min(7_600.0, max(lowFrequency, sampleRate * 0.46))
+        let denominator = max(1, bandCount - 1)
+        self.centerFrequencies = (0..<bandCount).map { index in
+            let fraction = Double(index) / Double(denominator)
+            return lowFrequency * pow(highFrequency / lowFrequency, fraction)
+        }
+    }
+
+    func amplitudes(from samples: [Float]) -> [CGFloat] {
+        guard !samples.isEmpty else {
+            return Array(repeating: 0, count: bandCount)
+        }
+
+        let sampleCount = samples.count
+        let windowedSamples = samples.enumerated().map { index, sample in
+            Float(Self.hannWindowValue(index: index, sampleCount: sampleCount)) * sample
+        }
+        let normalization = max(1, Self.hannWindowSum(sampleCount: sampleCount) / 2)
+
+        return centerFrequencies.map { frequency in
+            let magnitude = Self.magnitude(
+                frequency: frequency,
+                sampleRate: sampleRate,
+                samples: windowedSamples
+            ) / normalization
+            return CGFloat(min(1, sqrt(magnitude) * 1.35))
+        }
+    }
+
+    private static func magnitude(
+        frequency: Double,
+        sampleRate: Double,
+        samples: [Float]
+    ) -> Double {
+        let radiansPerSample = 2 * Double.pi * frequency / sampleRate
+        var real = 0.0
+        var imaginary = 0.0
+
+        for (index, sample) in samples.enumerated() {
+            let angle = radiansPerSample * Double(index)
+            let value = Double(sample)
+            real += value * cos(angle)
+            imaginary -= value * sin(angle)
+        }
+
+        return sqrt((real * real) + (imaginary * imaginary))
+    }
+
+    private static func hannWindowValue(index: Int, sampleCount: Int) -> Double {
+        guard sampleCount > 1 else { return 1 }
+        return 0.5 - (0.5 * cos(2 * Double.pi * Double(index) / Double(sampleCount - 1)))
+    }
+
+    private static func hannWindowSum(sampleCount: Int) -> Double {
+        guard sampleCount > 1 else { return 1 }
+        return Double(sampleCount - 1) / 2
+    }
+}

--- a/macos/AgentCLI/Tests/AgentCLITests/VoiceSpectrumAnalyzerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/VoiceSpectrumAnalyzerTests.swift
@@ -1,0 +1,49 @@
+#if canImport(XCTest)
+import Foundation
+import XCTest
+@testable import AgentCLI
+
+final class VoiceSpectrumAnalyzerTests: XCTestCase {
+    func testLowAndHighTonesPeakInDifferentFrequencyBands() {
+        let sampleRate = 16_000.0
+        let analyzer = VoiceSpectrumAnalyzer(sampleRate: sampleRate, bandCount: 16)
+
+        let lowTone = Self.sineWave(frequency: 220, sampleRate: sampleRate)
+        let highTone = Self.sineWave(frequency: 3_200, sampleRate: sampleRate)
+
+        let lowPeakIndex = analyzer.amplitudes(from: lowTone).maxIndex()
+        let highPeakIndex = analyzer.amplitudes(from: highTone).maxIndex()
+
+        XCTAssertNotNil(lowPeakIndex)
+        XCTAssertNotNil(highPeakIndex)
+        XCTAssertLessThan(lowPeakIndex!, 5)
+        XCTAssertGreaterThan(highPeakIndex!, 9)
+    }
+
+    func testSilenceProducesNoFrequencyEnergy() {
+        let analyzer = VoiceSpectrumAnalyzer(sampleRate: 16_000, bandCount: 16)
+
+        let amplitudes = analyzer.amplitudes(from: Array(repeating: Float(0), count: 1_024))
+
+        XCTAssertEqual(amplitudes.count, 16)
+        XCTAssertTrue(amplitudes.allSatisfy { $0 == 0 })
+    }
+
+    private static func sineWave(
+        frequency: Double,
+        sampleRate: Double,
+        sampleCount: Int = 2_048
+    ) -> [Float] {
+        (0..<sampleCount).map { index in
+            Float(sin(2 * Double.pi * frequency * Double(index) / sampleRate))
+        }
+    }
+}
+
+private extension Array where Element == CGFloat {
+    func maxIndex() -> Int? {
+        guard let maxValue = self.max() else { return nil }
+        return firstIndex(of: maxValue)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Replace the synthetic standing-wave voice level meter with live microphone buffer analysis.
- Add a Hann-windowed spectrum analyzer over 16 log-spaced frequency bands.
- Add analyzer coverage for low tones, high tones, and silence.

## Test Plan
- [x] `swift test`
- [x] Direct analyzer smoke check: 220 Hz peaks at bar 3, 3200 Hz peaks at bar 12, silence is zero

## Notes
- `xcodebuild test -scheme AgentCLI -destination 'platform=macOS'` could not run in this environment because the active developer directory is Command Line Tools, not full Xcode.