### PR TITLE
Document NeMo Parakeet setup

### DIFF
--- a/docs/commands/install-extras.md
+++ b/docs/commands/install-extras.md
@@ -83,3 +83,16 @@ agent-cli install-extras rag memory vad
 # Install all extras
 agent-cli install-extras --all
 ```
+
+## NeMo / Parakeet
+
+Use the runtime installer for NVIDIA NeMo support:
+
+```bash
+agent-cli install-extras nemo-whisper wyoming
+agent-cli server whisper --backend nemo
+```
+
+This matters on Python 3.14. Plain `pip install "agent-cli[nemo-whisper]"` uses
+the published extra metadata, while `agent-cli install-extras nemo-whisper` can
+apply agent-cli's temporary uv override for the pinned NeMo Git build.

--- a/docs/commands/server/index.md
+++ b/docs/commands/server/index.md
@@ -57,7 +57,7 @@ While Faster Whisper, Piper, and Kokoro are all available as standalone servers,
 
 2. **TTL-based memory management** - Like [LlamaSwap](https://github.com/mostlygeek/llama-swap), models load on-demand and automatically unload after idle periods. Run voice services 24/7 without permanently consuming RAM/VRAM - memory is freed when you're not actively using speech features.
 
-3. **Multi-platform acceleration** - Whisper automatically uses the optimal backend: [MLX Whisper](https://github.com/ml-explore/mlx-examples/tree/main/whisper) on Apple Silicon for native Metal acceleration, [Faster Whisper](https://github.com/SYSTRAN/faster-whisper) on Linux/CUDA for GPU acceleration.
+3. **Multi-platform acceleration** - Whisper automatically uses the optimal backend: [MLX Whisper](https://github.com/ml-explore/mlx-examples/tree/main/whisper) on Apple Silicon for native Metal acceleration, [Faster Whisper](https://github.com/SYSTRAN/faster-whisper) on Linux/CUDA for GPU acceleration, and [NVIDIA NeMo](https://github.com/NVIDIA/NeMo) for Parakeet models.
 
 4. **Unified configuration** - Consistent CLI interface, environment variables, and Docker setup across all services.
 

--- a/docs/commands/server/whisper.md
+++ b/docs/commands/server/whisper.md
@@ -34,6 +34,12 @@ Run a local ASR server with automatic backend selection based on your platform:
 >   --default-language en
 > ```
 >
+> NVIDIA Parakeet via NeMo:
+> ```bash
+> agent-cli install-extras nemo-whisper wyoming
+> agent-cli server whisper --backend nemo
+> ```
+>
 > Use it with any OpenAI-compatible client, or configure agent-cli to use it - see [Configuration](../../configuration.md#using-local-whisper-server).
 
 ## Features
@@ -74,6 +80,12 @@ agent-cli server whisper --device cpu
 agent-cli server whisper --model large-v3 --download-only
 
 # Run NVIDIA Parakeet via NeMo
+agent-cli server whisper --backend nemo
+
+# Keep Parakeet loaded after first request (avoids repeated load cost)
+agent-cli server whisper --backend nemo --ttl 0
+
+# Run a specific Parakeet model instead of the NeMo default
 agent-cli server whisper --backend nemo --model parakeet-tdt-0.6b-v3
 
 # Preload model at startup and wait until ready
@@ -287,15 +299,62 @@ Notes for Cohere Transcribe:
 
 ### NVIDIA NeMo (Parakeet)
 
-For NeMo models like `nvidia/parakeet-tdt-0.6b-v3`:
+The NeMo backend runs NVIDIA Parakeet models behind the same OpenAI-compatible
+HTTP API and Wyoming protocol as the other Whisper backends. With `--backend
+nemo`, the default model is `parakeet-unified-en-0.6b`.
+
+Install the runtime dependencies:
 
 ```bash
-pip install "agent-cli[nemo-whisper,wyoming]"
-agent-cli server whisper --backend nemo --model parakeet-tdt-0.6b-v3
+agent-cli install-extras nemo-whisper wyoming
 ```
 
-NeMo models are currently transcription-only in this server. Requests to
-`/v1/audio/translations` return `400` for `--backend nemo`.
+Start the server:
+
+```bash
+agent-cli server whisper --backend nemo
+```
+
+Use it from agent-cli through either protocol:
+
+```bash
+# OpenAI-compatible HTTP API
+ag transcribe \
+  --asr-provider openai \
+  --asr-openai-base-url http://localhost:10301/v1
+
+# Wyoming protocol
+ag transcribe \
+  --asr-provider wyoming \
+  --asr-wyoming-ip localhost \
+  --asr-wyoming-port 10300
+```
+
+Run it as a daemon with persistent arguments:
+
+```bash
+agent-cli daemon install whisper -y -- \
+  --backend nemo \
+  --model parakeet-unified-en-0.6b \
+  --ttl 0
+```
+
+Notes for NeMo/Parakeet:
+
+- `--backend nemo` defaults to `parakeet-unified-en-0.6b`.
+- `--backend auto` switches to NeMo when any requested model name is a Parakeet model.
+- NeMo uses CUDA when available and CPU otherwise; it does not use MLX/MPS on Apple Silicon.
+- First request can be slow because the model loads lazily. Use `--preload` to load at startup, or `--ttl 0` to keep it loaded after the first request.
+- REST uploads can be WAV, MP3, M4A, FLAC, OGG, AAC, or WebM when `ffmpeg` is available.
+- NeMo models are currently transcription-only in this server. Requests to `/v1/audio/translations` return `400`.
+- Segment formats (`verbose_json`, `srt`, `vtt`) require timestamp output from the selected NeMo model.
+
+Python 3.14 note:
+
+On Python 3.14, the plain published extra path does not apply agent-cli's NeMo
+override. The `agent-cli install-extras nemo-whisper` path is uv-aware and can
+apply agent-cli's temporary pinned NeMo Git install plus override file. Prefer it
+over plain `pip install "agent-cli[nemo-whisper]"` on Python 3.14.
 
 ### Docker
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,7 @@ Add to your config file so all commands use your local server:
 ```toml
 [defaults]
 asr_provider = "wyoming"
+asr_wyoming_ip = "localhost"
 asr_wyoming_port = 10300
 ```
 
@@ -259,6 +260,37 @@ Now just run `agent-cli transcribe` - it automatically uses your local server.
 > [!TIP]
 > **OpenAI SDK users:** The server also exposes an OpenAI-compatible API on port 10301.
 > See [server whisper docs](commands/server/whisper.md) for all options.
+
+### NVIDIA Parakeet via NeMo
+
+Start a Parakeet server:
+
+```bash
+agent-cli install-extras nemo-whisper wyoming
+agent-cli server whisper --backend nemo --ttl 0
+```
+
+`--backend nemo` defaults to `parakeet-unified-en-0.6b`. `--ttl 0` keeps the
+model loaded after the first request, which is useful because NeMo model loading
+is expensive.
+
+Use it from agent-cli through Wyoming:
+
+```toml
+[defaults]
+asr_provider = "wyoming"
+asr_wyoming_ip = "localhost"
+asr_wyoming_port = 10300
+```
+
+Or through the OpenAI-compatible HTTP API:
+
+```toml
+[defaults]
+asr_provider = "openai"
+asr_openai_base_url = "http://localhost:10301/v1"
+asr_openai_model = "whisper-1"
+```
 
 ## Audio Device Configuration
 


### PR DESCRIPTION
## Summary
- expand Whisper server docs with NeMo/Parakeet install, run, client, daemon, and Python 3.14 notes
- add local config examples for using Parakeet through Wyoming or the OpenAI-compatible API
- document the runtime installer path for the nemo-whisper extra

## Verification
- uv run pytest -q tests/test_docs_gen.py
- COLUMNS=90 TERMINAL_WIDTH=90 _TYPER_FORCE_DISABLE_TERMINAL=1 uv run markdown-code-runner docs/commands/server/whisper.md
- COLUMNS=90 TERMINAL_WIDTH=90 _TYPER_FORCE_DISABLE_TERMINAL=1 uv run markdown-code-runner docs/commands/install-extras.md
- uv run zensical build