### PR TITLE
Fix macOS accessibility reset flow

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -1,5 +1,4 @@
 import AppKit
-import ApplicationServices
 import Foundation
 import SwiftUI
 import UserNotifications
@@ -88,11 +87,6 @@ final class AgentCommandRunner: ObservableObject {
         URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension")!,
         URL(string: "x-apple.systempreferences:com.apple.preference.notifications")!
     ]
-    private static let accessibilitySettingsURLs: [URL] = [
-        URL(string: "x-apple.systempreferences:com.apple.Security-Privacy.extension?Privacy_Accessibility")!,
-        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
-    ]
-
     func warmUpTranscription() {
         guard !hasStartedTranscriptionWarmUp else { return }
         hasStartedTranscriptionWarmUp = true
@@ -512,39 +506,49 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     func resetAccessibilityPermission() {
-        let result = runTCCReset(service: "Accessibility")
-        try? FileManager.default.removeItem(at: AgentRuntime.shared.accessibilityPromptMarkerURL)
-        requestAccessibilityPermissionPrompt()
-        _ = openAccessibilitySettings()
+        ConfigurableHotkeyController.shared.suspendFunctionAwareHotkeysForAccessibilityReset()
+        statusMessage = "Resetting Accessibility permission..."
 
-        guard result.exitCode == 0 else {
-            let output = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
-            statusMessage = output.isEmpty
-                ? "Could not reset Accessibility permission"
-                : "Could not reset Accessibility permission: \(output)"
-            return
+        DispatchQueue.global(qos: .utility).async {
+            let result = self.runTCCReset(service: "Accessibility")
+
+            Task { @MainActor in
+                try? FileManager.default.removeItem(at: AgentRuntime.shared.accessibilityPromptMarkerURL)
+
+                guard result.exitCode == 0 else {
+                    ConfigurableHotkeyController.shared.resumeFunctionAwareHotkeysAfterAccessibilityReset(runner: self)
+                    let output = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+                    self.statusMessage = output.isEmpty
+                        ? "Could not reset Accessibility permission"
+                        : "Could not reset Accessibility permission: \(output)"
+                    return
+                }
+
+                self.statusMessage = "Accessibility permission reset. Restarting AgentCLI to request permission cleanly."
+                self.relaunchAfterAccessibilityReset()
+            }
         }
-
-        statusMessage = "Accessibility permission reset. Enable Agent CLI in Accessibility, then reopen AgentCLI if auto-insert still fails."
     }
 
-    @discardableResult
-    func openAccessibilitySettings() -> Bool {
-        for url in Self.accessibilitySettingsURLs where NSWorkspace.shared.open(url) {
-            statusMessage = "Opened Accessibility Settings. Accessibility permission controls auto-inserting transcripts."
-            return true
+    private func relaunchAfterAccessibilityReset() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "sleep 1; /usr/bin/open \"$1\"",
+            "relaunch-agentcli",
+            Bundle.main.bundleURL.path
+        ]
+
+        do {
+            try process.run()
+            NSApp.terminate(nil)
+        } catch {
+            statusMessage = "Accessibility permission reset. Reopen AgentCLI, then enable it in Accessibility."
         }
-        statusMessage = "Could not open Accessibility Settings"
-        return false
     }
 
-    private func requestAccessibilityPermissionPrompt() {
-        let promptOption = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-        let options = [promptOption: true] as CFDictionary
-        _ = AXIsProcessTrustedWithOptions(options)
-    }
-
-    private func runTCCReset(service: String) -> CommandResult {
+    nonisolated private func runTCCReset(service: String) -> CommandResult {
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "lt.nijho.agent-cli.menubar"
         let process = Process()
         let pipe = Pipe()

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -105,6 +105,30 @@ final class ConfigurableHotkeyController {
         CGEvent.tapEnable(tap: tap, enable: true)
     }
 
+    func suspendFunctionAwareHotkeysForAccessibilityReset() {
+        cancelPendingHoldToTranscribe()
+
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+        }
+        if let runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        }
+
+        eventTap = nil
+        runLoopSource = nil
+        functionKeyIsDown = false
+        suppressNextFunctionKeyRelease = false
+        holdToTranscribeIsRecording = false
+    }
+
+    func resumeFunctionAwareHotkeysAfterAccessibilityReset(runner: AgentCommandRunner) {
+        guard registered, eventTap == nil else { return }
+        self.runner = runner
+        registerFunctionAwareTranscriptionHotkeys(runner: runner)
+    }
+
     private func handleFunctionAwareHotkey(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         switch type {
         case .tapDisabledByTimeout, .tapDisabledByUserInput:

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -957,10 +957,26 @@ def test_macos_app_can_reset_accessibility_permission() -> None:
     assert 'runTCCReset(service: "Accessibility")' in source
     assert 'process.arguments = ["reset", service, bundleIdentifier]' in source
     assert "accessibilityPromptMarkerURL" in source
-    assert "AXIsProcessTrustedWithOptions(options)" in source
-    assert "accessibilitySettingsURLs" in source
-    assert "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility" in source
-    assert "Enable Agent CLI in Accessibility" in source
+    assert '"relaunch-agentcli"' in source
+    assert "Restarting AgentCLI to request permission cleanly" in source
+
+
+def test_macos_app_resets_accessibility_from_clean_input_state() -> None:
+    """Resetting the app's own Accessibility grant should not prompt from a live event tap."""
+    runner_source = read_swift_source_file(SWIFT_SOURCE_DIR / "AgentCommandRunner.swift")
+    hotkey_source = read_swift_source_file(SWIFT_SOURCE_DIR / "ConfigurableHotkeyController.swift")
+
+    assert (
+        "ConfigurableHotkeyController.shared.suspendFunctionAwareHotkeysForAccessibilityReset()"
+        in runner_source
+    )
+    assert "DispatchQueue.global(qos: .utility).async" in runner_source
+    assert "relaunchAfterAccessibilityReset()" in runner_source
+    assert "AXIsProcessTrustedWithOptions(options)" not in runner_source
+    assert "requestAccessibilityPermissionPrompt" not in runner_source
+    assert "func suspendFunctionAwareHotkeysForAccessibilityReset()" in hotkey_source
+    assert "CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)" in hotkey_source
+    assert "CGEvent.tapEnable(tap: tap, enable: false)" in hotkey_source
 
 
 def test_macos_app_makes_command_errors_discoverable() -> None:


### PR DESCRIPTION
## Summary
- Stop the Fn-aware event tap before resetting the app's Accessibility TCC grant.
- Run `tccutil reset Accessibility` off the main thread and avoid prompting from the live reset menu action.
- Relaunch AgentCLI after a successful reset so the normal startup permission prompt happens from a clean process.

## Test Plan
- `uv run pytest tests/test_macos_app.py -k 'accessibility'`
- `swift test` from `macos/AgentCLI`
- `uv run pytest tests/test_macos_app.py`
- `uv sync --all-extras`
- `uv run pytest`
- `pre-commit run --all-files`