### PR TITLE
Clean up macOS menu activity abstractions

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -18,11 +18,6 @@ private enum HoldTranscriptionState {
     }
 }
 
-private struct ActiveCommandActivity {
-    let title: String
-    let startedAt: Date
-}
-
 @MainActor
 final class AgentCommandRunner: ObservableObject {
     static let shared = AgentCommandRunner()
@@ -36,11 +31,7 @@ final class AgentCommandRunner: ObservableObject {
     private var recordingIndicator = RecordingIndicatorController()
     private let pasteController: TranscriptPasteController
     private let bootstrap: AgentBootstrap
-    private var bootstrapPhaseStartedAt: Date?
-    private var recordingStartedAt: Date?
-    private var transcribingStartedAt: Date?
-    private var activeCommandActivities: [String: ActiveCommandActivity] = [:]
-    private var activeCommandActivityOrder: [String] = []
+    private var activityTracker = MenuActivityTracker()
     private var pendingStopRecordingCommands: Set<String> = []
     private var holdTranscriptionState: HoldTranscriptionState = .idle
     private var holdToTranscribePasteTarget: FocusedTextTarget?
@@ -60,26 +51,16 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     func menuActivityStatus(now: Date) -> MenuActivityStatus {
-        if bootstrapPhase.isPreparing {
-            return MenuActivityStatus.active(
-                title: bootstrapPhase.activityTitle,
-                startedAt: bootstrapPhaseStartedAt ?? now,
-                now: now
+        if hasLastError && statusMessage.localizedCaseInsensitiveContains("failed") {
+            return activityTracker.status(
+                now: now,
+                fallback: MenuActivityStatus.inactive(message: "Last command failed")
             )
         }
-        if let transcribingStartedAt {
-            return MenuActivityStatus.active(title: "Transcribing", startedAt: transcribingStartedAt, now: now)
-        }
-        if isRecording {
-            return MenuActivityStatus.active(title: "Recording", startedAt: recordingStartedAt ?? now, now: now)
-        }
-        if let activity = currentCommandActivity {
-            return MenuActivityStatus.active(title: activity.title, startedAt: activity.startedAt, now: now)
-        }
-        if hasLastError && statusMessage.localizedCaseInsensitiveContains("failed") {
-            return MenuActivityStatus.inactive(message: "Last command failed")
-        }
-        return MenuActivityStatus.completed(title: Self.compactMenuStatus(statusMessage))
+        return activityTracker.status(
+            now: now,
+            fallback: MenuActivityStatus.completed(title: Self.compactMenuStatus(statusMessage))
+        )
     }
 
     var menuBarIconState: MenuBarIconState {
@@ -146,10 +127,10 @@ final class AgentCommandRunner: ObservableObject {
         bootstrapPhase = phase
         if phase.isPreparing {
             if !wasPreparing || phaseChanged {
-                bootstrapPhaseStartedAt = Date()
+                activityTracker.beginBootstrap(title: phase.activityTitle)
             }
         } else {
-            bootstrapPhaseStartedAt = nil
+            activityTracker.finishBootstrap()
         }
     }
 
@@ -390,34 +371,21 @@ final class AgentCommandRunner: ObservableObject {
         pendingStopRecordingCommands.remove(command.identifier)
     }
 
-    private var currentCommandActivity: ActiveCommandActivity? {
-        activeCommandActivityOrder.reversed().compactMap { activeCommandActivities[$0] }.first
-    }
-
     private func beginCommandActivity(for command: AgentCommand) {
-        if activeCommandActivities[command.identifier] == nil {
-            activeCommandActivityOrder.append(command.identifier)
-        }
-        activeCommandActivities[command.identifier] = ActiveCommandActivity(
-            title: command.menuActivityTitle,
-            startedAt: Date()
-        )
+        activityTracker.beginCommand(identifier: command.identifier, title: command.menuActivityTitle)
     }
 
     private func finishCommandActivity(for command: AgentCommand) {
-        activeCommandActivities.removeValue(forKey: command.identifier)
-        activeCommandActivityOrder.removeAll { $0 == command.identifier }
+        activityTracker.finishCommand(identifier: command.identifier)
     }
 
     private func beginTranscribingActivity() {
-        if transcribingStartedAt == nil {
-            transcribingStartedAt = Date()
-        }
+        activityTracker.beginTranscribing()
     }
 
     private func clearTranscribingActivityIfFinished() {
         if pendingStopRecordingCommands.isEmpty && !holdTranscriptionState.isFinishing {
-            transcribingStartedAt = nil
+            activityTracker.finishTranscribing()
         }
     }
 
@@ -447,7 +415,7 @@ final class AgentCommandRunner: ObservableObject {
         recordingIndicator.begin(for: command)
         isRecording = recordingIndicator.isRecording
         if !wasRecording && isRecording {
-            recordingStartedAt = Date()
+            activityTracker.beginRecording()
         }
         return true
     }
@@ -456,7 +424,7 @@ final class AgentCommandRunner: ObservableObject {
         recordingIndicator.end(for: command)
         isRecording = recordingIndicator.isRecording
         if !isRecording {
-            recordingStartedAt = nil
+            activityTracker.finishRecording()
         }
     }
 

--- a/macos/AgentCLI/Sources/AgentCLI/MenuActivityStatusRow.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuActivityStatusRow.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+@MainActor
+final class MenuActivityStatusRow {
+    private let prefix: String
+    private let item: NSMenuItem
+    private let separator: NSMenuItem
+
+    init(prefix: String) {
+        self.prefix = prefix
+        item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        separator = .separator()
+    }
+
+    func add(to menu: NSMenu) {
+        menu.addItem(item)
+        menu.addItem(separator)
+    }
+
+    func update(_ activityStatus: MenuActivityStatus) {
+        item.title = "\(prefix)\(activityStatus.message)"
+        item.isHidden = !activityStatus.isActive
+        separator.isHidden = !activityStatus.isActive
+    }
+}

--- a/macos/AgentCLI/Sources/AgentCLI/MenuActivityTracker.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuActivityTracker.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct MenuActivityTracker {
+    private struct Activity {
+        let title: String
+        let startedAt: Date
+    }
+
+    private var bootstrapActivity: Activity?
+    private var recordingActivity: Activity?
+    private var transcribingActivity: Activity?
+    private var commandActivities: [String: Activity] = [:]
+    private var commandActivityOrder: [String] = []
+
+    mutating func beginBootstrap(title: String, at startedAt: Date = Date()) {
+        bootstrapActivity = Activity(title: title, startedAt: startedAt)
+    }
+
+    mutating func finishBootstrap() {
+        bootstrapActivity = nil
+    }
+
+    mutating func beginRecording(at startedAt: Date = Date()) {
+        guard recordingActivity == nil else { return }
+        recordingActivity = Activity(title: "Recording", startedAt: startedAt)
+    }
+
+    mutating func finishRecording() {
+        recordingActivity = nil
+    }
+
+    mutating func beginTranscribing(at startedAt: Date = Date()) {
+        guard transcribingActivity == nil else { return }
+        transcribingActivity = Activity(title: "Transcribing", startedAt: startedAt)
+    }
+
+    mutating func finishTranscribing() {
+        transcribingActivity = nil
+    }
+
+    mutating func beginCommand(identifier: String, title: String, at startedAt: Date = Date()) {
+        if commandActivities[identifier] == nil {
+            commandActivityOrder.append(identifier)
+        }
+        commandActivities[identifier] = Activity(title: title, startedAt: startedAt)
+    }
+
+    mutating func finishCommand(identifier: String) {
+        commandActivities.removeValue(forKey: identifier)
+        commandActivityOrder.removeAll { $0 == identifier }
+    }
+
+    func status(now: Date = Date(), fallback: MenuActivityStatus) -> MenuActivityStatus {
+        guard let activity = currentActivity else { return fallback }
+        return MenuActivityStatus.active(title: activity.title, startedAt: activity.startedAt, now: now)
+    }
+
+    private var currentActivity: Activity? {
+        bootstrapActivity
+            ?? transcribingActivity
+            ?? recordingActivity
+            ?? commandActivityOrder.reversed().compactMap { commandActivities[$0] }.first
+    }
+}

--- a/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
@@ -20,10 +20,8 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private let recentRecordingsMenu = NSMenu()
     private let troubleshootingMenu = NSMenu()
     private var voiceStatusItem: NSMenuItem?
-    private var recentActivityStatusItem: NSMenuItem?
-    private var recentActivityStatusSeparator: NSMenuItem?
-    private var troubleshootingActivityStatusItem: NSMenuItem?
-    private var troubleshootingActivityStatusSeparator: NSMenuItem?
+    private var recentActivityStatusRow: MenuActivityStatusRow?
+    private var troubleshootingActivityStatusRow: MenuActivityStatusRow?
     private var statusRefreshTimer: Timer?
 
     private override init() {
@@ -113,12 +111,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private func rebuildRecentRecordingsMenu() {
         recentRecordingsMenu.removeAllItems()
-        let activityItem = disabledItem("")
-        let activitySeparator = NSMenuItem.separator()
-        recentRecordingsMenu.addItem(activityItem)
-        recentRecordingsMenu.addItem(activitySeparator)
-        recentActivityStatusItem = activityItem
-        recentActivityStatusSeparator = activitySeparator
+        recentActivityStatusRow = activityStatusRow(in: recentRecordingsMenu)
 
         let recentTranscriptions = RecentTranscriptionReader.recentTranscriptions()
         if recentTranscriptions.isEmpty {
@@ -141,12 +134,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private func rebuildTroubleshootingMenu() {
         troubleshootingMenu.removeAllItems()
-        let activityItem = disabledItem("")
-        let activitySeparator = NSMenuItem.separator()
-        troubleshootingMenu.addItem(activityItem)
-        troubleshootingMenu.addItem(activitySeparator)
-        troubleshootingActivityStatusItem = activityItem
-        troubleshootingActivityStatusSeparator = activitySeparator
+        troubleshootingActivityStatusRow = activityStatusRow(in: troubleshootingMenu)
 
         troubleshootingMenu.addItem(actionItem(
             "Voice Service Status",
@@ -240,26 +228,14 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     private func updateSubmenuActivityStatus(_ activityStatus: MenuActivityStatus) {
-        updateSubmenuActivityStatus(
-            item: recentActivityStatusItem,
-            separator: recentActivityStatusSeparator,
-            activityStatus: activityStatus
-        )
-        updateSubmenuActivityStatus(
-            item: troubleshootingActivityStatusItem,
-            separator: troubleshootingActivityStatusSeparator,
-            activityStatus: activityStatus
-        )
+        recentActivityStatusRow?.update(activityStatus)
+        troubleshootingActivityStatusRow?.update(activityStatus)
     }
 
-    private func updateSubmenuActivityStatus(
-        item: NSMenuItem?,
-        separator: NSMenuItem?,
-        activityStatus: MenuActivityStatus
-    ) {
-        item?.title = "\(Self.activityStatusTitlePrefix)\(activityStatus.message)"
-        item?.isHidden = !activityStatus.isActive
-        separator?.isHidden = !activityStatus.isActive
+    private func activityStatusRow(in menu: NSMenu) -> MenuActivityStatusRow {
+        let row = MenuActivityStatusRow(prefix: Self.activityStatusTitlePrefix)
+        row.add(to: menu)
+        return row
     }
 
     private var usesUserInstalledAgentCLI: Bool {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -297,6 +297,68 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertFalse(MenuActivityStatus.completed(title: "Ready").isActive)
     }
 
+    func testMenuActivityTrackerPrioritizesAndRestoresActivities() {
+        var tracker = MenuActivityTracker()
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        let now = Date(timeIntervalSinceReferenceDate: 1_065)
+        let fallback = MenuActivityStatus.completed(title: "Ready")
+
+        tracker.beginCommand(identifier: "autocorrect", title: "Autocorrect Clipboard", at: startedAt)
+        XCTAssertEqual(
+            tracker.status(now: now, fallback: fallback),
+            MenuActivityStatus.active(title: "Autocorrect Clipboard", startedAt: startedAt, now: now)
+        )
+
+        tracker.beginRecording(at: startedAt.addingTimeInterval(10))
+        XCTAssertEqual(
+            tracker.status(now: now, fallback: fallback),
+            MenuActivityStatus.active(title: "Recording", startedAt: startedAt.addingTimeInterval(10), now: now)
+        )
+
+        tracker.beginTranscribing(at: startedAt.addingTimeInterval(20))
+        XCTAssertEqual(
+            tracker.status(now: now, fallback: fallback),
+            MenuActivityStatus.active(title: "Transcribing", startedAt: startedAt.addingTimeInterval(20), now: now)
+        )
+
+        tracker.beginBootstrap(title: "Installing CLI runtime", at: startedAt.addingTimeInterval(30))
+        XCTAssertEqual(
+            tracker.status(now: now, fallback: fallback),
+            MenuActivityStatus.active(
+                title: "Installing CLI runtime",
+                startedAt: startedAt.addingTimeInterval(30),
+                now: now
+            )
+        )
+
+        tracker.finishBootstrap()
+        XCTAssertEqual(
+            tracker.status(now: now, fallback: fallback),
+            MenuActivityStatus.active(title: "Transcribing", startedAt: startedAt.addingTimeInterval(20), now: now)
+        )
+
+        tracker.finishTranscribing()
+        tracker.finishRecording()
+        tracker.finishCommand(identifier: "autocorrect")
+
+        XCTAssertEqual(tracker.status(now: now, fallback: fallback), fallback)
+    }
+
+    func testMenuActivityTrackerRestoresPreviousCommandWhenLatestFinishes() {
+        var tracker = MenuActivityTracker()
+        let startedAt = Date(timeIntervalSinceReferenceDate: 2_000)
+        let fallback = MenuActivityStatus.completed(title: "Ready")
+
+        tracker.beginCommand(identifier: "first", title: "First Command", at: startedAt)
+        tracker.beginCommand(identifier: "second", title: "Second Command", at: startedAt.addingTimeInterval(4))
+        tracker.finishCommand(identifier: "second")
+
+        XCTAssertEqual(
+            tracker.status(now: startedAt.addingTimeInterval(12), fallback: fallback),
+            MenuActivityStatus.active(title: "First Command", startedAt: startedAt, now: startedAt.addingTimeInterval(12))
+        )
+    }
+
     @MainActor
     func testIdleMenuStatusUsesCompletedCheckmark() {
         let runner = AgentCommandRunner { _, _, _ in

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -51,6 +51,8 @@ def test_macos_app_package_files_exist() -> None:
         "FocusedTextTarget.swift",
         "MenuBarIcon.swift",
         "MenuActivityStatus.swift",
+        "MenuActivityStatusRow.swift",
+        "MenuActivityTracker.swift",
         "RecordingIndicatorController.swift",
         "SettingsWindowController.swift",
         "Shortcuts.swift",


### PR DESCRIPTION
## Summary
- move menu activity priority/timing state into a dedicated MenuActivityTracker
- replace duplicated submenu activity item/separator fields with MenuActivityStatusRow
- add Swift coverage for tracker priority and command restoration behavior

## Verification
- swift build --package-path macos/AgentCLI
- uv run pytest -q tests/test_macos_app.py
- uv run pre-commit run --all-files
- git diff --check

Note: local swift test --package-path macos/AgentCLI --enable-xctest links the test bundle but cannot execute here because this Command Line Tools install fails xcrun --sdk macosx --show-sdk-platform-path. CI macOS runners should execute the XCTest target.