### PR TITLE
Clarify Homebrew tap URL in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 
 ### Prefer the macOS menu bar app?
 
-Install the native AgentCLI app with Homebrew:
+Install the native AgentCLI app with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
@@ -260,7 +260,7 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 AgentCLI is also available as a native macOS menu bar app for voice workflows that should work from any app without keeping a terminal open.
 
-Install it with Homebrew:
+Install it with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ Before you begin, ensure you have:
 
 ### Option 1: macOS Menu Bar App
 
-For the native Mac app with global shortcuts and automatic local Whisper setup:
+For the native Mac app with global shortcuts and automatic local Whisper setup. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 
 ### Prefer the macOS app?
 
-Install the native menu bar app with Homebrew:
+Install the native menu bar app with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -17,7 +17,7 @@ The app is a SwiftUI wrapper around the same `agent-cli` commands. It bundles `u
 
 ## Install with Homebrew
 
-Install the signed app release with the Homebrew cask:
+Install the signed app release with the Homebrew cask. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -14,7 +14,7 @@ Agent CLI is designed to work with system-wide hotkeys, allowing you to trigger 
 
 ### Native Menu Bar App
 
-For the easiest macOS hotkey workflow, install the native AgentCLI menu bar app:
+For the easiest macOS hotkey workflow, install the native AgentCLI menu bar app. The explicit tap URL is intentional because the cask lives in this repository:
 
 ```bash
 brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli


### PR DESCRIPTION
## Summary
- Clarify that the explicit Homebrew tap URL is intentional because the cask lives in this repository
- Update README and docs install snippets consistently

## Verification
- `just doc-build`