### PR TITLE
Add macOS transcription TTL setting

### DIFF
--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -283,7 +283,37 @@ def _is_uv_cmd(cmd: list[str]) -> bool:
 
 def _uv_override_path(extra: str) -> Path:
     """Return the override file path for an extra."""
-    return _OVERRIDES_DIR / f"{extra}.txt"
+    source = _OVERRIDES_DIR / f"{extra}.txt"
+    if not _path_contains_whitespace(source):
+        return source
+    return _materialize_uv_override(source)
+
+
+def _path_contains_whitespace(path: Path) -> bool:
+    return any(character.isspace() for character in str(path))
+
+
+def _materialized_uv_overrides_dir() -> Path:
+    configured_dir = os.environ.get("AGENTCLI_UV_OVERRIDES_DIR")
+    if configured_dir:
+        configured_path = Path(configured_dir).expanduser()
+        if not _path_contains_whitespace(configured_path):
+            return configured_path
+
+    return Path.home() / ".cache" / "agent-cli" / "uv-overrides"
+
+
+def _materialize_uv_override(source: Path) -> Path:
+    """Copy a bundled override to a no-space path that uv can parse."""
+    target = _materialized_uv_overrides_dir() / source.name
+    try:
+        source_bytes = source.read_bytes()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists() or target.read_bytes() != source_bytes:
+            target.write_bytes(source_bytes)
+    except OSError:
+        return source
+    return target
 
 
 def _supports_uv_runtime_override(

--- a/agent_cli/core/deps.py
+++ b/agent_cli/core/deps.py
@@ -286,6 +286,8 @@ def _uv_override_path(extra: str) -> Path:
     source = _OVERRIDES_DIR / f"{extra}.txt"
     if not _path_contains_whitespace(source):
         return source
+    # uv mishandles --overrides paths with spaces (for example, app bundles
+    # installed under "Application Support"), so hand it a copied no-space path.
     return _materialize_uv_override(source)
 
 
@@ -300,6 +302,8 @@ def _materialized_uv_overrides_dir() -> Path:
         if not _path_contains_whitespace(configured_path):
             return configured_path
 
+    # Keep this outside AGENTCLI_APP_SUPPORT_DIR; that path usually contains a
+    # space on macOS and would reintroduce the launchd/uv parse failure.
     return Path.home() / ".cache" / "agent-cli" / "uv-overrides"
 
 

--- a/agent_cli/install/launchd.py
+++ b/agent_cli/install/launchd.py
@@ -88,16 +88,18 @@ def _get_recent_logs(service_name: str, num_lines: int = 10) -> list[str]:
 
     lines: list[str] = []
 
-    # Prefer stdout as it has structured output (startup message, usage examples)
-    # stderr often has noisy warnings from libraries like PyTorch/Kokoro
     for log_file in [stdout_log, stderr_log]:
         if log_file.exists():
             try:
                 with log_file.open() as f:
                     all_lines = f.readlines()
-                    lines = [line.rstrip() for line in all_lines[-num_lines:]]
+                    recent_lines = [line.rstrip() for line in all_lines[-num_lines:]]
+                    if not recent_lines:
+                        continue
                     if lines:
-                        break
+                        lines.append("")
+                    lines.append(f"==> {log_file.name} <==")
+                    lines.extend(recent_lines)
             except OSError:
                 continue
 

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -360,8 +360,10 @@ struct AgentRuntime {
         var contents = "runtimeMode=\(modeName)\npackageSource=\(agentCLIPackageSource)\n"
         if runtimeMode == .bundled {
             let backend = TranscriptionSettings.selectedBackend(userDefaults: userDefaults)
+            let ttlSeconds = TranscriptionSettings.selectedModelTTLSeconds(userDefaults: userDefaults)
             contents += "transcriptionBackend=\(backend.rawValue)\n"
             contents += "transcriptionModel=\(TranscriptionSettings.selectedModelName(userDefaults: userDefaults))\n"
+            contents += "transcriptionModelTTLSeconds=\(ttlSeconds)\n"
         }
         return contents
     }

--- a/macos/AgentCLI/Sources/AgentCLI/SettingsWindowController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/SettingsWindowController.swift
@@ -5,7 +5,7 @@ import SwiftUI
 final class SettingsWindowController {
     static let shared = SettingsWindowController()
 
-    private static let contentSize = NSSize(width: 460, height: 640)
+    private static let contentSize = NSSize(width: 460, height: 680)
 
     private var window: NSWindow?
 

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -285,6 +285,8 @@ struct SettingsView: View {
     private var transcriptionBackend = TranscriptionBackend.whisper.rawValue
     @AppStorage(TranscriptionSettings.transcriptionModelKey)
     private var transcriptionModel = TranscriptionBackend.whisper.defaultModelName
+    @AppStorage(TranscriptionSettings.transcriptionModelTTLSecondsKey)
+    private var transcriptionModelTTLSeconds = TranscriptionSettings.defaultModelTTLSeconds
     @AppStorage(TranscriptionSettings.transcriptionExtraInstructionsKey)
     private var transcriptionExtraInstructions = ""
     @State private var shortcutRevision = 0
@@ -335,13 +337,31 @@ struct SettingsView: View {
                 }
                 .pickerStyle(.menu)
                 .disabled(useUserInstalledAgentCLI)
+
+                Stepper(
+                    value: Binding(
+                        get: { max(0, transcriptionModelTTLSeconds) },
+                        set: { transcriptionModelTTLSeconds = max(0, $0) }
+                    ),
+                    in: 0...86_400,
+                    step: 60
+                ) {
+                    HStack {
+                        Text("Model TTL")
+                        Spacer()
+                        Text(Self.formatTTLSeconds(transcriptionModelTTLSeconds))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .disabled(useUserInstalledAgentCLI)
             } header: {
                 Text("Voice Service")
             } footer: {
                 Text(
                     useUserInstalledAgentCLI
                         ? "Disabled while User-Installed agent-cli is active."
-                        : "Changing these settings restarts the bundled voice service on next transcription."
+                        : "TTL is how long the selected model lives in memory after the last transcription. Set to 0 to keep it loaded until the voice service restarts."
                 )
             }
 
@@ -425,6 +445,26 @@ struct SettingsView: View {
         let backend = selectedTranscriptionBackend
         guard backend.modelOption(named: transcriptionModel) == nil else { return }
         transcriptionModel = backend.defaultModelName
+    }
+
+    private static func formatTTLSeconds(_ seconds: Int) -> String {
+        let clampedSeconds = max(0, seconds)
+        if clampedSeconds == 0 {
+            return "Never"
+        }
+        if clampedSeconds < 60 {
+            return "\(clampedSeconds)s"
+        }
+        if clampedSeconds < 3_600 {
+            return "\(clampedSeconds / 60)m"
+        }
+
+        let hours = clampedSeconds / 3_600
+        let minutes = (clampedSeconds % 3_600) / 60
+        if minutes == 0 {
+            return "\(hours)h"
+        }
+        return "\(hours)h \(minutes)m"
     }
 }
 

--- a/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/TranscriptionSettings.swift
@@ -61,6 +61,8 @@ enum TranscriptionSettings {
     static let transcriptionExtraInstructionsKey = "transcriptionExtraInstructions"
     static let transcriptionBackendKey = "transcriptionBackend"
     static let transcriptionModelKey = "transcriptionModel"
+    static let transcriptionModelTTLSecondsKey = "transcriptionModelTTLSeconds"
+    static let defaultModelTTLSeconds = 300
 
     static var extraInstructions: String {
         UserDefaults.standard.string(forKey: transcriptionExtraInstructionsKey) ?? ""
@@ -77,6 +79,13 @@ enum TranscriptionSettings {
         return backend.modelOption(named: storedModelName)?.id ?? backend.defaultModelName
     }
 
+    static func selectedModelTTLSeconds(userDefaults: UserDefaults = .standard) -> Int {
+        guard let storedValue = userDefaults.object(forKey: transcriptionModelTTLSecondsKey) as? NSNumber else {
+            return defaultModelTTLSeconds
+        }
+        return max(0, storedValue.intValue)
+    }
+
     static func whisperDaemonInstallArguments(userDefaults: UserDefaults = .standard) -> [String] {
         let backend = selectedBackend(userDefaults: userDefaults)
         return [
@@ -89,6 +98,8 @@ enum TranscriptionSettings {
             backend.cliBackend,
             "--model",
             selectedModelName(userDefaults: userDefaults),
+            "--ttl",
+            "\(selectedModelTTLSeconds(userDefaults: userDefaults))",
         ]
     }
 }

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -64,12 +64,32 @@ final class AgentCommandTests: XCTestCase {
                     "daemon", "install", "whisper", "-y", "--",
                     "--backend", "nemo",
                     "--model", "parakeet-tdt-0.6b-v3",
+                    "--ttl", "86400",
                 ]
             ),
             [
                 "daemon", "install", "whisper", "-y", "--",
                 "--backend", "nemo",
                 "--model", "parakeet-tdt-0.6b-v3",
+                "--ttl", "86400",
+            ]
+        )
+    }
+
+    func testTranscriptionDaemonArgumentsIncludeConfiguredTTL() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.transcription-ttl")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.transcription-ttl")
+        defaults.set("nemo", forKey: TranscriptionSettings.transcriptionBackendKey)
+        defaults.set("parakeet-unified-en-0.6b", forKey: TranscriptionSettings.transcriptionModelKey)
+        defaults.set(86400, forKey: TranscriptionSettings.transcriptionModelTTLSecondsKey)
+
+        XCTAssertEqual(
+            TranscriptionSettings.whisperDaemonInstallArguments(userDefaults: defaults),
+            [
+                "daemon", "install", "whisper", "-y", "--",
+                "--backend", "nemo",
+                "--model", "parakeet-unified-en-0.6b",
+                "--ttl", "86400",
             ]
         )
     }
@@ -220,7 +240,12 @@ final class AgentCommandTests: XCTestCase {
             userDefaults: defaults,
             processRunner: { _, arguments, _ in
                 processArguments.append(arguments)
-                if arguments == ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"] {
+                if arguments == [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "auto",
+                    "--model", "large-v3",
+                    "--ttl", "300",
+                ] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
                 }
@@ -241,7 +266,12 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(
             processArguments,
             [
-                ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"],
+                [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "auto",
+                    "--model", "large-v3",
+                    "--ttl", "300",
+                ],
             ]
         )
         XCTAssertEqual(phases, [.installingVoiceService, .waitingForVoiceService])
@@ -277,7 +307,12 @@ final class AgentCommandTests: XCTestCase {
             userDefaults: defaults,
             processRunner: { _, arguments, _ in
                 processArguments.append(arguments)
-                if arguments == ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"] {
+                if arguments == [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "auto",
+                    "--model", "large-v3",
+                    "--ttl", "300",
+                ] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
                 }
@@ -297,7 +332,12 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(
             processArguments,
             [
-                ["daemon", "install", "whisper", "-y", "--", "--backend", "auto", "--model", "large-v3"],
+                [
+                    "daemon", "install", "whisper", "-y", "--",
+                    "--backend", "auto",
+                    "--model", "large-v3",
+                    "--ttl", "300",
+                ],
             ]
         )
     }
@@ -339,6 +379,7 @@ final class AgentCommandTests: XCTestCase {
                     "daemon", "install", "whisper", "-y", "--",
                     "--backend", "nemo",
                     "--model", "parakeet-tdt-0.6b-v3",
+                    "--ttl", "300",
                 ] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
@@ -363,6 +404,7 @@ final class AgentCommandTests: XCTestCase {
                     "daemon", "install", "whisper", "-y", "--",
                     "--backend", "nemo",
                     "--model", "parakeet-tdt-0.6b-v3",
+                    "--ttl", "300",
                 ],
             ]
         )
@@ -413,6 +455,7 @@ final class AgentCommandTests: XCTestCase {
                     "daemon", "install", "whisper", "-y", "--",
                     "--backend", "nemo",
                     "--model", "parakeet-tdt-0.6b-v3",
+                    "--ttl", "300",
                 ] {
                     installedWhisper = true
                     return CommandResult(exitCode: 0, output: "Installed and started")
@@ -438,6 +481,7 @@ final class AgentCommandTests: XCTestCase {
                     "daemon", "install", "whisper", "-y", "--",
                     "--backend", "nemo",
                     "--model", "parakeet-tdt-0.6b-v3",
+                    "--ttl", "300",
                 ],
             ]
         )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,6 +12,8 @@ import pytest
 from typer.testing import CliRunner
 
 from agent_cli.cli import app
+from agent_cli.core import deps
+from agent_cli.install import launchd as launchd_module
 from agent_cli.install.launchd import _generate_plist as launchd_generate_plist
 from agent_cli.install.launchd import _get_log_command as launchd_get_log_command
 from agent_cli.install.launchd import _get_service_status as launchd_get_service_status
@@ -157,6 +159,34 @@ class TestServiceConfig:
 
         assert "agent-cli[server,nemo-whisper,wyoming]" in cmd
         assert cmd[cmd.index("--python") + 1] == "3.13"
+
+    def test_build_service_command_materializes_nemo_override_without_spaces(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """UV --overrides receives a copied no-space path for bundled app installs."""
+        uv_path = tmp_path / "uv"
+        uv_path.touch()
+        source_dir = tmp_path / "Application Support" / "AgentCLI" / "_overrides"
+        source_dir.mkdir(parents=True)
+        source_override = source_dir / "nemo-whisper.txt"
+        source_override.write_text("kaldialign==0.9.3\n")
+        materialized_dir = tmp_path / "agentcli-overrides"
+        monkeypatch.setattr(deps, "_OVERRIDES_DIR", source_dir)
+        monkeypatch.setattr(deps, "_find_runtime_uv", lambda: str(uv_path))
+        monkeypatch.setenv("AGENTCLI_UV_OVERRIDES_DIR", str(materialized_dir))
+
+        cmd = build_service_command(
+            SERVICES["whisper"],
+            uv_path,
+            use_macos_extra=True,
+            extra_command_args=["--backend", "nemo"],
+        )
+
+        override_path = Path(cmd[cmd.index("--overrides") + 1])
+        assert override_path == materialized_dir / "nemo-whisper.txt"
+        assert " " not in override_path.as_posix()
+        assert override_path.read_text() == source_override.read_text()
+        assert "agent-cli[server,nemo-whisper,wyoming]" in cmd
 
     def test_build_service_command_uses_app_package_source(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -762,6 +792,21 @@ class TestLaunchdModule:
         )
 
         assert plist["ProgramArguments"][-4:] == ["--model", "small", "--port", "10311"]
+
+    def test_launchd_recent_logs_include_stdout_and_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Status output should include stderr when stdout has stale startup logs."""
+        (tmp_path / "stdout.log").write_text("old large-v3 startup\n")
+        (tmp_path / "stderr.log").write_text("error: File not found: `Library/Application`\n")
+        monkeypatch.setattr(launchd_module, "_get_log_dir", lambda _service_name: tmp_path)
+
+        lines = launchd_module._get_recent_logs("whisper", 5)
+
+        assert "==> stdout.log <==" in lines
+        assert "old large-v3 startup" in lines
+        assert "==> stderr.log <==" in lines
+        assert "error: File not found: `Library/Application`" in lines
 
     @patch("subprocess.run")
     def test_launchd_get_service_status_not_installed(


### PR DESCRIPTION
## Summary
- add a macOS Voice Service TTL control that passes `--ttl` to the bundled Whisper/NeMo daemon
- include TTL in the daemon marker so changing it reinstalls the bundled voice service
- fix NeMo launchd installs by materializing uv override files to a no-space cache path before passing `--overrides`
- include both stdout and stderr in recent launchd status logs so crash-loop errors are visible instead of stale startup output

## Launchd finding
The current plist shape is otherwise correct for Parakeet: bundled uv, Python 3.13, NeMo extra/override, backend `nemo`, and model `parakeet-unified-en-0.6b`. The failure came from uv splitting the `--overrides` path under `Application Support`, producing `File not found: Library/Application`.

## Tests
- `uv run pytest tests/test_daemon.py`
- `uv run ruff check agent_cli/core/deps.py agent_cli/install/launchd.py tests/test_daemon.py`
- `swift test --package-path macos/AgentCLI`

`swift test --package-path macos/AgentCLI --enable-xctest` is blocked locally by CommandLineTools: `xcrun: error: unable to lookup item PlatformPath`.
