### PR TITLE
Add macOS transcription backend picker

### DIFF
--- a/agent_cli/install/service_config.py
+++ b/agent_cli/install/service_config.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
+from agent_cli.core.deps import _uv_tool_extra_args
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -35,6 +37,12 @@ class ServiceConfig:
 
 # TTS services that are mutually exclusive (same ports)
 TTS_SERVICES = ("tts-kokoro", "tts-piper")
+_WHISPER_BACKEND_EXTRAS = {
+    "faster-whisper",
+    "mlx-whisper",
+    "whisper-transformers",
+    "nemo-whisper",
+}
 
 
 def detect_preferred_tts() -> str:
@@ -127,14 +135,20 @@ def build_service_command(
 ) -> list[str]:
     """Build the command args for running a service via uv tool run."""
     extra = (service.macos_extra or service.extra) if use_macos_extra else service.extra
+    extra = _service_extra_for_command(service, extra, extra_command_args)
+    extras = _split_extras(extra)
     package_source = os.environ.get("AGENTCLI_PACKAGE_SOURCE", "agent-cli")
 
     args = [str(uv_path), "tool", "run"]
 
     # Add python version constraint (skip on macOS when using macos_extra,
     # since macos_extra typically avoids deps that lack py3.14 wheels)
-    if service.python_version and not (use_macos_extra and service.macos_extra):
+    uses_macos_extra_without_python_pin = (
+        use_macos_extra and service.macos_extra and "nemo-whisper" not in extras
+    )
+    if service.python_version and not uses_macos_extra_without_python_pin:
         args.extend(["--python", service.python_version])
+    args.extend(_uv_tool_extra_args(extras))
 
     # Build the command: either custom command path or default "server <name>"
     cmd_path = service.command or ["server", service.name]
@@ -150,6 +164,45 @@ def build_service_command(
         ],
     )
     return args
+
+
+def _service_extra_for_command(
+    service: ServiceConfig,
+    extra: str,
+    extra_command_args: list[str] | None,
+) -> str:
+    """Adjust service extras when custom daemon args select a specific backend."""
+    if service.name != "whisper" or not _uses_nemo_backend(extra_command_args):
+        return extra
+
+    parts = _split_extras(extra)
+    result: list[str] = []
+    inserted = False
+    for part in parts:
+        if part in _WHISPER_BACKEND_EXTRAS:
+            if not inserted:
+                result.append("nemo-whisper")
+                inserted = True
+            continue
+        result.append(part)
+
+    if not inserted:
+        result.append("nemo-whisper")
+    return ",".join(result)
+
+
+def _split_extras(extra: str) -> list[str]:
+    return [part.strip() for part in extra.split(",") if part.strip()]
+
+
+def _uses_nemo_backend(extra_command_args: list[str] | None) -> bool:
+    args = extra_command_args or []
+    for index, arg in enumerate(args):
+        if arg in {"--backend", "-b"} and index + 1 < len(args):
+            return args[index + 1] == "nemo"
+        if arg in {"--backend=nemo", "-b=nemo"}:
+            return True
+    return False
 
 
 def find_uv(extra_paths: list[Path] | None = None) -> Path | None:

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -15,6 +15,7 @@ struct AgentCommand {
     let title: String
     let arguments: [String]
     let appliesTranscriptionExtraInstructions: Bool
+    let appliesTranscriptionDaemonSettings: Bool
     let forceBootstrap: Bool
     let bootstrapRequirement: AgentBootstrapRequirement
     let showsRecordingIndicator: Bool
@@ -27,6 +28,7 @@ struct AgentCommand {
         title: String,
         arguments: [String],
         appliesTranscriptionExtraInstructions: Bool = false,
+        appliesTranscriptionDaemonSettings: Bool = false,
         forceBootstrap: Bool = false,
         bootstrapRequirement: AgentBootstrapRequirement = .cliRuntime,
         showsRecordingIndicator: Bool = false,
@@ -38,6 +40,7 @@ struct AgentCommand {
         self.title = title
         self.arguments = arguments
         self.appliesTranscriptionExtraInstructions = appliesTranscriptionExtraInstructions
+        self.appliesTranscriptionDaemonSettings = appliesTranscriptionDaemonSettings
         self.forceBootstrap = forceBootstrap
         self.bootstrapRequirement = bootstrapRequirement
         self.showsRecordingIndicator = showsRecordingIndicator
@@ -46,7 +49,14 @@ struct AgentCommand {
         self.finishNotificationTitle = finishNotificationTitle
     }
 
-    func resolvedArguments(extraInstructions: String?) -> [String] {
+    func resolvedArguments(
+        extraInstructions: String?,
+        transcriptionDaemonArguments: [String]? = nil
+    ) -> [String] {
+        if appliesTranscriptionDaemonSettings {
+            return transcriptionDaemonArguments ?? arguments
+        }
+
         guard appliesTranscriptionExtraInstructions else { return arguments }
 
         let trimmedInstructions = extraInstructions?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -110,7 +120,8 @@ struct AgentCommand {
     static let installVoiceService = AgentCommand(
         identifier: "install-voice-service",
         title: "Install Voice Service",
-        arguments: ["daemon", "install", "whisper", "-y"]
+        arguments: ["daemon", "install", "whisper", "-y"],
+        appliesTranscriptionDaemonSettings: true
     )
 
     static let installOrUpdateCLI = AgentCommand(

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommandRunner.swift
@@ -207,7 +207,13 @@ final class AgentCommandRunner: ObservableObject {
 
         let bootstrap = self.bootstrap
         let reportBootstrapPhase = makeBootstrapProgressReporter()
-        let commandArguments = command.resolvedArguments(extraInstructions: TranscriptionSettings.extraInstructions)
+        let transcriptionDaemonArguments = AgentRuntime.shared.usesUserInstalledAgentCLI
+            ? nil
+            : TranscriptionSettings.whisperDaemonInstallArguments()
+        let commandArguments = command.resolvedArguments(
+            extraInstructions: TranscriptionSettings.extraInstructions,
+            transcriptionDaemonArguments: transcriptionDaemonArguments
+        )
         DispatchQueue.global(qos: .userInitiated).async {
             let bootstrapResult = bootstrap(command.bootstrapRequirement, command.forceBootstrap, reportBootstrapPhase)
             guard bootstrapResult.exitCode == 0 else {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -338,7 +338,10 @@ struct AgentRuntime {
 
     private func installWhisperDaemon(progress: AgentBootstrapProgress) -> CommandResult {
         progress(.installingVoiceService)
-        let result = runAgentCLI(arguments: ["daemon", "ensure", "whisper", "--quiet"])
+        let arguments = runtimeMode == .bundled
+            ? TranscriptionSettings.whisperDaemonInstallArguments(userDefaults: userDefaults)
+            : ["daemon", "ensure", "whisper", "--quiet"]
+        let result = runAgentCLI(arguments: arguments)
         guard result.exitCode == 0 else {
             return result
         }
@@ -354,7 +357,13 @@ struct AgentRuntime {
 
     private var whisperDaemonMarkerContents: String {
         let modeName = runtimeMode == .userInstalled ? "user-installed" : "bundled"
-        return "runtimeMode=\(modeName)\npackageSource=\(agentCLIPackageSource)\n"
+        var contents = "runtimeMode=\(modeName)\npackageSource=\(agentCLIPackageSource)\n"
+        if runtimeMode == .bundled {
+            let backend = TranscriptionSettings.selectedBackend(userDefaults: userDefaults)
+            contents += "transcriptionBackend=\(backend.rawValue)\n"
+            contents += "transcriptionModel=\(TranscriptionSettings.selectedModelName(userDefaults: userDefaults))\n"
+        }
+        return contents
     }
 
     private func warmUpWhisperModel() -> CommandResult {

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -281,9 +281,17 @@ struct SettingsView: View {
     private var useUserInstalledAgentCLI = false
     @AppStorage(RecordingSoundSettings.enabledKey)
     private var recordingSoundsEnabled = false
+    @AppStorage(TranscriptionSettings.transcriptionBackendKey)
+    private var transcriptionBackend = TranscriptionBackend.whisper.rawValue
+    @AppStorage(TranscriptionSettings.transcriptionModelKey)
+    private var transcriptionModel = TranscriptionBackend.whisper.defaultModelName
     @AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)
     private var transcriptionExtraInstructions = ""
     @State private var shortcutRevision = 0
+
+    private var selectedTranscriptionBackend: TranscriptionBackend {
+        TranscriptionBackend(rawValue: transcriptionBackend) ?? .whisper
+    }
 
     var body: some View {
         Form {
@@ -309,6 +317,32 @@ struct SettingsView: View {
                 Text("General")
             } footer: {
                 Text("Runs the agent-cli found on PATH with your normal config instead of the app's private bundled-uv runtime. Recording sounds use Frog when recording starts and Purr when recording ends.")
+            }
+
+            Section {
+                Picker("Backend", selection: $transcriptionBackend) {
+                    ForEach(TranscriptionBackend.allCases) { backend in
+                        Text(backend.title).tag(backend.rawValue)
+                    }
+                }
+                .pickerStyle(.menu)
+                .disabled(useUserInstalledAgentCLI)
+
+                Picker("Model", selection: $transcriptionModel) {
+                    ForEach(selectedTranscriptionBackend.modelOptions) { model in
+                        Text(model.title).tag(model.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .disabled(useUserInstalledAgentCLI)
+            } header: {
+                Text("Voice Service")
+            } footer: {
+                Text(
+                    useUserInstalledAgentCLI
+                        ? "Disabled while User-Installed agent-cli is active."
+                        : "Changing these settings restarts the bundled voice service on next transcription."
+                )
             }
 
             Section {
@@ -378,9 +412,19 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onChange(of: transcriptionBackend) { _ in
+            normalizeTranscriptionModel()
+        }
         .onAppear {
             loginItemController.refresh()
+            normalizeTranscriptionModel()
         }
+    }
+
+    private func normalizeTranscriptionModel() {
+        let backend = selectedTranscriptionBackend
+        guard backend.modelOption(named: transcriptionModel) == nil else { return }
+        transcriptionModel = backend.defaultModelName
     }
 }
 

--- a/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
@@ -1,9 +1,94 @@
 import Foundation
 
+struct TranscriptionModelOption: Identifiable, Equatable {
+    let id: String
+    let title: String
+}
+
+enum TranscriptionBackend: String, CaseIterable, Identifiable {
+    case whisper
+    case nemo
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .whisper:
+            return "Whisper"
+        case .nemo:
+            return "NeMo"
+        }
+    }
+
+    var cliBackend: String {
+        switch self {
+        case .whisper:
+            return "auto"
+        case .nemo:
+            return "nemo"
+        }
+    }
+
+    var defaultModelName: String {
+        modelOptions[0].id
+    }
+
+    var modelOptions: [TranscriptionModelOption] {
+        switch self {
+        case .whisper:
+            return [
+                TranscriptionModelOption(id: "large-v3", title: "Large v3"),
+                TranscriptionModelOption(id: "large-v3-turbo", title: "Turbo"),
+                TranscriptionModelOption(id: "small", title: "Small"),
+            ]
+        case .nemo:
+            return [
+                TranscriptionModelOption(id: "parakeet-unified-en-0.6b", title: "Parakeet Unified 0.6B"),
+                TranscriptionModelOption(id: "parakeet-tdt-0.6b-v3", title: "Parakeet TDT 0.6B v3"),
+                TranscriptionModelOption(id: "parakeet-tdt_ctc-110m", title: "Parakeet TDT CTC 110M"),
+            ]
+        }
+    }
+
+    func modelOption(named modelName: String) -> TranscriptionModelOption? {
+        modelOptions.first { $0.id == modelName }
+    }
+}
+
 enum TranscriptionSettings {
     static let transcriptionExtraInstructionsKey = "transcriptionExtraInstructions"
+    static let transcriptionBackendKey = "transcriptionBackend"
+    static let transcriptionModelKey = "transcriptionModel"
 
     static var extraInstructions: String {
         UserDefaults.standard.string(forKey: transcriptionExtraInstructionsKey) ?? ""
+    }
+
+    static func selectedBackend(userDefaults: UserDefaults = .standard) -> TranscriptionBackend {
+        let rawValue = userDefaults.string(forKey: transcriptionBackendKey) ?? TranscriptionBackend.whisper.rawValue
+        return TranscriptionBackend(rawValue: rawValue) ?? .whisper
+    }
+
+    static func selectedModelName(userDefaults: UserDefaults = .standard) -> String {
+        let backend = selectedBackend(userDefaults: userDefaults)
+        let storedModelName = userDefaults.string(forKey: transcriptionModelKey) ?? ""
+        return backend.modelOption(named: storedModelName)?.id ?? backend.defaultModelName
+    }
+
+    static func whisperDaemonInstallArguments(userDefaults: UserDefaults = .standard) -> [String] {
+        let backend = selectedBackend(userDefaults: userDefaults)
+        return [
+            "daemon",
+            "install",
+            "whisper",
+            "-y",
+            "--",
+            "--backend",
+            backend.cliBackend,
+            "--model",
+            selectedModelName(userDefaults: userDefaults),
+        ]
     }
 }

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -56,6 +56,24 @@ final class AgentCommandTests: XCTestCase {
         )
     }
 
+    func testInstallVoiceServiceUsesResolvedTranscriptionDaemonArguments() {
+        XCTAssertEqual(
+            AgentCommand.installVoiceService.resolvedArguments(
+                extraInstructions: nil,
+                transcriptionDaemonArguments: [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "nemo",
+                    "--model", "parakeet-tdt-0.6b-v3",
+                ]
+            ),
+            [
+                "daemon", "install", "whisper", "-y", "--",
+                "--backend", "nemo",
+                "--model", "parakeet-tdt-0.6b-v3",
+            ]
+        )
+    }
+
     func testAutocorrectOnlyRequiresCliRuntime() {
         XCTAssertEqual(AgentCommand.autocorrect.arguments, ["autocorrect", "--quiet"])
         XCTAssertEqual(AgentCommand.autocorrect.bootstrapRequirement, .cliRuntime)
@@ -202,7 +220,7 @@ final class AgentCommandTests: XCTestCase {
             userDefaults: defaults,
             processRunner: { _, arguments, _ in
                 processArguments.append(arguments)
-                if arguments == ["daemon", "ensure", "whisper", "--quiet"] {
+                if arguments == ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
                 }
@@ -223,10 +241,206 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(
             processArguments,
             [
-                ["daemon", "ensure", "whisper", "--quiet"],
+                ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"],
             ]
         )
-        XCTAssertEqual(phases, [.waitingForVoiceService, .installingVoiceService, .waitingForVoiceService])
+        XCTAssertEqual(phases, [.installingVoiceService, .waitingForVoiceService])
+    }
+
+    func testTranscriptionBootstrapInstallsDefaultWhisperModel() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentCLITests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let binURL = tempURL.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let agentCLIURL = binURL.appendingPathComponent("agent-cli")
+        _ = FileManager.default.createFile(atPath: agentCLIURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: agentCLIURL.path)
+
+        try """
+        packageSource=agent-cli
+        installRequirement=agent-cli[audio,llm]
+
+        """.write(
+            to: tempURL.appendingPathComponent(".agent-cli-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let defaults = UserDefaults(suiteName: "AgentCLITests.default-whisper-model")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.default-whisper-model")
+        var installedWhisper = false
+        var processArguments: [[String]] = []
+        let runtime = AgentRuntime(
+            environment: ["AGENTCLI_APP_SUPPORT_DIR": tempURL.path],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                processArguments.append(arguments)
+                if arguments == ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"] {
+                    installedWhisper = true
+                    return CommandResult(exitCode: 0, output: "Installed and started")
+                }
+                XCTFail("Unexpected process arguments: \(arguments)")
+                return CommandResult(exitCode: 1, output: "unexpected")
+            },
+            localhostConnector: { port in
+                XCTAssertEqual(port, 10300)
+                return installedWhisper
+            },
+            whisperReadyTimeout: 0.01
+        )
+
+        let result = runtime.ensureReady(for: .transcription)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(
+            processArguments,
+            [
+                ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"],
+            ]
+        )
+    }
+
+    func testTranscriptionBootstrapInstallsSelectedNemoModel() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentCLITests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let binURL = tempURL.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let agentCLIURL = binURL.appendingPathComponent("agent-cli")
+        _ = FileManager.default.createFile(atPath: agentCLIURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: agentCLIURL.path)
+
+        try """
+        packageSource=agent-cli
+        installRequirement=agent-cli[audio,llm]
+
+        """.write(
+            to: tempURL.appendingPathComponent(".agent-cli-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let defaults = UserDefaults(suiteName: "AgentCLITests.nemo-model")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.nemo-model")
+        defaults.set("nemo", forKey: "transcriptionBackend")
+        defaults.set("parakeet-tdt-0.6b-v3", forKey: "transcriptionModel")
+
+        var installedWhisper = false
+        var processArguments: [[String]] = []
+        let runtime = AgentRuntime(
+            environment: ["AGENTCLI_APP_SUPPORT_DIR": tempURL.path],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                processArguments.append(arguments)
+                if arguments == [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "nemo",
+                    "--model", "parakeet-tdt-0.6b-v3",
+                ] {
+                    installedWhisper = true
+                    return CommandResult(exitCode: 0, output: "Installed and started")
+                }
+                XCTFail("Unexpected process arguments: \(arguments)")
+                return CommandResult(exitCode: 1, output: "unexpected")
+            },
+            localhostConnector: { port in
+                XCTAssertEqual(port, 10300)
+                return installedWhisper
+            },
+            whisperReadyTimeout: 0.01
+        )
+
+        let result = runtime.ensureReady(for: .transcription)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(
+            processArguments,
+            [
+                [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "nemo",
+                    "--model", "parakeet-tdt-0.6b-v3",
+                ],
+            ]
+        )
+    }
+
+    func testSelectedWhisperModelInvalidatesBundledDaemonMarker() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentCLITests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let binURL = tempURL.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let agentCLIURL = binURL.appendingPathComponent("agent-cli")
+        _ = FileManager.default.createFile(atPath: agentCLIURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: agentCLIURL.path)
+
+        try """
+        packageSource=agent-cli
+        installRequirement=agent-cli[audio,llm]
+
+        """.write(
+            to: tempURL.appendingPathComponent(".agent-cli-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        runtimeMode=bundled
+        packageSource=agent-cli
+
+        """.write(
+            to: tempURL.appendingPathComponent(".whisper-daemon-installed"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let defaults = UserDefaults(suiteName: "AgentCLITests.whisper-marker")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.whisper-marker")
+        defaults.set("nemo", forKey: "transcriptionBackend")
+        defaults.set("parakeet-tdt-0.6b-v3", forKey: "transcriptionModel")
+        var installedWhisper = false
+        var processArguments: [[String]] = []
+        let runtime = AgentRuntime(
+            environment: ["AGENTCLI_APP_SUPPORT_DIR": tempURL.path],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                processArguments.append(arguments)
+                if arguments == [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "nemo",
+                    "--model", "parakeet-tdt-0.6b-v3",
+                ] {
+                    installedWhisper = true
+                    return CommandResult(exitCode: 0, output: "Installed and started")
+                }
+                XCTFail("Unexpected process arguments: \(arguments)")
+                return CommandResult(exitCode: 1, output: "unexpected")
+            },
+            localhostConnector: { port in
+                XCTAssertEqual(port, 10300)
+                return installedWhisper
+            },
+            whisperReadyTimeout: 0.01
+        )
+
+        XCTAssertEqual(
+            runtime.ensureReady(for: .transcription).exitCode,
+            0
+        )
+        XCTAssertEqual(
+            processArguments,
+            [
+                [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "nemo",
+                    "--model", "parakeet-tdt-0.6b-v3",
+                ],
+            ]
+        )
     }
 
     func testAppVersionDisplayIncludesShortVersionAndBuild() {

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -143,6 +143,21 @@ class TestServiceConfig:
         cmd = build_service_command(service, uv_path, use_macos_extra=True)
         assert "agent-cli[server,macos-dep]" in cmd
 
+    def test_build_service_command_uses_nemo_extra_for_nemo_backend(self, tmp_path: Path) -> None:
+        """NeMo daemon args should install the NeMo backend extra."""
+        uv_path = tmp_path / "uv"
+        uv_path.touch()
+
+        cmd = build_service_command(
+            SERVICES["whisper"],
+            uv_path,
+            use_macos_extra=True,
+            extra_command_args=["--backend", "nemo", "--model", "parakeet-tdt-0.6b-v3"],
+        )
+
+        assert "agent-cli[server,nemo-whisper,wyoming]" in cmd
+        assert cmd[cmd.index("--python") + 1] == "3.13"
+
     def test_build_service_command_uses_app_package_source(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Add macOS Settings pickers for bundled transcription backend and model selection.
- Install/reinstall bundled Whisper daemon with selected Whisper or NeMo model args, with marker invalidation when selection changes.
- Ensure NeMo daemon installs use the nemo-whisper extra, Python 3.13, and runtime overrides.

## Test Plan
- uv run ruff check agent_cli/install/service_config.py tests/test_daemon.py
- uv run pytest tests/test_daemon.py::TestServiceConfig
- swift test

Note: Full XCTest execution is unavailable in this local CommandLineTools setup because xcrun cannot resolve the macOS PlatformPath.