### PR TITLE
Add live menu activity timers

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -55,6 +55,10 @@ struct AgentCommand {
         return arguments + ["--extra-instructions", trimmedInstructions]
     }
 
+    var menuActivityTitle: String {
+        title
+    }
+
     static let toggleTranscription = AgentCommand(
         identifier: "transcribe",
         title: "Toggle Transcription",

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -18,6 +18,11 @@ private enum HoldTranscriptionState {
     }
 }
 
+private struct ActiveCommandActivity {
+    let title: String
+    let startedAt: Date
+}
+
 @MainActor
 final class AgentCommandRunner: ObservableObject {
     static let shared = AgentCommandRunner()
@@ -32,6 +37,10 @@ final class AgentCommandRunner: ObservableObject {
     private let pasteController: TranscriptPasteController
     private let bootstrap: AgentBootstrap
     private var bootstrapPhaseStartedAt: Date?
+    private var recordingStartedAt: Date?
+    private var transcribingStartedAt: Date?
+    private var activeCommandActivities: [String: ActiveCommandActivity] = [:]
+    private var activeCommandActivityOrder: [String] = []
     private var pendingStopRecordingCommands: Set<String> = []
     private var holdTranscriptionState: HoldTranscriptionState = .idle
     private var holdToTranscribePasteTarget: FocusedTextTarget?
@@ -43,22 +52,34 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     var menuStatusMessage: String {
-        if isRecording {
-            return "Recording"
-        }
+        menuActivityStatus.message
+    }
+
+    var menuActivityStatus: MenuActivityStatus {
+        menuActivityStatus(now: Date())
+    }
+
+    func menuActivityStatus(now: Date) -> MenuActivityStatus {
         if bootstrapPhase.isPreparing {
-            return bootstrapPhase.statusMessage(
-                animationTick: bootstrapAnimationTick(now: Date()),
-                elapsedSeconds: bootstrapElapsedSeconds(now: Date())
+            return MenuActivityStatus.active(
+                title: bootstrapPhase.activityTitle,
+                startedAt: bootstrapPhaseStartedAt ?? now,
+                now: now
             )
         }
-        if holdTranscriptionState.isFinishing {
-            return "Transcribing..."
+        if let transcribingStartedAt {
+            return MenuActivityStatus.active(title: "Transcribing", startedAt: transcribingStartedAt, now: now)
+        }
+        if isRecording {
+            return MenuActivityStatus.active(title: "Recording", startedAt: recordingStartedAt ?? now, now: now)
+        }
+        if let activity = currentCommandActivity {
+            return MenuActivityStatus.active(title: activity.title, startedAt: activity.startedAt, now: now)
         }
         if hasLastError && statusMessage.localizedCaseInsensitiveContains("failed") {
-            return "Last command failed"
+            return MenuActivityStatus.inactive(message: "Last command failed")
         }
-        return Self.compactMenuStatus(statusMessage)
+        return MenuActivityStatus.completed(title: Self.compactMenuStatus(statusMessage))
     }
 
     var menuBarIconState: MenuBarIconState {
@@ -140,15 +161,6 @@ final class AgentCommandRunner: ObservableObject {
         }
     }
 
-    private func bootstrapAnimationTick(now: Date) -> Int {
-        bootstrapElapsedSeconds(now: now) % 4
-    }
-
-    private func bootstrapElapsedSeconds(now: Date) -> Int {
-        guard let startedAt = bootstrapPhaseStartedAt else { return 0 }
-        return max(0, Int(now.timeIntervalSince(startedAt)))
-    }
-
     @discardableResult
     func beginHoldToTranscribe() -> Bool {
         guard holdTranscriptionState == .idle else {
@@ -174,6 +186,7 @@ final class AgentCommandRunner: ObservableObject {
         holdTranscriptionState = .stopping
 
         let wasRecording = recordingIndicator.isRecordingCommand(.toggleTranscription)
+        beginTranscribingActivity()
         if wasRecording {
             endRecordingIndicator(for: .toggleTranscription)
             statusMessage = "Transcribing..."
@@ -206,9 +219,11 @@ final class AgentCommandRunner: ObservableObject {
 
         if isStopRequest {
             markStopRequested(for: command)
+            beginTranscribingActivity()
         }
 
         activeCommandCount += 1
+        beginCommandActivity(for: command)
         if !self.bootstrapPhase.isPreparing {
             statusMessage = isStopRequest
                 ? "Stopping \(command.title)..."
@@ -233,6 +248,8 @@ final class AgentCommandRunner: ObservableObject {
                         self.clearPasteAfterRecording(for: command)
                     }
                     self.clearHoldTranscriptionState(for: command)
+                    self.clearTranscribingActivityIfFinished()
+                    self.finishCommandActivity(for: command)
                     self.activeCommandCount = max(0, self.activeCommandCount - 1)
                     self.lastOutput = bootstrapResult.output
                     self.recordFailure(command: command, result: bootstrapResult)
@@ -272,7 +289,9 @@ final class AgentCommandRunner: ObservableObject {
                         }
                     }
                     self.clearPasteAfterRecording(for: command)
+                    self.clearTranscribingActivityIfFinished()
                 }
+                self.finishCommandActivity(for: command)
                 self.activeCommandCount = max(0, self.activeCommandCount - 1)
 
                 if isStopRequest && result.exitCode == 0 {
@@ -285,6 +304,7 @@ final class AgentCommandRunner: ObservableObject {
 
                 if isStopRequest {
                     self.clearStopRequested(for: command)
+                    self.clearTranscribingActivityIfFinished()
                 }
                 self.lastOutput = result.output
                 if result.exitCode != 0 {
@@ -319,6 +339,7 @@ final class AgentCommandRunner: ObservableObject {
                 Task { @MainActor in
                     self.reportBootstrapPhase(.failed)
                     self.holdTranscriptionState = .idle
+                    self.clearTranscribingActivityIfFinished()
                     self.lastOutput = bootstrapResult.output
                     self.recordFailure(command: AgentCommand.stopTranscription, result: bootstrapResult)
                     self.statusMessage = message
@@ -345,6 +366,7 @@ final class AgentCommandRunner: ObservableObject {
                 }
 
                 self.holdTranscriptionState = .idle
+                self.clearTranscribingActivityIfFinished()
                 let message = result.output.isEmpty
                     ? "Toggle Transcription stop failed with exit code \(result.exitCode)"
                     : "Toggle Transcription stop failed: \(result.output)"
@@ -366,6 +388,37 @@ final class AgentCommandRunner: ObservableObject {
 
     private func clearStopRequested(for command: AgentCommand) {
         pendingStopRecordingCommands.remove(command.identifier)
+    }
+
+    private var currentCommandActivity: ActiveCommandActivity? {
+        activeCommandActivityOrder.reversed().compactMap { activeCommandActivities[$0] }.first
+    }
+
+    private func beginCommandActivity(for command: AgentCommand) {
+        if activeCommandActivities[command.identifier] == nil {
+            activeCommandActivityOrder.append(command.identifier)
+        }
+        activeCommandActivities[command.identifier] = ActiveCommandActivity(
+            title: command.menuActivityTitle,
+            startedAt: Date()
+        )
+    }
+
+    private func finishCommandActivity(for command: AgentCommand) {
+        activeCommandActivities.removeValue(forKey: command.identifier)
+        activeCommandActivityOrder.removeAll { $0 == command.identifier }
+    }
+
+    private func beginTranscribingActivity() {
+        if transcribingStartedAt == nil {
+            transcribingStartedAt = Date()
+        }
+    }
+
+    private func clearTranscribingActivityIfFinished() {
+        if pendingStopRecordingCommands.isEmpty && !holdTranscriptionState.isFinishing {
+            transcribingStartedAt = nil
+        }
     }
 
     private func shouldPasteAfterRecording(for command: AgentCommand) -> Bool {
@@ -390,14 +443,21 @@ final class AgentCommandRunner: ObservableObject {
             return false
         }
 
+        let wasRecording = isRecording
         recordingIndicator.begin(for: command)
         isRecording = recordingIndicator.isRecording
+        if !wasRecording && isRecording {
+            recordingStartedAt = Date()
+        }
         return true
     }
 
     private func endRecordingIndicator(for command: AgentCommand) {
         recordingIndicator.end(for: command)
         isRecording = recordingIndicator.isRecording
+        if !isRecording {
+            recordingStartedAt = nil
+        }
     }
 
     func copyLastOutput() {

--- a/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/BootstrapState.swift
@@ -46,18 +46,17 @@ enum BootstrapPhase: Equatable {
     func statusMessage(animationTick: Int, elapsedSeconds: Int) -> String {
         switch self {
         case .checkingRuntime, .installingRuntime, .installingVoiceService, .waitingForVoiceService, .warmingWhisperModel:
-            let spinnerFrames = ["◐", "◓", "◑", "◒"]
-            let spinner = spinnerFrames[animationTick % spinnerFrames.count]
-            let minutes = elapsedSeconds / 60
-            let seconds = elapsedSeconds % 60
-            let elapsedTime = String(format: "%02d:%02d", minutes, seconds)
-            return "\(animatedStatusMessage) \(spinner) (\(elapsedTime))"
+            return MenuActivityStatus.active(
+                title: activityTitle,
+                animationTick: animationTick,
+                elapsedSeconds: elapsedSeconds
+            ).message
         case .idle, .failed:
             return statusMessage
         }
     }
 
-    private var animatedStatusMessage: String {
+    var activityTitle: String {
         switch self {
         case .checkingRuntime:
             return "Checking CLI runtime"

--- a/macos/AgentCLI/Sources/AgentCLI/MenuActivityStatus.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuActivityStatus.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct MenuActivityStatus: Equatable {
+    let message: String
+    let isActive: Bool
+
+    static func active(title: String, startedAt: Date, now: Date) -> MenuActivityStatus {
+        let elapsedSeconds = max(0, Int(now.timeIntervalSince(startedAt)))
+        return active(title: title, animationTick: elapsedSeconds % spinnerFrames.count, elapsedSeconds: elapsedSeconds)
+    }
+
+    static func active(title: String, animationTick: Int, elapsedSeconds: Int) -> MenuActivityStatus {
+        let spinner = spinnerFrames[animationTick % spinnerFrames.count]
+        let minutes = elapsedSeconds / 60
+        let seconds = elapsedSeconds % 60
+        let elapsedTime = String(format: "%02d:%02d", minutes, seconds)
+        return MenuActivityStatus(message: "\(title) \(spinner) (\(elapsedTime))", isActive: true)
+    }
+
+    static func completed(title: String) -> MenuActivityStatus {
+        MenuActivityStatus(message: "\(title) ✓", isActive: false)
+    }
+
+    static func inactive(message: String) -> MenuActivityStatus {
+        MenuActivityStatus(message: message, isActive: false)
+    }
+
+    private static let spinnerFrames = ["◐", "◓", "◑", "◒"]
+}

--- a/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
@@ -8,6 +8,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private static let statusRefreshInterval: TimeInterval = 0.8
     private static let statusRefreshRunLoopModes: [RunLoop.Mode] = [.common, .eventTracking]
     private static let voiceStatusTitlePrefix = "Voice: "
+    private static let activityStatusTitlePrefix = "Status: "
 
     private let runner = AgentCommandRunner.shared
     private let appUpdater = AppUpdater.shared
@@ -19,6 +20,10 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private let recentRecordingsMenu = NSMenu()
     private let troubleshootingMenu = NSMenu()
     private var voiceStatusItem: NSMenuItem?
+    private var recentActivityStatusItem: NSMenuItem?
+    private var recentActivityStatusSeparator: NSMenuItem?
+    private var troubleshootingActivityStatusItem: NSMenuItem?
+    private var troubleshootingActivityStatusSeparator: NSMenuItem?
     private var statusRefreshTimer: Timer?
 
     private override init() {
@@ -108,9 +113,17 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private func rebuildRecentRecordingsMenu() {
         recentRecordingsMenu.removeAllItems()
+        let activityItem = disabledItem("")
+        let activitySeparator = NSMenuItem.separator()
+        recentRecordingsMenu.addItem(activityItem)
+        recentRecordingsMenu.addItem(activitySeparator)
+        recentActivityStatusItem = activityItem
+        recentActivityStatusSeparator = activitySeparator
+
         let recentTranscriptions = RecentTranscriptionReader.recentTranscriptions()
         if recentTranscriptions.isEmpty {
             recentRecordingsMenu.addItem(disabledItem("No recent transcriptions"))
+            refreshDynamicStatus()
             return
         }
 
@@ -123,10 +136,18 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             item.representedObject = transcription.text
             recentRecordingsMenu.addItem(item)
         }
+        refreshDynamicStatus()
     }
 
     private func rebuildTroubleshootingMenu() {
         troubleshootingMenu.removeAllItems()
+        let activityItem = disabledItem("")
+        let activitySeparator = NSMenuItem.separator()
+        troubleshootingMenu.addItem(activityItem)
+        troubleshootingMenu.addItem(activitySeparator)
+        troubleshootingActivityStatusItem = activityItem
+        troubleshootingActivityStatusSeparator = activitySeparator
+
         troubleshootingMenu.addItem(actionItem(
             "Voice Service Status",
             symbolName: "waveform.path.ecg",
@@ -191,6 +212,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             symbolName: "arrow.counterclockwise",
             action: #selector(resetKeyboardShortcuts)
         ))
+        refreshDynamicStatus()
     }
 
     private func startStatusRefreshTimer() {
@@ -207,12 +229,37 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     private func refreshDynamicStatus() {
-        voiceStatusItem?.title = "\(Self.voiceStatusTitlePrefix)\(runner.menuStatusMessage)"
+        let activityStatus = runner.menuActivityStatus
+        voiceStatusItem?.title = "\(Self.voiceStatusTitlePrefix)\(activityStatus.message)"
+        updateSubmenuActivityStatus(activityStatus)
         if let button = statusItem?.button {
             button.image = MenuBarIconImage.logoImage(state: runner.menuBarIconState)
             button.imagePosition = .imageOnly
             button.toolTip = accessibilityLabel(for: runner.menuBarIconState)
         }
+    }
+
+    private func updateSubmenuActivityStatus(_ activityStatus: MenuActivityStatus) {
+        updateSubmenuActivityStatus(
+            item: recentActivityStatusItem,
+            separator: recentActivityStatusSeparator,
+            activityStatus: activityStatus
+        )
+        updateSubmenuActivityStatus(
+            item: troubleshootingActivityStatusItem,
+            separator: troubleshootingActivityStatusSeparator,
+            activityStatus: activityStatus
+        )
+    }
+
+    private func updateSubmenuActivityStatus(
+        item: NSMenuItem?,
+        separator: NSMenuItem?,
+        activityStatus: MenuActivityStatus
+    ) {
+        item?.title = "\(Self.activityStatusTitlePrefix)\(activityStatus.message)"
+        item?.isHidden = !activityStatus.isActive
+        separator?.isHidden = !activityStatus.isActive
     }
 
     private var usesUserInstalledAgentCLI: Bool {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -280,6 +280,36 @@ final class AgentCommandTests: XCTestCase {
         )
     }
 
+    func testMenuActivityStatusFormatsActiveWorkWithSpinnerAndElapsedCounter() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        let now = Date(timeIntervalSinceReferenceDate: 1_125)
+
+        XCTAssertEqual(
+            MenuActivityStatus.active(title: "Recording", startedAt: startedAt, now: now).message,
+            "Recording ◓ (02:05)"
+        )
+        XCTAssertTrue(MenuActivityStatus.active(title: "Recording", startedAt: startedAt, now: now).isActive)
+    }
+
+    func testMenuActivityStatusFormatsCompletedWorkWithCheckmark() {
+        XCTAssertEqual(MenuActivityStatus.completed(title: "Ready").message, "Ready ✓")
+        XCTAssertEqual(MenuActivityStatus.completed(title: "Text inserted").message, "Text inserted ✓")
+        XCTAssertFalse(MenuActivityStatus.completed(title: "Ready").isActive)
+    }
+
+    @MainActor
+    func testIdleMenuStatusUsesCompletedCheckmark() {
+        let runner = AgentCommandRunner { _, _, _ in
+            CommandResult(exitCode: 0, output: "")
+        }
+
+        XCTAssertEqual(runner.menuStatusMessage, "Ready ✓")
+
+        runner.statusMessage = "Text inserted"
+
+        XCTAssertEqual(runner.menuStatusMessage, "Text inserted ✓")
+    }
+
     @MainActor
     func testMenuStatusComputesElapsedPreparationTimeWhenRead() {
         let bootstrapStarted = expectation(description: "bootstrap started")

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -50,6 +50,7 @@ def test_macos_app_package_files_exist() -> None:
         "ConfigurableHotkeyController.swift",
         "FocusedTextTarget.swift",
         "MenuBarIcon.swift",
+        "MenuActivityStatus.swift",
         "RecordingIndicatorController.swift",
         "SettingsWindowController.swift",
         "Shortcuts.swift",


### PR DESCRIPTION
## Summary
- add a shared macOS menu activity formatter for spinner, elapsed counter, and completed checkmark states
- show live recording/transcribing/command activity in the root status row and active rows inside Recent Recordings and Troubleshooting
- keep submenu activity rows updated in-place from the existing timer so open menus are not rebuilt every tick

## Verification
- swift build --package-path macos/AgentCLI
- uv run pytest -q tests/test_macos_app.py
- uv run pre-commit run --all-files
- git diff --check HEAD~1..HEAD

Note: local swift test --package-path macos/AgentCLI --enable-xctest links the test bundle but cannot execute here because this Command Line Tools install fails xcrun --sdk macosx --show-sdk-platform-path. CI macOS runners should execute the XCTest target.