### PR TITLE
Add macOS transcription log menu item

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -476,6 +476,24 @@ final class AgentCommandRunner: ObservableObject {
         }
     }
 
+    func openTranscriptionLog() {
+        let url = RecentTranscriptionReader.defaultLogURL
+
+        do {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if !FileManager.default.fileExists(atPath: url.path) {
+                _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+            }
+            if NSWorkspace.shared.open(url) {
+                statusMessage = "Opened transcription log"
+            } else {
+                statusMessage = "Could not open transcription log"
+            }
+        } catch {
+            statusMessage = "Could not open transcription log: \(error.localizedDescription)"
+        }
+    }
+
     func openConfigFolder() {
         let url = AgentRuntime.shared.appSupportURL.appendingPathComponent("config", isDirectory: true)
 

--- a/macos/AgentCLI/Sources/AgentCLI/RecentTranscriptionReader.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/RecentTranscriptionReader.swift
@@ -29,9 +29,12 @@ struct RecentTranscription: Equatable, Identifiable {
 enum RecentTranscriptionReader {
     static let defaultLimit = 20
     static let defaultLogPath = "~/.config/agent-cli/transcriptions.jsonl"
+    static var defaultLogURL: URL {
+        URL(fileURLWithPath: NSString(string: defaultLogPath).expandingTildeInPath)
+    }
 
     static func recentTranscriptions(limit: Int = defaultLimit) -> [RecentTranscription] {
-        recentTranscriptions(from: defaultLogURL(), limit: limit)
+        recentTranscriptions(from: defaultLogURL, limit: limit)
     }
 
     static func recentTranscriptions(from logURL: URL, limit: Int = defaultLimit) -> [RecentTranscription] {
@@ -52,10 +55,6 @@ enum RecentTranscriptionReader {
         }
 
         return entries
-    }
-
-    private static func defaultLogURL() -> URL {
-        URL(fileURLWithPath: NSString(string: defaultLogPath).expandingTildeInPath)
     }
 
     private static func parseLine(_ line: String, lineIndex: Int) -> RecentTranscription? {

--- a/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/StatusMenuController.swift
@@ -113,6 +113,13 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         recentRecordingsMenu.removeAllItems()
         recentActivityStatusRow = activityStatusRow(in: recentRecordingsMenu)
 
+        recentRecordingsMenu.addItem(actionItem(
+            "Open Transcription Log",
+            symbolName: "doc.text.magnifyingglass",
+            action: #selector(openTranscriptionLog)
+        ))
+        recentRecordingsMenu.addItem(.separator())
+
         let recentTranscriptions = RecentTranscriptionReader.recentTranscriptions()
         if recentTranscriptions.isEmpty {
             recentRecordingsMenu.addItem(disabledItem("No recent transcriptions"))
@@ -355,6 +362,10 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
         runner.statusMessage = "Copied recent transcription"
+    }
+
+    @objc private func openTranscriptionLog() {
+        runner.openTranscriptionLog()
     }
 
     @objc private func quit() {

--- a/macos/AgentCLI/Tests/AgentCLITests/RecentTranscriptionReaderTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/RecentTranscriptionReaderTests.swift
@@ -3,6 +3,13 @@ import XCTest
 @testable import AgentCLI
 
 final class RecentTranscriptionReaderTests: XCTestCase {
+    func testDefaultLogURLExpandsConfiguredTranscriptionLogPath() {
+        XCTAssertEqual(
+            RecentTranscriptionReader.defaultLogURL.path,
+            NSString(string: "~/.config/agent-cli/transcriptions.jsonl").expandingTildeInPath
+        )
+    }
+
     func testRecentTranscriptionsPreferProcessedTextNewestFirst() throws {
         let logURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -93,6 +93,23 @@ def test_macos_app_has_swift_unit_test_target() -> None:
     assert "swift test --package-path macos/AgentCLI --enable-xctest" in workflow
 
 
+def test_macos_app_exposes_transcription_log_from_menu() -> None:
+    """Recorded transcriptions should be logged and the log should be openable."""
+    command = (SWIFT_SOURCE_DIR / "AgentCommand.swift").read_text(encoding="utf-8")
+    reader = (SWIFT_SOURCE_DIR / "RecentTranscriptionReader.swift").read_text(encoding="utf-8")
+    runner = (SWIFT_SOURCE_DIR / "AgentCommandRunner.swift").read_text(encoding="utf-8")
+    menu = (SWIFT_SOURCE_DIR / "StatusMenuController.swift").read_text(encoding="utf-8")
+
+    assert '"--transcription-log"' in command
+    assert "RecentTranscriptionReader.defaultLogPath" in command
+    assert 'static let defaultLogPath = "~/.config/agent-cli/transcriptions.jsonl"' in reader
+    assert "static var defaultLogURL: URL" in reader
+    assert "func openTranscriptionLog()" in runner
+    assert "RecentTranscriptionReader.defaultLogURL" in runner
+    assert '"Open Transcription Log"' in menu
+    assert "#selector(openTranscriptionLog)" in menu
+
+
 def test_macos_info_plist_declares_menu_bar_agent_app() -> None:
     """The app bundle should be installable and hidden from the Dock."""
     with (MACOS_APP / "Resources" / "Info.plist").open("rb") as f:


### PR DESCRIPTION
## Summary
- Reuse the macOS app's existing transcription log path as a shared default URL.
- Add an `Open Transcription Log` action to the `Recent Recordings` submenu.
- Create the log directory/file on demand before opening it with `NSWorkspace`.

## Test Plan
- [x] `uv run pytest tests/test_macos_app.py`
- [x] `swift build --package-path macos/AgentCLI`

## Notes
- `Record to Clipboard` already passes `--transcription-log ~/.config/agent-cli/transcriptions.jsonl`, so macOS transcriptions are logged automatically today.
