### PR TITLE
Update Homebrew cask install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 Install the native AgentCLI app with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 The app provides global shortcuts, a menu bar UI, automatic local Whisper setup on first transcription, and a private bundled `agent-cli` runtime. See the [macOS app guide](docs/installation/macos-app.md) for setup, updates, and uninstall instructions.
@@ -263,8 +262,7 @@ AgentCLI is also available as a native macOS menu bar app for voice workflows th
 Install it with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 The app is a SwiftUI wrapper around the same `agent-cli` commands. It bundles `uv`, installs a private `agent-cli[audio,llm]` runtime in your Application Support folder on first use, and starts the local Whisper daemon automatically the first time you transcribe.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,8 +22,7 @@ Before you begin, ensure you have:
 For the native Mac app with global shortcuts and automatic local Whisper setup:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 See: [macOS Menu Bar App](installation/macos-app.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,8 +74,7 @@ Since then I have expanded the tool with many more features, all focused on loca
 Install the native menu bar app with Homebrew:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 The app provides global shortcuts, a menu bar UI, automatic local Whisper setup, and a private bundled `agent-cli` runtime. See the [macOS app guide](installation/macos-app.md).

--- a/docs/installation/macos-app.md
+++ b/docs/installation/macos-app.md
@@ -20,8 +20,7 @@ The app is a SwiftUI wrapper around the same `agent-cli` commands. It bundles `u
 Install the signed app release with the Homebrew cask:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 Then open **AgentCLI** from `/Applications` or Spotlight.

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -17,8 +17,7 @@ Agent CLI is designed to work with system-wide hotkeys, allowing you to trigger 
 For the easiest macOS hotkey workflow, install the native AgentCLI menu bar app:
 
 ```bash
-brew tap basnijholt/agent-cli
-brew install --cask agent-cli
+brew install --cask basnijholt/tap/agent-cli
 ```
 
 The app registers global shortcuts itself and can manage a private `agent-cli` runtime. See the [macOS app guide](installation/macos-app.md).

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -17,6 +17,13 @@ BUILD_SCRIPT = ROOT / "macos" / "build-macos-app.sh"
 E2E_SCRIPT = ROOT / "macos" / "test-macos-app-e2e.sh"
 LOGO_SVG = ROOT / "docs" / "logo-clean.svg"
 MENU_BAR_LOGO_SVG = ROOT / "docs" / "logo-avatar.svg"
+MACOS_APP_INSTALL_DOCS = [
+    ROOT / "README.md",
+    ROOT / "docs" / "getting-started.md",
+    ROOT / "docs" / "index.md",
+    ROOT / "docs" / "system-integration.md",
+    ROOT / "docs" / "installation" / "macos-app.md",
+]
 
 
 def assert_script_executable(path: Path) -> None:
@@ -65,6 +72,20 @@ def test_macos_app_package_files_exist() -> None:
     assert (MACOS_APP / "README.md").is_file()
     assert LOGO_SVG.is_file()
     assert MENU_BAR_LOGO_SVG.is_file()
+
+
+def test_macos_app_homebrew_docs_use_tap_cask_one_liner() -> None:
+    """Homebrew tap shorthand should use the public basnijholt/homebrew-tap repo."""
+    install_command = "brew install --cask basnijholt/tap/agent-cli"
+
+    for path in MACOS_APP_INSTALL_DOCS:
+        text = path.read_text(encoding="utf-8")
+        assert install_command in text, path
+        assert "\nbrew tap basnijholt/agent-cli\n" not in text, path
+        assert "brew install --cask basnijholt/agent-cli/agent-cli" not in text, path
+        assert (
+            "brew tap basnijholt/agent-cli https://github.com/basnijholt/agent-cli.git" not in text
+        ), path
 
 
 def test_macos_app_depends_on_keyboardshortcuts_package() -> None:


### PR DESCRIPTION
## Summary
- Replace two-step Homebrew cask install snippets with `brew install --cask basnijholt/tap/agent-cli`
- Add a docs regression test so the old `basnijholt/agent-cli` tap form does not come back

## Test Plan
- `uv run pytest tests/test_macos_app.py`