### PR TITLE
Boost quiet waveform levels

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
@@ -195,7 +195,8 @@ final class VoiceLevelMeter: NSObject, ObservableObject {
 
     private static func normalizedPower(_ power: Float, minimumPower: Float) -> CGFloat {
         guard power > minimumPower else { return 0.08 }
-        return CGFloat((power - minimumPower) / abs(minimumPower))
+        let linearLevel = CGFloat((power - minimumPower) / abs(minimumPower))
+        return CGFloat(sqrt(Double(linearLevel)))
     }
 
     private static func samples(from buffer: AVAudioPCMBuffer) -> [Float]? {

--- a/macos/AgentCLI/Tests/AgentCLITests/VoiceLevelMeterTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/VoiceLevelMeterTests.swift
@@ -9,7 +9,7 @@ final class VoiceLevelMeterTests: XCTestCase {
 
         let level = VoiceLevelMeter.normalizedLevel(from: quietTone)
 
-        XCTAssertGreaterThan(level, 0.2)
+        XCTAssertGreaterThan(level, 0.5)
     }
 
     func testSilenceUsesIdleLevel() {


### PR DESCRIPTION
## Summary
- apply square-root scaling to normalized voice levels so quiet input renders taller
- tighten the quiet-input regression assertion for the voice level meter

## Verification
- swift build
- git diff --check -- macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift macos/AgentCLI/Tests/AgentCLITests/VoiceLevelMeterTests.swift

Note: Explicit XCTest execution is blocked in this local Command Line Tools setup because `xcrun --sdk macosx --show-sdk-platform-path` fails with no platform path available.