### PR TITLE
Fix macOS setup menu bar icon

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -64,13 +64,7 @@ final class AgentCommandRunner: ObservableObject {
     }
 
     var menuBarIconState: MenuBarIconState {
-        if isRecording {
-            return .recording
-        }
-        if bootstrapPhase.isPreparing {
-            return .preparing
-        }
-        return .idle
+        MenuBarIconState.current(isPreparing: bootstrapPhase.isPreparing, isRecording: isRecording)
     }
 
     init(

--- a/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
@@ -6,6 +6,16 @@ enum MenuBarIconState: Equatable {
     case idle
     case preparing
     case recording
+
+    static func current(isPreparing: Bool, isRecording: Bool) -> Self {
+        if isPreparing {
+            return .preparing
+        }
+        if isRecording {
+            return .recording
+        }
+        return .idle
+    }
 }
 
 struct AgentCLIMenuBarIcon: View {
@@ -94,12 +104,15 @@ enum MenuBarIconImage {
 
         let image = NSImage(size: NSSize(width: 22, height: 18))
         image.lockFocus()
+        let logoRect = NSRect(x: 0, y: 0, width: 18, height: 18)
         avatar.draw(
-            in: NSRect(x: 0, y: 0, width: 18, height: 18),
+            in: logoRect,
             from: .zero,
             operation: .sourceOver,
             fraction: 1
         )
+        NSColor.white.setFill()
+        logoRect.fill(using: .sourceIn)
 
         NSColor.white.setFill()
         NSBezierPath(ovalIn: NSRect(x: 12.5, y: 0.5, width: 10, height: 10)).fill()

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -307,6 +307,13 @@ final class AgentCommandTests: XCTestCase {
         )
     }
 
+    func testMenuBarIconShowsPreparingBeforeRecording() {
+        XCTAssertEqual(MenuBarIconState.current(isPreparing: false, isRecording: false), .idle)
+        XCTAssertEqual(MenuBarIconState.current(isPreparing: false, isRecording: true), .recording)
+        XCTAssertEqual(MenuBarIconState.current(isPreparing: true, isRecording: false), .preparing)
+        XCTAssertEqual(MenuBarIconState.current(isPreparing: true, isRecording: true), .preparing)
+    }
+
     func testMenuActivityStatusFormatsActiveWorkWithSpinnerAndElapsedCounter() {
         let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
         let now = Date(timeIntervalSinceReferenceDate: 1_125)


### PR DESCRIPTION
## Summary
- keep the menu bar icon in the preparing state while voice-service bootstrap is active
- render badged menu bar logos with a white glyph so setup/recording badges match light menu bar icons
- add coverage for setup-state icon precedence

## Testing
- swift test