### PR TITLE
Fix NeMo daemon runtime and unified model load

### DIFF
--- a/agent_cli/install/launchd.py
+++ b/agent_cli/install/launchd.py
@@ -117,6 +117,7 @@ def _generate_plist(
         value = os.environ.get(key)
         if value:
             environment[key] = value
+    environment["AGENTCLI_UV_PATH"] = uv_path.as_posix()
 
     return {
         "Label": _get_label(service.name),

--- a/agent_cli/install/systemd.py
+++ b/agent_cli/install/systemd.py
@@ -104,12 +104,14 @@ def _generate_unit_file(
     exec_start = _format_exec_start(
         build_service_command(service, uv_path, extra_command_args=extra_command_args),
     )
+    uv_environment = _format_exec_start_arg(f"AGENTCLI_UV_PATH={uv_path}")
 
     return f"""[Unit]
 Description=agent-cli {service.display_name}
 After=network.target
 
 [Service]
+Environment={uv_environment}
 ExecStart={exec_start}
 Restart=on-failure
 RestartSec=5

--- a/agent_cli/server/whisper/backends/nemo.py
+++ b/agent_cli/server/whisper/backends/nemo.py
@@ -209,6 +209,40 @@ def _build_transcribe_kwargs(
     return transcribe_kwargs
 
 
+def _set_config_value(config: Any, key: str, value: Any) -> None:
+    """Set a NeMo config value, including OmegaConf configs in struct mode."""
+    try:
+        setattr(config, key, value)
+        return
+    except (AttributeError, TypeError):
+        if isinstance(config, dict):
+            config[key] = value
+            return
+        raise
+    except Exception:
+        from omegaconf import open_dict  # noqa: PLC0415
+
+        with open_dict(config):
+            setattr(config, key, value)
+
+
+def _ensure_validation_ds_config(model: Any) -> None:
+    """NeMo RNNT transcribe expects cfg.validation_ds to be a mapping."""
+    config = getattr(model, "cfg", None)
+    if config is None:
+        return
+
+    try:
+        validation_ds = (
+            config.get("validation_ds") if hasattr(config, "get") else config.validation_ds
+        )
+    except (AttributeError, KeyError):
+        return
+
+    if validation_ds is None:
+        _set_config_value(config, "validation_ds", {})
+
+
 def _load_model_in_subprocess(model_name: str, device: str) -> str:
     """Load model in subprocess. Returns actual device string."""
     import nemo.collections.asr as nemo_asr  # noqa: PLC0415
@@ -217,6 +251,7 @@ def _load_model_in_subprocess(model_name: str, device: str) -> str:
 
     resolved_device = _resolve_device(device)
     model = nemo_asr.models.ASRModel.from_pretrained(model_name=model_name)
+    _ensure_validation_ds_config(model)
     if hasattr(model, "to"):
         model = model.to(resolved_device)
     if hasattr(model, "eval"):

--- a/tests/install/test_launchd.py
+++ b/tests/install/test_launchd.py
@@ -25,6 +25,7 @@ def test_generate_plist_sets_path_for_homebrew_bins() -> None:
     assert "/opt/homebrew/bin" in path.split(":")
     assert "/usr/local/bin" in path.split(":")
     assert path.endswith("/usr/bin:/bin:/usr/sbin:/sbin")
+    assert plist["EnvironmentVariables"]["AGENTCLI_UV_PATH"] == "/opt/homebrew/bin/uv"
 
 
 def test_generate_plist_preserves_app_private_uv_environment(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -853,6 +853,7 @@ class TestSystemdModule:
         assert "[Install]" in unit_content
         assert "ExecStart=" in unit_content
         assert str(uv_path) in unit_content
+        assert "Environment=AGENTCLI_UV_PATH=uv" in unit_content
         assert "Restart=on-failure" in unit_content
 
     def test_systemd_generate_unit_file_appends_extra_args(self) -> None:

--- a/tests/test_nemo_backend.py
+++ b/tests/test_nemo_backend.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 def _install_mock_nemo(
     monkeypatch: pytest.MonkeyPatch,
     calls: dict[str, object],
+    *,
+    model: object | None = None,
 ) -> None:
     """Install a minimal mock of nemo.collections.asr in sys.modules."""
 
@@ -30,7 +32,7 @@ def _install_mock_nemo(
         @staticmethod
         def from_pretrained(*, model_name: str) -> object:
             calls["model_name"] = model_name
-            return object()
+            return model if model is not None else object()
 
     nemo_module: Any = ModuleType("nemo")
     collections_module: Any = ModuleType("nemo.collections")
@@ -233,6 +235,36 @@ def test_resolve_device_preserves_explicit_cpu(
     """Ensure explicit non-auto device values are preserved."""
     _install_mock_torch(monkeypatch, cuda_available=False)
     assert backend._resolve_device("cpu") == "cpu"
+
+
+def test_load_model_fills_missing_validation_ds_for_unified_parakeet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NeMo transcribe expects validation_ds to be a mapping, not None."""
+
+    class _Model:
+        def __init__(self) -> None:
+            self.cfg = SimpleNamespace(validation_ds=None)
+
+        def to(self, device: str) -> _Model:
+            assert device == "cpu"
+            return self
+
+        def eval(self) -> None:
+            return None
+
+    calls: dict[str, object] = {}
+    model = _Model()
+    _install_mock_torch(monkeypatch, cuda_available=False)
+    _install_mock_nemo(monkeypatch, calls, model=model)
+    monkeypatch.setattr(backend._state, "model", None)
+    monkeypatch.setattr(backend._state, "device", None)
+
+    assert backend._load_model_in_subprocess("nvidia/parakeet-unified-en-0.6b", "cpu") == "cpu"
+
+    assert calls["model_name"] == "nvidia/parakeet-unified-en-0.6b"
+    assert model.cfg.validation_ds == {}
+    assert backend._state.model is model
 
 
 def test_audio_duration_seconds_returns_zero_for_non_wav(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- propagate the daemon uv executable as AGENTCLI_UV_PATH so uvx-cache re-exec can find uv under launchd/systemd
- normalize NeMo models with cfg.validation_ds=None before transcribe; parakeet-unified-en-0.6b otherwise crashes inside NeMo RNNT transcribe
- add regression coverage for launchd/systemd env and unified Parakeet load

## Validation
- uv run pytest tests/test_daemon.py tests/install/test_launchd.py tests/test_requires_extras.py tests/test_nemo_backend.py tests/test_server_whisper.py tests/test_api_integration.py::test_server_whisper_backend_nemo_defaults_to_unified_parakeet -q
- uv run ruff check agent_cli/install/launchd.py agent_cli/install/systemd.py agent_cli/server/whisper/backends/nemo.py tests/install/test_launchd.py tests/test_daemon.py tests/test_nemo_backend.py
- uv run ruff format --check agent_cli/install/launchd.py agent_cli/install/systemd.py agent_cli/server/whisper/backends/nemo.py tests/install/test_launchd.py tests/test_daemon.py tests/test_nemo_backend.py
- local source live test: uvx re-exec, health, AIFF transcription with parakeet-unified-en-0.6b
- local source daemon live test: exact daemon install args, plist env, health, AIFF transcription