### PR TITLE
Reference upstream NeMo validation_ds fix

### DIFF
--- a/agent_cli/server/whisper/backends/nemo.py
+++ b/agent_cli/server/whisper/backends/nemo.py
@@ -240,6 +240,7 @@ def _ensure_validation_ds_config(model: Any) -> None:
         return
 
     if validation_ds is None:
+        # TODO(NVIDIA-NeMo/NeMo#15752): Drop after NeMo release.  # noqa: FIX002
         _set_config_value(config, "validation_ds", {})
 
 


### PR DESCRIPTION
## Summary
- add a TODO on the temporary NeMo `validation_ds` shim
- point it at NVIDIA-NeMo/NeMo#15752 so we know when this agent-cli workaround can go away

## Validation
- `uv run ruff check agent_cli/server/whisper/backends/nemo.py`
- `uv run ruff format --check agent_cli/server/whisper/backends/nemo.py`
- commit hooks also ran and passed
