### PR TITLE
Use short Homebrew tap command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Since then I have expanded the tool with many more features, all focused on loca
 
 ### Prefer the macOS menu bar app?
 
-Install the native AgentCLI app with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
+Install the native AgentCLI app with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 
@@ -260,10 +260,10 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 AgentCLI is also available as a native macOS menu bar app for voice workflows that should work from any app without keeping a terminal open.
 
-Install it with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
+Install it with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,10 +19,10 @@ Before you begin, ensure you have:
 
 ### Option 1: macOS Menu Bar App
 
-For the native Mac app with global shortcuts and automatic local Whisper setup. The explicit tap URL is intentional because the cask lives in this repository:
+For the native Mac app with global shortcuts and automatic local Whisper setup:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,10 +71,10 @@ Since then I have expanded the tool with many more features, all focused on loca
 
 ### Prefer the macOS app?
 
-Install the native menu bar app with Homebrew. The explicit tap URL is intentional because the cask lives in this repository:
+Install the native menu bar app with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -17,10 +17,10 @@ The app is a SwiftUI wrapper around the same `agent-cli` commands. It bundles `u
 
 ## Install with Homebrew
 
-Install the signed app release with the Homebrew cask. The explicit tap URL is intentional because the cask lives in this repository:
+Install the signed app release with the Homebrew cask:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -14,10 +14,10 @@ Agent CLI is designed to work with system-wide hotkeys, allowing you to trigger 
 
 ### Native Menu Bar App
 
-For the easiest macOS hotkey workflow, install the native AgentCLI menu bar app. The explicit tap URL is intentional because the cask lives in this repository:
+For the easiest macOS hotkey workflow, install the native AgentCLI menu bar app:
 
 ```bash
-brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli
+brew tap basnijholt/agent-cli
 brew install --cask agent-cli
 ```
 


### PR DESCRIPTION
## Summary
- Replace explicit Homebrew tap URLs with the short `brew tap basnijholt/agent-cli` form
- Remove the prior explanatory text about explicit tap URLs

## Verification
- `just doc-build`