### PR TITLE
Allow custom args for daemon installs

### DIFF
--- a/agent_cli/daemon/cli.py
+++ b/agent_cli/daemon/cli.py
@@ -50,6 +50,9 @@ agent-cli daemon ensure whisper
 # Install whisper as a background daemon
 agent-cli daemon install whisper
 
+# Install whisper with custom server args
+agent-cli daemon install whisper -- --model small --port 10311
+
 # Install GPU-accelerated TTS
 agent-cli daemon install tts-kokoro
 
@@ -220,6 +223,17 @@ def _service_status_payload(
     }
 
 
+def _split_services_and_command_args(tokens: list[str]) -> tuple[list[str], list[str]]:
+    """Split daemon names from trailing service command args."""
+    services: list[str] = []
+    for index, token in enumerate(tokens):
+        if token.startswith("-"):
+            return services, tokens[index:]
+        services.append(token)
+
+    return services, []
+
+
 @app.command("ensure")
 def ensure_cmd(
     service: Annotated[
@@ -363,13 +377,26 @@ def install_cmd(  # noqa: PLR0912, PLR0915
         # Skip confirmation prompts
         agent-cli daemon install whisper -y
 
+        # Pass server args to one daemon command
+        agent-cli daemon install whisper -- --model small --port 10311
+
     After installation, check status with:
         agent-cli daemon status
     """
-    if not services and not all_services:
+    raw_services = services or []
+    requested_services, command_args = _split_services_and_command_args(raw_services)
+
+    if not raw_services and not all_services:
         err_console.print(
             f"[bold red]Error:[/bold red] Specify services to install or use --all. "
             f"Available: {', '.join(SERVICES.keys())}",
+        )
+        raise typer.Exit(1)
+
+    if command_args and (all_services or len(requested_services) != 1):
+        err_console.print(
+            "[bold red]Error:[/bold red] Custom service command args are only supported "
+            "when installing exactly one service.",
         )
         raise typer.Exit(1)
 
@@ -384,15 +411,20 @@ def install_cmd(  # noqa: PLR0912, PLR0915
         # Get default services (auto-selects one TTS backend based on platform)
         selected_services = get_default_services()
     else:
-        assert services is not None  # Already checked above
-        invalid = [s for s in services if s not in SERVICES]
+        if not requested_services:
+            err_console.print(
+                f"[bold red]Error:[/bold red] Specify services to install or use --all. "
+                f"Available: {', '.join(SERVICES.keys())}",
+            )
+            raise typer.Exit(1)
+        invalid = [s for s in requested_services if s not in SERVICES]
         if invalid:
             err_console.print(
                 f"[bold red]Error:[/bold red] Unknown service(s): {', '.join(invalid)}. "
                 f"Available: {', '.join(SERVICES.keys())}",
             )
             raise typer.Exit(1)
-        selected_services = services
+        selected_services = requested_services
 
     # Check uv dependency
     if not skip_deps:
@@ -402,6 +434,8 @@ def install_cmd(  # noqa: PLR0912, PLR0915
     if not no_confirm:
         console.print()
         console.print(f"[bold]Will install:[/bold] {', '.join(selected_services)}")
+        if command_args:
+            console.print(f"[bold]With args:[/bold] {' '.join(command_args)}")
         if not _confirm_action("Continue?"):
             console.print("[dim]Cancelled.[/dim]")
             raise typer.Exit(0)
@@ -414,7 +448,11 @@ def install_cmd(  # noqa: PLR0912, PLR0915
     failed = []
 
     for svc_name in selected_services:
-        result = manager.install_service(svc_name)
+        result = (
+            manager.install_service(svc_name, command_args)
+            if command_args
+            else manager.install_service(svc_name)
+        )
         if result.success:
             if result.log_dir:
                 console.print(

--- a/agent_cli/install/launchd.py
+++ b/agent_cli/install/launchd.py
@@ -109,6 +109,7 @@ def _generate_plist(
     uv_path: Path,
     home_dir: Path,
     log_dir: Path,
+    extra_command_args: list[str] | None = None,
 ) -> dict:
     """Generate plist dictionary for a launchd service."""
     environment = {"PATH": _MACOS_DAEMON_PATH}
@@ -119,7 +120,12 @@ def _generate_plist(
 
     return {
         "Label": _get_label(service.name),
-        "ProgramArguments": build_service_command(service, uv_path, use_macos_extra=True),
+        "ProgramArguments": build_service_command(
+            service,
+            uv_path,
+            use_macos_extra=True,
+            extra_command_args=extra_command_args,
+        ),
         "RunAtLoad": True,
         "KeepAlive": True,
         "WorkingDirectory": str(home_dir),
@@ -170,7 +176,10 @@ def _get_service_status(service_name: str) -> ServiceStatus:
     )
 
 
-def _install_service(service_name: str) -> InstallResult:
+def _install_service(
+    service_name: str,
+    extra_command_args: list[str] | None = None,
+) -> InstallResult:
     """Install a service as a macOS launchd service.
 
     Returns an InstallResult with success status and message.
@@ -200,7 +209,7 @@ def _install_service(service_name: str) -> InstallResult:
     plist_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Generate and write plist
-    plist_data = _generate_plist(service, uv_path, home_dir, log_dir)
+    plist_data = _generate_plist(service, uv_path, home_dir, log_dir, extra_command_args)
 
     with plist_path.open("wb") as f:
         plistlib.dump(plist_data, f)

--- a/agent_cli/install/service_config.py
+++ b/agent_cli/install/service_config.py
@@ -123,6 +123,7 @@ def build_service_command(
     uv_path: Path,
     *,
     use_macos_extra: bool = False,
+    extra_command_args: list[str] | None = None,
 ) -> list[str]:
     """Build the command args for running a service via uv tool run."""
     extra = (service.macos_extra or service.extra) if use_macos_extra else service.extra
@@ -145,6 +146,7 @@ def build_service_command(
             "agent-cli",
             *cmd_path,
             *service.command_args,
+            *(extra_command_args or []),
         ],
     )
     return args
@@ -239,7 +241,7 @@ class ServiceManager(NamedTuple):
 
     check_uv_installed: Callable[[], tuple[bool, Path | None]]
     install_uv: Callable[[], tuple[bool, str]]
-    install_service: Callable[[str], InstallResult]
+    install_service: Callable[..., InstallResult]
     uninstall_service: Callable[[str], UninstallResult]
     get_service_status: Callable[[str], ServiceStatus]
     get_log_command: Callable[[str], str]

--- a/agent_cli/install/systemd.py
+++ b/agent_cli/install/systemd.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 import subprocess
 from pathlib import Path
 
@@ -20,6 +19,40 @@ from agent_cli.install.service_config import (
 
 # Linux-specific paths for uv
 _LINUX_UV_PATHS = [Path("/usr/bin/uv")]
+
+_SYSTEMD_ESCAPE_CHARS = {
+    "\a": r"\a",
+    "\b": r"\b",
+    "\f": r"\f",
+    "\n": r"\n",
+    "\r": r"\r",
+    "\t": r"\t",
+    "\v": r"\v",
+    "\\": r"\\",
+    '"': r"\"",
+}
+
+
+def _format_exec_start_arg(arg: str) -> str:
+    """Format one argv item for systemd ExecStart syntax."""
+    needs_quotes = arg == "" or any(char.isspace() or char in {'"', "'", "\\", ";"} for char in arg)
+
+    escaped_parts: list[str] = []
+    for char in arg:
+        if char == "%":
+            escaped_parts.append("%%")
+        elif char == "$":
+            escaped_parts.append("$$")
+        else:
+            escaped_parts.append(_SYSTEMD_ESCAPE_CHARS.get(char, char))
+
+    escaped = "".join(escaped_parts)
+    return f'"{escaped}"' if needs_quotes else escaped
+
+
+def _format_exec_start(args: list[str]) -> str:
+    """Format argv for systemd ExecStart without shell quoting."""
+    return " ".join(_format_exec_start_arg(arg) for arg in args)
 
 
 def _get_unit_name(service_name: str) -> str:
@@ -68,7 +101,7 @@ def _generate_unit_file(
     extra_command_args: list[str] | None = None,
 ) -> str:
     """Generate systemd unit file content for a service."""
-    exec_start = shlex.join(
+    exec_start = _format_exec_start(
         build_service_command(service, uv_path, extra_command_args=extra_command_args),
     )
 

--- a/agent_cli/install/systemd.py
+++ b/agent_cli/install/systemd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -64,9 +65,12 @@ def _get_recent_logs(service_name: str, num_lines: int = 10) -> list[str]:
 def _generate_unit_file(
     service: ServiceConfig,
     uv_path: Path,
+    extra_command_args: list[str] | None = None,
 ) -> str:
     """Generate systemd unit file content for a service."""
-    exec_start = " ".join(build_service_command(service, uv_path))
+    exec_start = shlex.join(
+        build_service_command(service, uv_path, extra_command_args=extra_command_args),
+    )
 
     return f"""[Unit]
 Description=agent-cli {service.display_name}
@@ -129,7 +133,10 @@ def _get_service_status(service_name: str) -> ServiceStatus:
     )
 
 
-def _install_service(service_name: str) -> InstallResult:
+def _install_service(
+    service_name: str,
+    extra_command_args: list[str] | None = None,
+) -> InstallResult:
     """Install a service as a Linux systemd user service.
 
     Returns an InstallResult with success status and message.
@@ -157,7 +164,7 @@ def _install_service(service_name: str) -> InstallResult:
     unit_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Generate and write unit file
-    unit_content = _generate_unit_file(service, uv_path)
+    unit_content = _generate_unit_file(service, uv_path, extra_command_args)
     unit_path.write_text(unit_content)
 
     # Stop service if running (ignore errors if not running)

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -59,6 +59,9 @@ agent-cli daemon install --all
 
 # Skip confirmation prompts
 agent-cli daemon install whisper -y
+
+# Pass server args to one daemon command
+agent-cli daemon install whisper -- --model small --port 10311
 ```
 
 **Options:**
@@ -68,6 +71,8 @@ agent-cli daemon install whisper -y
 | `--all, -a` | Install all available services |
 | `--skip-deps` | Skip uv dependency check |
 | `--no-confirm, -y` | Skip confirmation prompts |
+
+Arguments after `--` are appended to the installed service command. This is only supported when installing exactly one daemon.
 
 ### `uninstall`
 
@@ -93,6 +98,9 @@ agent-cli daemon uninstall --all
 ```bash
 # Install whisper as a background daemon
 agent-cli daemon install whisper
+
+# Install whisper with custom server args
+agent-cli daemon install whisper -- --model small --port 10311
 
 # Check status of all daemons
 agent-cli daemon status
@@ -152,6 +160,9 @@ agent-cli daemon uninstall whisper
 
   # Install whisper as a background daemon
   agent-cli daemon install whisper
+
+  # Install whisper with custom server args
+  agent-cli daemon install whisper -- --model small --port 10311
 
   # Install GPU-accelerated TTS
   agent-cli daemon install tts-kokoro

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,6 +12,7 @@ import pytest
 from typer.testing import CliRunner
 
 from agent_cli.cli import app
+from agent_cli.install.launchd import _generate_plist as launchd_generate_plist
 from agent_cli.install.launchd import _get_log_command as launchd_get_log_command
 from agent_cli.install.launchd import _get_service_status as launchd_get_service_status
 from agent_cli.install.launchd import manager as launchd_manager
@@ -83,6 +84,33 @@ class TestServiceConfig:
         assert "test" in cmd
         assert "--port" in cmd
         assert "8080" in cmd
+
+    def test_build_service_command_appends_runtime_args(self, tmp_path: Path) -> None:
+        """User-provided daemon args are appended to the generated server command."""
+        uv_path = tmp_path / "uv"
+        uv_path.touch()
+        service = ServiceConfig(
+            name="whisper",
+            display_name="Whisper ASR",
+            description="Test",
+            extra="server",
+            command_args=["--port", "10301"],
+        )
+
+        cmd = build_service_command(
+            service,
+            uv_path,
+            extra_command_args=["--backend", "nemo", "--model", "parakeet"],
+        )
+
+        assert cmd[-6:] == [
+            "--port",
+            "10301",
+            "--backend",
+            "nemo",
+            "--model",
+            "parakeet",
+        ]
 
     def test_build_service_command_with_python_version(self, tmp_path: Path) -> None:
         """Test building service command with Python version constraint."""
@@ -434,6 +462,58 @@ class TestDaemonCLI:
         mock_manager.install_service.assert_called_once_with("whisper")
 
     @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_install_passes_trailing_service_args(self, mock_get_manager: MagicMock) -> None:
+        """Arguments after -- are persisted in the installed service command."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.check_uv_installed.return_value = (True, Path("/usr/bin/uv"))
+        mock_manager.install_service.return_value = InstallResult(
+            success=True,
+            message="Installed and started",
+            log_dir=None,
+        )
+        mock_manager.get_log_command.return_value = "journalctl --user -u agent-cli-whisper -f"
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(
+            app,
+            [
+                "daemon",
+                "install",
+                "whisper",
+                "-y",
+                "--",
+                "--backend",
+                "nemo",
+                "--model",
+                "parakeet-unified-en-0.6b",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_manager.install_service.assert_called_once_with(
+            "whisper",
+            ["--backend", "nemo", "--model", "parakeet-unified-en-0.6b"],
+        )
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
+    def test_daemon_install_rejects_trailing_args_with_multiple_services(
+        self, mock_get_manager: MagicMock
+    ) -> None:
+        """Custom daemon args are only valid when installing one service."""
+        mock_manager = MagicMock(spec=ServiceManager)
+        mock_manager.check_uv_installed.return_value = (True, Path("/usr/bin/uv"))
+        mock_get_manager.return_value = mock_manager
+
+        result = runner.invoke(
+            app,
+            ["daemon", "install", "whisper", "tts-kokoro", "-y", "--", "--port", "10309"],
+        )
+
+        assert result.exit_code == 1
+        assert "only supported when installing exactly one service" in result.output
+        mock_manager.install_service.assert_not_called()
+
+    @patch("agent_cli.daemon.cli.get_service_manager")
     def test_daemon_install_failure(self, mock_get_manager: MagicMock) -> None:
         """Test failed daemon installation."""
         mock_manager = MagicMock(spec=ServiceManager)
@@ -653,6 +733,21 @@ class TestLaunchdModule:
         assert "agent-cli-whisper" in cmd
         assert ".log" in cmd
 
+    def test_launchd_generate_plist_appends_extra_args(self, tmp_path: Path) -> None:
+        """Launchd plist persists user-provided daemon args."""
+        uv_path = tmp_path / "uv"
+        service = SERVICES["whisper"]
+
+        plist = launchd_generate_plist(
+            service,
+            uv_path,
+            tmp_path,
+            tmp_path,
+            ["--model", "small", "--port", "10311"],
+        )
+
+        assert plist["ProgramArguments"][-4:] == ["--model", "small", "--port", "10311"]
+
     @patch("subprocess.run")
     def test_launchd_get_service_status_not_installed(
         self,
@@ -759,3 +854,16 @@ class TestSystemdModule:
         assert "ExecStart=" in unit_content
         assert str(uv_path) in unit_content
         assert "Restart=on-failure" in unit_content
+
+    def test_systemd_generate_unit_file_appends_extra_args(self, tmp_path: Path) -> None:
+        """Systemd unit file persists user-provided daemon args."""
+        uv_path = tmp_path / "uv"
+        service = SERVICES["whisper"]
+
+        unit_content = systemd_generate_unit_file(
+            service,
+            uv_path,
+            ["--model", "small", "--port", "10311"],
+        )
+
+        assert "--model small --port 10311" in unit_content

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -842,9 +842,9 @@ class TestSystemdModule:
         assert status.pid == 12345
         mock_exists.assert_called()
 
-    def test_systemd_generate_unit_file(self, tmp_path: Path) -> None:
+    def test_systemd_generate_unit_file(self) -> None:
         """Test systemd unit file generation."""
-        uv_path = tmp_path / "uv"
+        uv_path = Path("/usr/bin/uv")
         service = SERVICES["whisper"]
         unit_content = systemd_generate_unit_file(service, uv_path)
 
@@ -855,9 +855,9 @@ class TestSystemdModule:
         assert str(uv_path) in unit_content
         assert "Restart=on-failure" in unit_content
 
-    def test_systemd_generate_unit_file_appends_extra_args(self, tmp_path: Path) -> None:
+    def test_systemd_generate_unit_file_appends_extra_args(self) -> None:
         """Systemd unit file persists user-provided daemon args."""
-        uv_path = tmp_path / "uv"
+        uv_path = Path("/usr/bin/uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -868,9 +868,9 @@ class TestSystemdModule:
 
         assert "--model small --port 10311" in unit_content
 
-    def test_systemd_generate_unit_file_escapes_percent_args(self, tmp_path: Path) -> None:
+    def test_systemd_generate_unit_file_escapes_percent_args(self) -> None:
         """Systemd unit file escapes literal percent signs in args."""
-        uv_path = tmp_path / "uv"
+        uv_path = Path("/usr/bin/uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -881,9 +881,9 @@ class TestSystemdModule:
 
         assert "audio%%20files" in unit_content
 
-    def test_systemd_generate_unit_file_escapes_dollar_args(self, tmp_path: Path) -> None:
+    def test_systemd_generate_unit_file_escapes_dollar_args(self) -> None:
         """Systemd unit file escapes literal dollar signs in args."""
-        uv_path = tmp_path / "uv"
+        uv_path = Path("/usr/bin/uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -894,9 +894,9 @@ class TestSystemdModule:
 
         assert "$$HOME/agent-cache" in unit_content
 
-    def test_systemd_generate_unit_file_uses_systemd_quotes(self, tmp_path: Path) -> None:
+    def test_systemd_generate_unit_file_uses_systemd_quotes(self) -> None:
         """Systemd unit file avoids shell-only quote concatenation."""
-        uv_path = tmp_path / "uv"
+        uv_path = Path("/usr/bin/uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -867,3 +867,44 @@ class TestSystemdModule:
         )
 
         assert "--model small --port 10311" in unit_content
+
+    def test_systemd_generate_unit_file_escapes_percent_args(self, tmp_path: Path) -> None:
+        """Systemd unit file escapes literal percent signs in args."""
+        uv_path = tmp_path / "uv"
+        service = SERVICES["whisper"]
+
+        unit_content = systemd_generate_unit_file(
+            service,
+            uv_path,
+            ["--base-url", "http://localhost/audio%20files"],
+        )
+
+        assert "audio%%20files" in unit_content
+
+    def test_systemd_generate_unit_file_escapes_dollar_args(self, tmp_path: Path) -> None:
+        """Systemd unit file escapes literal dollar signs in args."""
+        uv_path = tmp_path / "uv"
+        service = SERVICES["whisper"]
+
+        unit_content = systemd_generate_unit_file(
+            service,
+            uv_path,
+            ["--cache-dir", "$HOME/agent-cache"],
+        )
+
+        assert "$$HOME/agent-cache" in unit_content
+
+    def test_systemd_generate_unit_file_uses_systemd_quotes(self, tmp_path: Path) -> None:
+        """Systemd unit file avoids shell-only quote concatenation."""
+        uv_path = tmp_path / "uv"
+        service = SERVICES["whisper"]
+
+        unit_content = systemd_generate_unit_file(
+            service,
+            uv_path,
+            ["--cache-dir", "/var/lib/O'Connor/cache", "--prompt", "hello world"],
+        )
+
+        assert "'\"'\"'" not in unit_content
+        assert '"/var/lib/O\'Connor/cache"' in unit_content
+        assert '"hello world"' in unit_content

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -844,7 +844,7 @@ class TestSystemdModule:
 
     def test_systemd_generate_unit_file(self) -> None:
         """Test systemd unit file generation."""
-        uv_path = Path("/usr/bin/uv")
+        uv_path = Path("uv")
         service = SERVICES["whisper"]
         unit_content = systemd_generate_unit_file(service, uv_path)
 
@@ -857,7 +857,7 @@ class TestSystemdModule:
 
     def test_systemd_generate_unit_file_appends_extra_args(self) -> None:
         """Systemd unit file persists user-provided daemon args."""
-        uv_path = Path("/usr/bin/uv")
+        uv_path = Path("uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -870,7 +870,7 @@ class TestSystemdModule:
 
     def test_systemd_generate_unit_file_escapes_percent_args(self) -> None:
         """Systemd unit file escapes literal percent signs in args."""
-        uv_path = Path("/usr/bin/uv")
+        uv_path = Path("uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -883,7 +883,7 @@ class TestSystemdModule:
 
     def test_systemd_generate_unit_file_escapes_dollar_args(self) -> None:
         """Systemd unit file escapes literal dollar signs in args."""
-        uv_path = Path("/usr/bin/uv")
+        uv_path = Path("uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(
@@ -896,7 +896,7 @@ class TestSystemdModule:
 
     def test_systemd_generate_unit_file_uses_systemd_quotes(self) -> None:
         """Systemd unit file avoids shell-only quote concatenation."""
-        uv_path = Path("/usr/bin/uv")
+        uv_path = Path("uv")
         service = SERVICES["whisper"]
 
         unit_content = systemd_generate_unit_file(


### PR DESCRIPTION
## Summary
- allow `agent-cli daemon install <service> -- <args>` to append args to the generated daemon command
- reject custom args with `--all` or multiple services
- persist args in launchd plist and systemd unit generation
- document the passthrough syntax

## Tests
- `uv run ruff check agent_cli/daemon/cli.py agent_cli/install/launchd.py agent_cli/install/service_config.py agent_cli/install/systemd.py tests/test_daemon.py`
- `uv run ruff format --check agent_cli/daemon/cli.py agent_cli/install/launchd.py agent_cli/install/service_config.py agent_cli/install/systemd.py tests/test_daemon.py`
- `uv run pytest tests/test_daemon.py tests/test_docs_gen.py -q`
- `git diff --check`