### PR TITLE
Lazy-load cli.py top-level imports

### DIFF
--- a/agent_cli/cli.py
+++ b/agent_cli/cli.py
@@ -7,12 +7,6 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich.table import Table
-
-from . import __version__
-from .config import load_config, normalize_provider_defaults
-from .core.process import set_process_title
-from .core.utils import console
 
 _HELP = """\
 AI-powered voice, text, and development tools.
@@ -49,6 +43,11 @@ app = typer.Typer(
 
 def _version_callback(value: bool) -> None:
     if value:
+        from rich.table import Table  # noqa: PLC0415
+
+        from . import __version__  # noqa: PLC0415
+        from .core.utils import console  # noqa: PLC0415
+
         path = Path(__file__).parent
         data = [
             ("agent-cli version", __version__),
@@ -81,11 +80,15 @@ def main(
 ) -> None:
     """AI-powered voice, text, and development tools."""
     if ctx.invoked_subcommand is None:
+        from .core.utils import console  # noqa: PLC0415
+
         console.print("[bold red]No command specified.[/bold red]")
         console.print("[bold yellow]Running --help for your convenience.[/bold yellow]")
         console.print(ctx.get_help())
         raise typer.Exit
     import dotenv  # noqa: PLC0415
+
+    from .core.process import set_process_title  # noqa: PLC0415
 
     dotenv.load_dotenv()
 
@@ -95,6 +98,8 @@ def main(
 
 def set_config_defaults(ctx: typer.Context, config_file: str | None) -> dict[str, Any]:
     """Set the default values for the CLI based on the config file."""
+    from .config import load_config, normalize_provider_defaults  # noqa: PLC0415
+
     config = load_config(config_file)
     wildcard_config = normalize_provider_defaults(config.get("defaults", {}))
 


### PR DESCRIPTION
## Summary
- Keep Typer imported globally.
- Move the former `cli.py` top-level imports for Rich, version metadata, config loading, console output, and process title setup into the functions that use them.
- Leave command registration and other modules unchanged.

## Test Plan
- [x] uv run ruff check agent_cli/cli.py tests/test_cli.py
- [x] uv run --extra audio --extra server pytest tests/test_cli.py tests/test_docs_gen.py -q
- [x] pre-commit hooks via git commit