### PR TITLE
Fix macOS setup badge color and light overlay

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/MenuBarIcon.swift
@@ -71,6 +71,17 @@ enum MenuBarIconImage {
         }
     }
 
+    static func badgeColor(for state: MenuBarIconState) -> NSColor? {
+        switch state {
+        case .idle:
+            return nil
+        case .preparing:
+            return .systemBlue
+        case .recording:
+            return .systemRed
+        }
+    }
+
     private static let idleLogoImage: NSImage? = {
         guard let url = Bundle.main.url(forResource: "logo-avatar", withExtension: "svg"),
               let image = NSImage(contentsOf: url)
@@ -86,11 +97,11 @@ enum MenuBarIconImage {
     private static let preparingLogoImage: NSImage? = makePreparingLogoImage()
 
     private static func makeRecordingLogoImage() -> NSImage? {
-        makeBadgedLogoImage(badgeColor: .systemRed, badgeDiameter: 7)
+        makeBadgedLogoImage(badgeColor: badgeColor(for: .recording) ?? .systemRed, badgeDiameter: 7)
     }
 
     private static func makePreparingLogoImage() -> NSImage? {
-        makeBadgedLogoImage(badgeColor: .controlAccentColor, badgeDiameter: 7)
+        makeBadgedLogoImage(badgeColor: badgeColor(for: .preparing) ?? .systemBlue, badgeDiameter: 7)
     }
 
     private static func makeBadgedLogoImage(badgeColor: NSColor, badgeDiameter: CGFloat) -> NSImage? {

--- a/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
@@ -4,6 +4,7 @@ import Foundation
 import SwiftUI
 
 struct VoiceLevelOverlayView: View {
+    @Environment(\.colorScheme) private var colorScheme
     @ObservedObject var meter: VoiceLevelMeter
 
     var body: some View {
@@ -13,8 +14,8 @@ struct VoiceLevelOverlayView: View {
                     .fill(
                         LinearGradient(
                             colors: [
-                                Color(red: 0.18, green: 0.82, blue: 0.92),
-                                Color(red: 0.64, green: 0.96, blue: 0.58)
+                                barGradientStart,
+                                barGradientEnd
                             ],
                             startPoint: .bottom,
                             endPoint: .top
@@ -25,13 +26,40 @@ struct VoiceLevelOverlayView: View {
             }
         }
         .frame(width: 147, height: 38)
-        .background(.ultraThinMaterial, in: Capsule())
+        .background(
+            Capsule()
+                .fill(backgroundColor)
+        )
         .overlay(
             Capsule()
-                .stroke(Color.white.opacity(0.22), lineWidth: 1)
+                .stroke(borderColor, lineWidth: 1)
         )
-        .shadow(color: Color.black.opacity(0.24), radius: 13, y: 6)
+        .shadow(color: shadowColor, radius: 13, y: 6)
         .accessibilityLabel(Text("Voice level"))
+    }
+
+    private var isLightMode: Bool {
+        colorScheme == .light
+    }
+
+    private var backgroundColor: Color {
+        isLightMode ? Color.white.opacity(0.88) : Color.black.opacity(0.42)
+    }
+
+    private var borderColor: Color {
+        isLightMode ? Color.black.opacity(0.12) : Color.white.opacity(0.22)
+    }
+
+    private var shadowColor: Color {
+        Color.black.opacity(isLightMode ? 0.16 : 0.24)
+    }
+
+    private var barGradientStart: Color {
+        isLightMode ? Color(red: 0.04, green: 0.45, blue: 0.95) : Color(red: 0.18, green: 0.82, blue: 0.92)
+    }
+
+    private var barGradientEnd: Color {
+        isLightMode ? Color(red: 0.07, green: 0.72, blue: 0.68) : Color(red: 0.64, green: 0.96, blue: 0.58)
     }
 }
 

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -1,4 +1,5 @@
 #if canImport(XCTest)
+import AppKit
 import XCTest
 @testable import AgentCLI
 
@@ -312,6 +313,12 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(MenuBarIconState.current(isPreparing: false, isRecording: true), .recording)
         XCTAssertEqual(MenuBarIconState.current(isPreparing: true, isRecording: false), .preparing)
         XCTAssertEqual(MenuBarIconState.current(isPreparing: true, isRecording: true), .preparing)
+    }
+
+    func testMenuBarIconUsesFixedSetupAndRecordingBadgeColors() {
+        XCTAssertNil(MenuBarIconImage.badgeColor(for: .idle))
+        XCTAssertEqual(MenuBarIconImage.badgeColor(for: .preparing), .systemBlue)
+        XCTAssertEqual(MenuBarIconImage.badgeColor(for: .recording), .systemRed)
     }
 
     func testMenuActivityStatusFormatsActiveWorkWithSpinnerAndElapsedCounter() {


### PR DESCRIPTION
## Summary
- use a fixed system blue badge for the macOS setup/preparing menu bar icon instead of the user's accent color
- keep recording badges fixed red
- improve the voice-level waveform bubble in light mode with a cleaner white background, subtler border/shadow, and less neon bar colors

## Testing
- swift test