### PR TITLE
Cache user CLI runtime checks

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -12,6 +12,21 @@ private enum AgentCLIRuntimeMode: Equatable {
     }
 }
 
+private final class UserInstalledCLICheckCache {
+    private let lock = NSLock()
+    private var isAvailable = false
+
+    func hasSuccessfulCheck() -> Bool {
+        lock.withLock { isAvailable }
+    }
+
+    func update(with result: CommandResult) {
+        lock.withLock {
+            isAvailable = result.exitCode == 0
+        }
+    }
+}
+
 typealias AgentProcessRunner = (URL, [String], [String: String]) -> CommandResult
 typealias LocalhostConnector = (UInt16) -> Bool
 
@@ -42,6 +57,7 @@ struct AgentRuntime {
     private let userDefaults: UserDefaults
     private let processRunner: AgentProcessRunner
     private let localhostConnector: LocalhostConnector
+    private let userInstalledCLICheckCache: UserInstalledCLICheckCache
     private let whisperReadyTimeout: TimeInterval
     let appSupportURL: URL
     let bundledUVURL: URL
@@ -73,6 +89,7 @@ struct AgentRuntime {
         self.userDefaults = userDefaults
         self.processRunner = processRunner
         self.localhostConnector = localhostConnector
+        self.userInstalledCLICheckCache = UserInstalledCLICheckCache()
         self.whisperReadyTimeout = whisperReadyTimeout
 
         if let override = environment["AGENTCLI_APP_SUPPORT_DIR"], !override.isEmpty {
@@ -196,8 +213,13 @@ struct AgentRuntime {
         }
 
         if mode == .userInstalled {
+            if !force, userInstalledCLICheckCache.hasSuccessfulCheck() {
+                return CommandResult(exitCode: 0, output: "")
+            }
             progress(.checkingRuntime)
-            return ensureUserInstalledCLIAvailable()
+            let result = ensureUserInstalledCLIAvailable()
+            userInstalledCLICheckCache.update(with: result)
+            return result
         }
 
         if !force,

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -108,6 +108,33 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertTrue(runtime.commandEnvironment()["PATH"]?.contains("/custom/bin") == true)
     }
 
+    func testUserInstalledRuntimeCachesSuccessfulCLIAvailabilityCheck() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-cache")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-cache")
+        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+        var processArguments: [[String]] = []
+        let runtime = AgentRuntime(
+            environment: [
+                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
+                "PATH": "/custom/bin",
+                "SHELL": "/no/such/shell",
+            ],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                processArguments.append(arguments)
+                return CommandResult(exitCode: 0, output: "agent-cli 1.2.3")
+            }
+        )
+
+        var phases: [BootstrapPhase] = []
+        XCTAssertEqual(runtime.ensureReady(for: .cliRuntime) { phases.append($0) }.exitCode, 0)
+        XCTAssertEqual(runtime.ensureReady(for: .cliRuntime) { phases.append($0) }.exitCode, 0)
+        XCTAssertEqual(runtime.ensureReady(for: .cliRuntime, force: true) { phases.append($0) }.exitCode, 0)
+
+        XCTAssertEqual(processArguments, [["agent-cli", "--version"], ["agent-cli", "--version"]])
+        XCTAssertEqual(phases, [.checkingRuntime, .checkingRuntime])
+    }
+
     func testUserInstalledCLIPathUsesLoginShellPathAndCommonUvBins() {
         let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-path")!
         defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-path")


### PR DESCRIPTION
## Summary
- Cache successful user-installed `agent-cli --version` checks for the app session
- Skip the repeated CLI runtime check on later non-forced readiness calls
- Keep forced checks refreshing the cache and add a Swift regression test

## Verification
- `swift build --package-path macos/AgentCLI`
- `uv run pytest tests/test_macos_app.py`

Note: `swift test --package-path macos/AgentCLI --enable-xctest --filter AgentCommandTests/testUserInstalledRuntimeCachesSuccessfulCLIAvailabilityCheck` compiles the test target but cannot launch XCTest in this local environment because Command Line Tools cannot resolve the macOS SDK PlatformPath via `xcrun`.