### PR TITLE
Fix early hold-to-transcribe release

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -3,6 +3,32 @@ import Carbon.HIToolbox
 import Foundation
 import KeyboardShortcuts
 
+struct HoldToTranscribeKeyState {
+    private(set) var isStartPendingOrRecording = false
+
+    mutating func requestStart() -> Bool {
+        guard !isStartPendingOrRecording else { return false }
+        isStartPendingOrRecording = true
+        return true
+    }
+
+    mutating func releaseNeedsStop() -> Bool {
+        guard isStartPendingOrRecording else { return false }
+        isStartPendingOrRecording = false
+        return true
+    }
+
+    mutating func completeStart(started: Bool) {
+        if !started {
+            isStartPendingOrRecording = false
+        }
+    }
+
+    mutating func reset() {
+        isStartPendingOrRecording = false
+    }
+}
+
 final class ConfigurableHotkeyController {
     static let shared = ConfigurableHotkeyController()
 
@@ -12,7 +38,7 @@ final class ConfigurableHotkeyController {
     private var runLoopSource: CFRunLoopSource?
     private var functionKeyIsDown = false
     private var suppressNextFunctionKeyRelease = false
-    private var holdToTranscribeIsRecording = false
+    private var holdToTranscribeKeyState = HoldToTranscribeKeyState()
     private var pendingHoldToTranscribeWorkItem: DispatchWorkItem?
     private let holdToTranscribeDelay: TimeInterval = 0.16
 
@@ -120,7 +146,7 @@ final class ConfigurableHotkeyController {
         runLoopSource = nil
         functionKeyIsDown = false
         suppressNextFunctionKeyRelease = false
-        holdToTranscribeIsRecording = false
+        holdToTranscribeKeyState.reset()
     }
 
     func resumeFunctionAwareHotkeysAfterAccessibilityReset(runner: AgentCommandRunner) {
@@ -169,7 +195,7 @@ final class ConfigurableHotkeyController {
             cancelPendingHoldToTranscribe()
             suppressNextFunctionKeyRelease = usesFunctionShortcut(shortcut)
 
-            if !isAutorepeat(event) && !holdToTranscribeIsRecording {
+            if !isAutorepeat(event) && !holdToTranscribeKeyState.isStartPendingOrRecording {
                 Task { @MainActor in
                     self.runner?.run(.toggleTranscription)
                 }
@@ -190,20 +216,21 @@ final class ConfigurableHotkeyController {
         }
 
         if type == .keyDown {
-            if !isAutorepeat(event) && !holdToTranscribeIsRecording {
+            if !isAutorepeat(event) && holdToTranscribeKeyState.requestStart() {
                 Task { @MainActor in
-                    guard let runner = self.runner else { return }
-                    if runner.beginHoldToTranscribe() {
-                        self.holdToTranscribeIsRecording = true
+                    guard let runner = self.runner else {
+                        self.holdToTranscribeKeyState.completeStart(started: false)
+                        return
                     }
+                    let started = runner.beginHoldToTranscribe()
+                    self.holdToTranscribeKeyState.completeStart(started: started)
                 }
             }
             return true
         }
 
         if type == .keyUp {
-            if holdToTranscribeIsRecording {
-                holdToTranscribeIsRecording = false
+            if holdToTranscribeKeyState.releaseNeedsStop() {
                 Task { @MainActor in
                     guard let runner = self.runner else { return }
                     runner.endHoldToTranscribe()
@@ -238,8 +265,7 @@ final class ConfigurableHotkeyController {
             return true
         }
 
-        if holdToTranscribeIsRecording {
-            holdToTranscribeIsRecording = false
+        if holdToTranscribeKeyState.releaseNeedsStop() {
             Task { @MainActor in
                 guard let runner = self.runner else { return }
                 runner.endHoldToTranscribe()
@@ -264,15 +290,19 @@ final class ConfigurableHotkeyController {
             }
 
             self.pendingHoldToTranscribeWorkItem = nil
+            guard self.holdToTranscribeKeyState.requestStart() else { return }
             Task { @MainActor in
                 if self.runner?.stopTranscriptionFromFunctionKeyIfNeeded() == true {
+                    self.holdToTranscribeKeyState.completeStart(started: false)
                     return
                 }
 
-                guard let runner = self.runner else { return }
-                if runner.beginHoldToTranscribe() {
-                    self.holdToTranscribeIsRecording = true
+                guard let runner = self.runner else {
+                    self.holdToTranscribeKeyState.completeStart(started: false)
+                    return
                 }
+                let started = runner.beginHoldToTranscribe()
+                self.holdToTranscribeKeyState.completeStart(started: started)
             }
         }
 

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -3,9 +3,9 @@ import Carbon.HIToolbox
 import Foundation
 import KeyboardShortcuts
 
-enum HoldToTranscribeKeyAction: Equatable {
+enum HoldToTranscribeStopDecision: Equatable {
     case none
-    case waitForStart
+    case deferUntilStartCompletes
     case stopNow
 }
 
@@ -33,20 +33,20 @@ struct HoldToTranscribeKeyState {
         return true
     }
 
-    mutating func release() -> HoldToTranscribeKeyAction {
+    mutating func releaseKey() -> HoldToTranscribeStopDecision {
         switch state {
         case .idle:
             return .none
         case .startPending:
             state = .startPending(releaseRequested: true)
-            return .waitForStart
+            return .deferUntilStartCompletes
         case .recording:
             state = .idle
             return .stopNow
         }
     }
 
-    mutating func completeStart(started: Bool) -> HoldToTranscribeKeyAction {
+    mutating func completeStart(started: Bool) -> HoldToTranscribeStopDecision {
         guard case let .startPending(releaseRequested) = state else { return .none }
         guard started else {
             state = .idle
@@ -116,10 +116,7 @@ final class ConfigurableHotkeyController {
                   !self.usesFunctionShortcut(shortcut) else {
                 return
             }
-            guard self.holdToTranscribeKeyState.requestStart() else { return }
-            Task { @MainActor in
-                self.finishHoldToTranscribeStart(runner: runner)
-            }
+            self.requestHoldToTranscribeStart(preferredRunner: runner)
         }
         KeyboardShortcuts.onKeyUp(for: .holdToTranscribe) {
             guard !ShortcutRecordingState.shared.isRecording,
@@ -127,7 +124,7 @@ final class ConfigurableHotkeyController {
                   !self.usesFunctionShortcut(shortcut) else {
                 return
             }
-            self.stopHoldToTranscribeIfNeeded(self.holdToTranscribeKeyState.release())
+            self.releaseHoldToTranscribeKey()
         }
     }
 
@@ -255,24 +252,14 @@ final class ConfigurableHotkeyController {
         }
 
         if type == .keyDown {
-            if !isAutorepeat(event) && holdToTranscribeKeyState.requestStart() {
-                Task { @MainActor in
-                    guard let runner = self.runner else {
-                        _ = self.holdToTranscribeKeyState.completeStart(started: false)
-                        return
-                    }
-                    let started = runner.beginHoldToTranscribe()
-                    let action = self.holdToTranscribeKeyState.completeStart(started: started)
-                    if action == .stopNow {
-                        runner.endHoldToTranscribe()
-                    }
-                }
+            if !isAutorepeat(event) {
+                requestHoldToTranscribeStart()
             }
             return true
         }
 
         if type == .keyUp {
-            stopHoldToTranscribeIfNeeded(holdToTranscribeKeyState.release())
+            releaseHoldToTranscribeKey()
             return true
         }
 
@@ -302,17 +289,7 @@ final class ConfigurableHotkeyController {
             return true
         }
 
-        let action = holdToTranscribeKeyState.release()
-        switch action {
-        case .stopNow:
-            stopHoldToTranscribeIfNeeded(action)
-        case .none:
-            Task { @MainActor in
-                _ = self.runner?.stopTranscriptionFromFunctionKeyIfNeeded()
-            }
-        case .waitForStart:
-            break
-        }
+        releaseHoldToTranscribeKey(stopExistingFunctionRecordingIfIdle: true)
 
         return true
     }
@@ -328,23 +305,7 @@ final class ConfigurableHotkeyController {
             }
 
             self.pendingHoldToTranscribeWorkItem = nil
-            guard self.holdToTranscribeKeyState.requestStart() else { return }
-            Task { @MainActor in
-                if self.runner?.stopTranscriptionFromFunctionKeyIfNeeded() == true {
-                    _ = self.holdToTranscribeKeyState.completeStart(started: false)
-                    return
-                }
-
-                guard let runner = self.runner else {
-                    _ = self.holdToTranscribeKeyState.completeStart(started: false)
-                    return
-                }
-                let started = runner.beginHoldToTranscribe()
-                let action = self.holdToTranscribeKeyState.completeStart(started: started)
-                if action == .stopNow {
-                    runner.endHoldToTranscribe()
-                }
-            }
+            self.requestHoldToTranscribeStart(stopExistingFunctionRecordingFirst: true)
         }
 
         pendingHoldToTranscribeWorkItem = workItem
@@ -358,6 +319,26 @@ final class ConfigurableHotkeyController {
         pendingHoldToTranscribeWorkItem = nil
     }
 
+    private func requestHoldToTranscribeStart(
+        preferredRunner: AgentCommandRunner? = nil,
+        stopExistingFunctionRecordingFirst: Bool = false
+    ) {
+        guard holdToTranscribeKeyState.requestStart() else { return }
+        Task { @MainActor in
+            if stopExistingFunctionRecordingFirst,
+               self.runner?.stopTranscriptionFromFunctionKeyIfNeeded() == true {
+                _ = self.holdToTranscribeKeyState.completeStart(started: false)
+                return
+            }
+
+            guard let runner = preferredRunner ?? self.runner else {
+                _ = self.holdToTranscribeKeyState.completeStart(started: false)
+                return
+            }
+            self.finishHoldToTranscribeStart(runner: runner)
+        }
+    }
+
     @MainActor
     private func finishHoldToTranscribeStart(runner: AgentCommandRunner) {
         let started = runner.beginHoldToTranscribe()
@@ -367,8 +348,22 @@ final class ConfigurableHotkeyController {
         }
     }
 
-    private func stopHoldToTranscribeIfNeeded(_ action: HoldToTranscribeKeyAction) {
-        guard action == .stopNow else { return }
+    private func releaseHoldToTranscribeKey(stopExistingFunctionRecordingIfIdle: Bool = false) {
+        switch holdToTranscribeKeyState.releaseKey() {
+        case .stopNow:
+            stopHoldToTranscribe()
+        case .none:
+            if stopExistingFunctionRecordingIfIdle {
+                Task { @MainActor in
+                    _ = self.runner?.stopTranscriptionFromFunctionKeyIfNeeded()
+                }
+            }
+        case .deferUntilStartCompletes:
+            break
+        }
+    }
+
+    private func stopHoldToTranscribe() {
         Task { @MainActor in
             guard let runner = self.runner else { return }
             runner.endHoldToTranscribe()

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -3,29 +3,67 @@ import Carbon.HIToolbox
 import Foundation
 import KeyboardShortcuts
 
+enum HoldToTranscribeKeyAction: Equatable {
+    case none
+    case waitForStart
+    case stopNow
+}
+
 struct HoldToTranscribeKeyState {
-    private(set) var isStartPendingOrRecording = false
-
-    mutating func requestStart() -> Bool {
-        guard !isStartPendingOrRecording else { return false }
-        isStartPendingOrRecording = true
-        return true
+    private enum State {
+        case idle
+        case startPending(releaseRequested: Bool)
+        case recording
     }
 
-    mutating func releaseNeedsStop() -> Bool {
-        guard isStartPendingOrRecording else { return false }
-        isStartPendingOrRecording = false
-        return true
-    }
+    private var state: State = .idle
 
-    mutating func completeStart(started: Bool) {
-        if !started {
-            isStartPendingOrRecording = false
+    var isStartPendingOrRecording: Bool {
+        switch state {
+        case .idle:
+            return false
+        case .startPending, .recording:
+            return true
         }
     }
 
+    mutating func requestStart() -> Bool {
+        guard case .idle = state else { return false }
+        state = .startPending(releaseRequested: false)
+        return true
+    }
+
+    mutating func release() -> HoldToTranscribeKeyAction {
+        switch state {
+        case .idle:
+            return .none
+        case .startPending:
+            state = .startPending(releaseRequested: true)
+            return .waitForStart
+        case .recording:
+            state = .idle
+            return .stopNow
+        }
+    }
+
+    mutating func completeStart(started: Bool) -> HoldToTranscribeKeyAction {
+        guard case let .startPending(releaseRequested) = state else { return .none }
+        guard started else {
+            state = .idle
+            return .none
+        }
+
+        if releaseRequested {
+            state = .idle
+            return .stopNow
+        }
+
+        state = .recording
+        return .none
+    }
+
     mutating func reset() {
-        isStartPendingOrRecording = false
+        state = .idle
     }
 }
 
@@ -78,8 +116,9 @@ final class ConfigurableHotkeyController {
                   !self.usesFunctionShortcut(shortcut) else {
                 return
             }
+            guard self.holdToTranscribeKeyState.requestStart() else { return }
             Task { @MainActor in
-                _ = runner.beginHoldToTranscribe()
+                self.finishHoldToTranscribeStart(runner: runner)
             }
         }
         KeyboardShortcuts.onKeyUp(for: .holdToTranscribe) {
@@ -88,7 +127,7 @@ final class ConfigurableHotkeyController {
                   !self.usesFunctionShortcut(shortcut) else {
                 return
             }
-            Task { @MainActor in runner.endHoldToTranscribe() }
+            self.stopHoldToTranscribeIfNeeded(self.holdToTranscribeKeyState.release())
         }
     }
 
@@ -219,23 +258,21 @@ final class ConfigurableHotkeyController {
             if !isAutorepeat(event) && holdToTranscribeKeyState.requestStart() {
                 Task { @MainActor in
                     guard let runner = self.runner else {
-                        self.holdToTranscribeKeyState.completeStart(started: false)
+                        _ = self.holdToTranscribeKeyState.completeStart(started: false)
                         return
                     }
                     let started = runner.beginHoldToTranscribe()
-                    self.holdToTranscribeKeyState.completeStart(started: started)
+                    let action = self.holdToTranscribeKeyState.completeStart(started: started)
+                    if action == .stopNow {
+                        runner.endHoldToTranscribe()
+                    }
                 }
             }
             return true
         }
 
         if type == .keyUp {
-            if holdToTranscribeKeyState.releaseNeedsStop() {
-                Task { @MainActor in
-                    guard let runner = self.runner else { return }
-                    runner.endHoldToTranscribe()
-                }
-            }
+            stopHoldToTranscribeIfNeeded(holdToTranscribeKeyState.release())
             return true
         }
 
@@ -265,15 +302,16 @@ final class ConfigurableHotkeyController {
             return true
         }
 
-        if holdToTranscribeKeyState.releaseNeedsStop() {
-            Task { @MainActor in
-                guard let runner = self.runner else { return }
-                runner.endHoldToTranscribe()
-            }
-        } else {
+        let action = holdToTranscribeKeyState.release()
+        switch action {
+        case .stopNow:
+            stopHoldToTranscribeIfNeeded(action)
+        case .none:
             Task { @MainActor in
                 _ = self.runner?.stopTranscriptionFromFunctionKeyIfNeeded()
             }
+        case .waitForStart:
+            break
         }
 
         return true
@@ -293,16 +331,19 @@ final class ConfigurableHotkeyController {
             guard self.holdToTranscribeKeyState.requestStart() else { return }
             Task { @MainActor in
                 if self.runner?.stopTranscriptionFromFunctionKeyIfNeeded() == true {
-                    self.holdToTranscribeKeyState.completeStart(started: false)
+                    _ = self.holdToTranscribeKeyState.completeStart(started: false)
                     return
                 }
 
                 guard let runner = self.runner else {
-                    self.holdToTranscribeKeyState.completeStart(started: false)
+                    _ = self.holdToTranscribeKeyState.completeStart(started: false)
                     return
                 }
                 let started = runner.beginHoldToTranscribe()
-                self.holdToTranscribeKeyState.completeStart(started: started)
+                let action = self.holdToTranscribeKeyState.completeStart(started: started)
+                if action == .stopNow {
+                    runner.endHoldToTranscribe()
+                }
             }
         }
 
@@ -315,6 +356,23 @@ final class ConfigurableHotkeyController {
     private func cancelPendingHoldToTranscribe() {
         pendingHoldToTranscribeWorkItem?.cancel()
         pendingHoldToTranscribeWorkItem = nil
+    }
+
+    @MainActor
+    private func finishHoldToTranscribeStart(runner: AgentCommandRunner) {
+        let started = runner.beginHoldToTranscribe()
+        let action = holdToTranscribeKeyState.completeStart(started: started)
+        if action == .stopNow {
+            runner.endHoldToTranscribe()
+        }
+    }
+
+    private func stopHoldToTranscribeIfNeeded(_ action: HoldToTranscribeKeyAction) {
+        guard action == .stopNow else { return }
+        Task { @MainActor in
+            guard let runner = self.runner else { return }
+            runner.endHoldToTranscribe()
+        }
     }
 
     private func shortcutMatches(type: CGEventType, event: CGEvent, shortcut: KeyboardShortcuts.Shortcut) -> Bool {

--- a/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
@@ -7,7 +7,7 @@ final class ConfigurableHotkeyControllerTests: XCTestCase {
         var state = HoldToTranscribeKeyState()
 
         XCTAssertTrue(state.requestStart())
-        XCTAssertEqual(state.release(), .waitForStart)
+        XCTAssertEqual(state.releaseKey(), .deferUntilStartCompletes)
 
         XCTAssertEqual(state.completeStart(started: true), .stopNow)
         XCTAssertFalse(state.isStartPendingOrRecording)
@@ -19,7 +19,7 @@ final class ConfigurableHotkeyControllerTests: XCTestCase {
         XCTAssertTrue(state.requestStart())
         XCTAssertEqual(state.completeStart(started: true), .none)
 
-        XCTAssertEqual(state.release(), .stopNow)
+        XCTAssertEqual(state.releaseKey(), .stopNow)
         XCTAssertFalse(state.isStartPendingOrRecording)
     }
 
@@ -27,7 +27,7 @@ final class ConfigurableHotkeyControllerTests: XCTestCase {
         var state = HoldToTranscribeKeyState()
 
         XCTAssertTrue(state.requestStart())
-        XCTAssertEqual(state.release(), .waitForStart)
+        XCTAssertEqual(state.releaseKey(), .deferUntilStartCompletes)
 
         XCTAssertEqual(state.completeStart(started: false), .none)
         XCTAssertFalse(state.isStartPendingOrRecording)

--- a/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
@@ -3,23 +3,34 @@ import XCTest
 @testable import AgentCLI
 
 final class ConfigurableHotkeyControllerTests: XCTestCase {
-    func testReleaseStopsPendingHoldStart() {
+    func testReleaseBeforeHoldStartCompletesStopsAfterSuccessfulStart() {
         var state = HoldToTranscribeKeyState()
 
         XCTAssertTrue(state.requestStart())
-        XCTAssertTrue(state.releaseNeedsStop())
-        state.completeStart(started: true)
+        XCTAssertEqual(state.release(), .waitForStart)
 
-        XCTAssertFalse(state.releaseNeedsStop())
+        XCTAssertEqual(state.completeStart(started: true), .stopNow)
+        XCTAssertFalse(state.isStartPendingOrRecording)
     }
 
-    func testFailedHoldStartClearsPendingState() {
+    func testReleaseAfterHoldStartStopsImmediately() {
         var state = HoldToTranscribeKeyState()
 
         XCTAssertTrue(state.requestStart())
-        state.completeStart(started: false)
+        XCTAssertEqual(state.completeStart(started: true), .none)
 
-        XCTAssertFalse(state.releaseNeedsStop())
+        XCTAssertEqual(state.release(), .stopNow)
+        XCTAssertFalse(state.isStartPendingOrRecording)
+    }
+
+    func testFailedHoldStartAfterReleaseClearsPendingStateWithoutStop() {
+        var state = HoldToTranscribeKeyState()
+
+        XCTAssertTrue(state.requestStart())
+        XCTAssertEqual(state.release(), .waitForStart)
+
+        XCTAssertEqual(state.completeStart(started: false), .none)
+        XCTAssertFalse(state.isStartPendingOrRecording)
     }
 }
 #endif

--- a/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/ConfigurableHotkeyControllerTests.swift
@@ -1,0 +1,25 @@
+#if canImport(XCTest)
+import XCTest
+@testable import AgentCLI
+
+final class ConfigurableHotkeyControllerTests: XCTestCase {
+    func testReleaseStopsPendingHoldStart() {
+        var state = HoldToTranscribeKeyState()
+
+        XCTAssertTrue(state.requestStart())
+        XCTAssertTrue(state.releaseNeedsStop())
+        state.completeStart(started: true)
+
+        XCTAssertFalse(state.releaseNeedsStop())
+    }
+
+    func testFailedHoldStartClearsPendingState() {
+        var state = HoldToTranscribeKeyState()
+
+        XCTAssertTrue(state.requestStart())
+        state.completeStart(started: false)
+
+        XCTAssertFalse(state.releaseNeedsStop())
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- track hold-to-transcribe as soon as a function-key start is requested, not only after the async start runs
- make an early key release schedule the stop path even while voice-service bootstrap or model warm-up is still running
- add small state tests covering release-before-start and failed-start cleanup

## Tests
- `swift test --package-path macos/AgentCLI`
- `git diff --check origin/main..HEAD`

`swift test --package-path macos/AgentCLI --enable-xctest` is still blocked locally by CommandLineTools: `xcrun: error: unable to lookup item PlatformPath`.
