### PR TITLE
Fix macOS transcription log opener

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -484,11 +484,8 @@ final class AgentCommandRunner: ObservableObject {
             if !FileManager.default.fileExists(atPath: url.path) {
                 _ = FileManager.default.createFile(atPath: url.path, contents: nil)
             }
-            if NSWorkspace.shared.open(url) {
-                statusMessage = "Opened transcription log"
-            } else {
-                statusMessage = "Could not open transcription log"
-            }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+            statusMessage = "Opened transcription log"
         } catch {
             statusMessage = "Could not open transcription log: \(error.localizedDescription)"
         }

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -99,6 +99,9 @@ def test_macos_app_exposes_transcription_log_from_menu() -> None:
     reader = (SWIFT_SOURCE_DIR / "RecentTranscriptionReader.swift").read_text(encoding="utf-8")
     runner = (SWIFT_SOURCE_DIR / "AgentCommandRunner.swift").read_text(encoding="utf-8")
     menu = (SWIFT_SOURCE_DIR / "StatusMenuController.swift").read_text(encoding="utf-8")
+    opener = runner[
+        runner.index("func openTranscriptionLog()") : runner.index("func openConfigFolder()")
+    ]
 
     assert '"--transcription-log"' in command
     assert "RecentTranscriptionReader.defaultLogPath" in command
@@ -106,6 +109,8 @@ def test_macos_app_exposes_transcription_log_from_menu() -> None:
     assert "static var defaultLogURL: URL" in reader
     assert "func openTranscriptionLog()" in runner
     assert "RecentTranscriptionReader.defaultLogURL" in runner
+    assert "activateFileViewerSelecting([url])" in opener
+    assert "NSWorkspace.shared.open(url)" not in opener
     assert '"Open Transcription Log"' in menu
     assert "#selector(openTranscriptionLog)" in menu
 


### PR DESCRIPTION
## Summary
- Reveal/select the transcription log in Finder instead of opening the `.jsonl` file through LaunchServices.
- Keep creating the log directory/file on demand before revealing it.
- Add a regression assertion so the menu action does not depend on a default `.jsonl` application.

## Test Plan
- [x] `uv run pytest tests/test_macos_app.py`
- [x] `swift build --package-path macos/AgentCLI`

## Root Cause
`NSWorkspace.shared.open(url)` asks macOS for the default application for `.jsonl`. On systems without a default handler, the menu action shows “There is no application set to open the document transcriptions.jsonl”. Finder reveal avoids that LaunchServices dependency.
