### PR TITLE
Fix NeMo daemon runtime installs

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -70,6 +70,18 @@ def _is_uvx_cache() -> bool:
     return "/cache/uv/" in prefix_str or "/archive-v" in prefix_str
 
 
+def _find_runtime_uv() -> str | None:
+    """Find uv for runtime dependency installs, including bundled app uv."""
+    for env_name in ("AGENTCLI_UV_PATH", "AGENTCLI_BUNDLED_UV"):
+        value = os.environ.get(env_name)
+        if not value:
+            continue
+        uv_path = Path(value).expanduser()
+        if uv_path.is_file() and os.access(uv_path, os.X_OK):
+            return str(uv_path)
+    return shutil.which("uv")
+
+
 # -- Package Checking --
 
 # Load extras from JSON file
@@ -252,8 +264,9 @@ def _install_via_uv_tool(extras: list[str], *, quiet: bool = False) -> bool:
 def _install_cmd() -> list[str]:
     """Build the install command with appropriate flags."""
     in_venv = _in_virtualenv()
-    if shutil.which("uv"):
-        cmd = ["uv", "pip", "install", "--python", sys.executable]
+    uv_path = _find_runtime_uv()
+    if uv_path:
+        cmd = [uv_path, "pip", "install", "--python", sys.executable]
         if not in_venv:
             cmd.append("--system")
         return cmd
@@ -281,7 +294,7 @@ def _supports_uv_runtime_override(
     """Return True when uv can install an extra with runtime overrides."""
     if extra not in _EXTRA_UV_RUNTIME_REQUIREMENTS:
         return False
-    has_uv = shutil.which("uv") is not None if uv_available is None else uv_available
+    has_uv = _find_runtime_uv() is not None if uv_available is None else uv_available
     return has_uv and _uv_override_path(extra).exists()
 
 
@@ -299,11 +312,15 @@ def _uv_pip_extra_requirements(extra: str, cmd: list[str]) -> list[str]:
     return list(_EXTRA_UV_RUNTIME_REQUIREMENTS[extra])
 
 
-def _uv_tool_extra_args(extras: list[str]) -> list[str]:
+def _uv_tool_extra_args(
+    extras: list[str],
+    *,
+    uv_available: bool | None = None,
+) -> list[str]:
     """Return uv tool arguments needed for extras with runtime overrides."""
     args: list[str] = []
     for extra in extras:
-        if not _supports_uv_runtime_override(extra):
+        if not _supports_uv_runtime_override(extra, uv_available=uv_available):
             continue
         args.extend(["--overrides", str(_uv_override_path(extra))])
         for requirement in _EXTRA_UV_RUNTIME_REQUIREMENTS[extra]:
@@ -409,19 +426,33 @@ def _maybe_exec_with_marker(cmd: list[str], message: str) -> None:
 
 
 def _maybe_reexec_with_uvx(extras: list[str]) -> None:
-    """Try to re-execute with uvx running agent-cli[extras] directly.
+    """Try to re-execute with uv running agent-cli[extras] directly.
 
     If successful, replaces the current process (never returns).
-    If not in uvx cache or uvx unavailable, returns normally.
+    If not in uvx cache or uv unavailable, returns normally.
     """
     if os.environ.get(_REEXEC_MARKER) or not _is_uvx_cache():
         return
-    uvx_path = shutil.which("uvx")
-    if not uvx_path:
+
+    uv_path = _find_runtime_uv()
+    if not uv_path:
         return
+
     extras_str = ",".join(extras)
-    # Run agent-cli[extras] directly with Python 3.13 (some deps lack 3.14 wheels)
-    cmd = [uvx_path, "--python", "3.13", f"agent-cli[{extras_str}]", *sys.argv[1:]]
+    package_source = os.environ.get("AGENTCLI_PACKAGE_SOURCE", "agent-cli")
+    package_spec = f"{package_source}[{extras_str}]"
+    cmd = [
+        uv_path,
+        "tool",
+        "run",
+        "--python",
+        "3.13",
+        *_uv_tool_extra_args(extras, uv_available=True),
+        "--from",
+        package_spec,
+        "agent-cli",
+        *sys.argv[1:],
+    ]
     _maybe_exec_with_marker(cmd, f"Re-running with extras: {extras_str}")
 
 

--- a/tests/test_requires_extras.py
+++ b/tests/test_requires_extras.py
@@ -15,10 +15,12 @@ from agent_cli.core.deps import (
     EXTRAS,
     _check_and_install_extras,
     _find_python_incompatible_extras,
+    _find_runtime_uv,
     _get_auto_install_setting,
     _get_install_hint,
     _install_via_uv_tool,
     _maybe_reexec_after_install,
+    _maybe_reexec_with_uvx,
     _resolve_extras_for_install,
     _should_skip_extra_check_for_process_control,
     get_combined_install_hint,
@@ -296,6 +298,65 @@ class TestCheckAndInstallExtras:
             python_version=(3, 14),
             uv_available=False,
         ) == ["nemo-whisper"]
+
+    def test_python_incompatible_extra_detection_uses_bundled_uv(self, tmp_path: Path) -> None:
+        """Bundled uv should enable NeMo runtime overrides even when uv is not on PATH."""
+        uv_path = tmp_path / "uv"
+        uv_path.touch()
+        uv_path.chmod(0o755)
+
+        with (
+            patch.dict(os.environ, {"AGENTCLI_BUNDLED_UV": str(uv_path)}, clear=True),
+            patch("agent_cli.core.deps.shutil.which", return_value=None),
+        ):
+            assert _find_runtime_uv() == str(uv_path)
+            assert (
+                _find_python_incompatible_extras(
+                    ["nemo-whisper"],
+                    python_version=(3, 14),
+                )
+                == []
+            )
+
+    def test_uvx_cache_reexec_uses_bundled_uv_with_nemo_overrides(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uvx-cache NeMo commands should re-exec via bundled uv with runtime overrides."""
+        uv_path = tmp_path / "uv"
+        uv_path.touch()
+        uv_path.chmod(0o755)
+        package_source = tmp_path / "agent_cli.whl"
+        captured: dict[str, object] = {}
+
+        def fake_execvpe(file: str, cmd: list[str], env: dict[str, str]) -> None:
+            captured["file"] = file
+            captured["cmd"] = cmd
+            captured["env"] = env
+
+        monkeypatch.setenv("AGENTCLI_BUNDLED_UV", str(uv_path))
+        monkeypatch.setenv("AGENTCLI_PACKAGE_SOURCE", str(package_source))
+        monkeypatch.setattr("agent_cli.core.deps.shutil.which", lambda _: None)
+        monkeypatch.setattr("agent_cli.core.deps._is_uvx_cache", lambda: True)
+        monkeypatch.setattr("agent_cli.core.deps.os.execvpe", fake_execvpe)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["agent-cli", "server", "whisper", "--backend", "nemo"],
+        )
+
+        _maybe_reexec_with_uvx(["server", "nemo-whisper", "wyoming"])
+
+        cmd = captured["cmd"]
+        assert isinstance(cmd, list)
+        assert cmd[:5] == [str(uv_path), "tool", "run", "--python", "3.13"]
+        assert "--overrides" in cmd
+        assert "nemo-whisper.txt" in cmd[cmd.index("--overrides") + 1]
+        assert "--with" in cmd
+        assert (
+            "NVIDIA-NeMo/NeMo.git@be23ce1ee6594da3d7fa2f37e603d3b3ba230a9e"
+            in cmd[cmd.index("--with") + 1]
+        )
+        assert cmd[cmd.index("--from") + 1] == f"{package_source}[server,nemo-whisper,wyoming]"
+        assert cmd[-4:] == ["server", "whisper", "--backend", "nemo"]
 
     def test_uv_pip_install_uses_nemo_git_override(self) -> None:
         """Uv pip installs NeMo from a pinned Git revision with the kaldialign override."""


### PR DESCRIPTION
## Summary
- Use bundled app uv for runtime extra detection and installation when uv is not on PATH.
- Re-exec uvx-cache commands through `uv tool run --python 3.13` with NeMo override flags, preserving `AGENTCLI_PACKAGE_SOURCE`.
- Cover the launchd/bundled-uv NeMo daemon path without coupling daemon service config to Whisper internals.

## Test plan
- `uv run pytest tests/test_daemon.py tests/test_requires_extras.py tests/test_server_whisper.py tests/test_api_integration.py::test_server_whisper_backend_nemo_defaults_to_unified_parakeet -q`
- `uv run ruff check agent_cli/core/deps.py agent_cli/install/service_config.py tests/test_daemon.py tests/test_requires_extras.py`
- `uv run ruff format --check agent_cli/core/deps.py agent_cli/install/service_config.py tests/test_daemon.py tests/test_requires_extras.py`
- `git diff --check`