### PR TITLE
Use purr for recording release sound

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift
@@ -18,7 +18,7 @@ enum RecordingSoundEvent: Hashable {
         case .startedRecording:
             return NSSound.Name("Frog")
         case .finishedRecording:
-            return NSSound.Name("Funk")
+            return NSSound.Name("Purr")
         }
     }
 }

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -308,7 +308,7 @@ struct SettingsView: View {
             } header: {
                 Text("General")
             } footer: {
-                Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime. Recording sounds use Frog when recording starts and Funk when recording ends.")
+                Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime. Recording sounds use Frog when recording starts and Purr when recording ends.")
             }
 
             Section {

--- a/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecordingIndicatorControllerTests.swift
@@ -1,4 +1,5 @@
 #if canImport(XCTest)
+import AppKit
 import XCTest
 @testable import AgentCLI
 
@@ -26,6 +27,11 @@ final class RecordingIndicatorControllerTests: XCTestCase {
         controller.end(for: .toggleTranscription)
 
         XCTAssertEqual(player.events, [.startedRecording, .finishedRecording])
+    }
+
+    func testRecordingSoundCueNamesUsePurrForFinishedRecording() {
+        XCTAssertEqual(RecordingSoundEvent.startedRecording.cueName, NSSound.Name("Frog"))
+        XCTAssertEqual(RecordingSoundEvent.finishedRecording.cueName, NSSound.Name("Purr"))
     }
 
     func testFinishSoundPlaysOnlyWhenAllRecordingCommandsHaveEnded() {


### PR DESCRIPTION
## Summary
- Change the macOS recording finish/release cue from `Funk` to `Purr`.
- Update the settings footer copy to describe the new start/end cue pairing.
- Add a focused cue-name assertion covering the `Purr` finish sound mapping.

## Test Plan
- `ruby -0777 -ne 'exit($_ =~ /case \\.finishedRecording:\\s*return NSSound\\.Name\\("Purr"\\)/m ? 0 : 1)' macos/AgentCLI/Sources/AgentCLI/RecordingSoundSettings.swift`
- `swift test`
- `git diff --check`

Note: in this Command Line Tools environment, `swift test` completes a successful build but does not print XCTest execution output; `xcodebuild test` requires full Xcode.
