### PR TITLE
Fix macOS voice spectrum overlay sensitivity

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/VoiceSpectrumAnalyzer.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceSpectrumAnalyzer.swift
@@ -2,9 +2,13 @@ import CoreGraphics
 import Foundation
 
 final class VoiceSpectrumAnalyzer {
+    private static let minimumDisplayDecibels = -60.0
+    private static let maximumDisplayDecibels = -18.0
+
     private let sampleRate: Double
     private let bandCount: Int
     private let centerFrequencies: [Double]
+    private let frequencyBands: [(lower: Double, upper: Double)]
 
     init(sampleRate: Double, bandCount: Int) {
         self.sampleRate = sampleRate
@@ -17,6 +21,11 @@ final class VoiceSpectrumAnalyzer {
             let fraction = Double(index) / Double(denominator)
             return lowFrequency * pow(highFrequency / lowFrequency, fraction)
         }
+        self.frequencyBands = Self.frequencyBands(
+            centerFrequencies: centerFrequencies,
+            lowFrequency: lowFrequency,
+            highFrequency: highFrequency
+        )
     }
 
     func amplitudes(from samples: [Float]) -> [CGFloat] {
@@ -30,14 +39,78 @@ final class VoiceSpectrumAnalyzer {
         }
         let normalization = max(1, Self.hannWindowSum(sampleCount: sampleCount) / 2)
 
-        return centerFrequencies.map { frequency in
-            let magnitude = Self.magnitude(
-                frequency: frequency,
+        let frequencyResolution = sampleRate / Double(sampleCount)
+        let maximumBin = max(1, sampleCount / 2)
+
+        return frequencyBands.enumerated().map { index, band in
+            let magnitude = Self.bandMagnitude(
+                band: band,
+                centerFrequency: centerFrequencies[index],
+                frequencyResolution: frequencyResolution,
+                maximumBin: maximumBin,
                 sampleRate: sampleRate,
                 samples: windowedSamples
             ) / normalization
-            return CGFloat(min(1, sqrt(magnitude) * 1.35))
+            return CGFloat(Self.normalizedDisplayAmplitude(forMagnitude: magnitude))
         }
+    }
+
+    private static func frequencyBands(
+        centerFrequencies: [Double],
+        lowFrequency: Double,
+        highFrequency: Double
+    ) -> [(lower: Double, upper: Double)] {
+        centerFrequencies.enumerated().map { index, centerFrequency in
+            let lower = index == 0
+                ? lowFrequency
+                : sqrt(centerFrequencies[index - 1] * centerFrequency)
+            let upper = index == centerFrequencies.count - 1
+                ? highFrequency
+                : sqrt(centerFrequency * centerFrequencies[index + 1])
+            return (lower, upper)
+        }
+    }
+
+    private static func bandMagnitude(
+        band: (lower: Double, upper: Double),
+        centerFrequency: Double,
+        frequencyResolution: Double,
+        maximumBin: Int,
+        sampleRate: Double,
+        samples: [Float]
+    ) -> Double {
+        let lowerBin = max(1, Int(ceil(band.lower / frequencyResolution)))
+        let upperBin = min(maximumBin, Int(floor(band.upper / frequencyResolution)))
+
+        if lowerBin <= upperBin {
+            var maximumMagnitude = 0.0
+            for bin in lowerBin...upperBin {
+                maximumMagnitude = max(
+                    maximumMagnitude,
+                    magnitude(
+                        frequency: Double(bin) * frequencyResolution,
+                        sampleRate: sampleRate,
+                        samples: samples
+                    )
+                )
+            }
+            return maximumMagnitude
+        }
+
+        let nearestCenterBin = min(maximumBin, max(1, Int((centerFrequency / frequencyResolution).rounded())))
+        return magnitude(
+            frequency: Double(nearestCenterBin) * frequencyResolution,
+            sampleRate: sampleRate,
+            samples: samples
+        )
+    }
+
+    private static func normalizedDisplayAmplitude(forMagnitude magnitude: Double) -> Double {
+        guard magnitude > 0 else { return 0 }
+
+        let decibels = 20 * log10(max(magnitude, Double.leastNonzeroMagnitude))
+        let normalized = (decibels - minimumDisplayDecibels) / (maximumDisplayDecibels - minimumDisplayDecibels)
+        return min(1, max(0, normalized))
     }
 
     private static func magnitude(

--- a/macos/AgentCLI/Tests/AgentCLITests/VoiceSpectrumAnalyzerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/VoiceSpectrumAnalyzerTests.swift
@@ -29,13 +29,25 @@ final class VoiceSpectrumAnalyzerTests: XCTestCase {
         XCTAssertTrue(amplitudes.allSatisfy { $0 == 0 })
     }
 
+    func testQuietSpeechLevelToneRisesAboveOverlayFloor() {
+        let analyzer = VoiceSpectrumAnalyzer(sampleRate: 16_000, bandCount: 16)
+        let quietSpeechLevel = pow(10.0, -45.0 / 20.0)
+
+        let amplitudes = analyzer.amplitudes(
+            from: Self.sineWave(frequency: 220, sampleRate: 16_000, amplitude: Float(quietSpeechLevel))
+        )
+
+        XCTAssertGreaterThan(amplitudes.max() ?? 0, 0.2)
+    }
+
     private static func sineWave(
         frequency: Double,
         sampleRate: Double,
-        sampleCount: Int = 2_048
+        sampleCount: Int = 2_048,
+        amplitude: Float = 1
     ) -> [Float] {
         (0..<sampleCount).map { index in
-            Float(sin(2 * Double.pi * frequency * Double(index) / sampleRate))
+            amplitude * Float(sin(2 * Double.pi * frequency * Double(index) / sampleRate))
         }
     }
 }


### PR DESCRIPTION
## Summary
- aggregate spectrum energy across frequency bands instead of sampling only exact center frequencies
- map band magnitudes through a dB display range so quiet speech rises above the pill floor
- add a regression test for quiet speech-level tone visibility

## Tests
- swift test --package-path macos/AgentCLI --filter VoiceSpectrumAnalyzerTests
- swiftc macos/AgentCLI/Sources/AgentCLI/VoiceSpectrumAnalyzer.swift <temporary harness> -o /tmp/agentcli-spectrum-check && /tmp/agentcli-spectrum-check
- uv run pytest tests/test_macos_app.py
- uv run --all-extras pytest
- pre-commit run --all-files

Note: local XCTest execution with --enable-xctest is blocked by this Command Line Tools install because xcrun cannot resolve the macOS PlatformPath.