### PR TITLE
Use MPS for NeMo on Apple Silicon

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -351,7 +351,7 @@ def whisper_cmd(  # noqa: C901, PLR0912, PLR0915
             "--device",
             "-d",
             help=(
-                "Compute device: `auto` (detect GPU), `cuda`, `cuda:0`, `cpu`. "
+                "Compute device: `auto` (detect GPU), `cuda`, `cuda:0`, `mps`, `cpu`. "
                 "MLX backend always uses Apple Silicon"
             ),
         ),

--- a/agent_cli/server/whisper/backends/nemo.py
+++ b/agent_cli/server/whisper/backends/nemo.py
@@ -6,6 +6,8 @@ import asyncio
 import inspect
 import io
 import logging
+import os
+import sys
 import tempfile
 import time
 import wave
@@ -89,16 +91,33 @@ _state = _SubprocessState()
 
 def _resolve_device(device: str) -> str:
     """Resolve the runtime device for NeMo inference."""
+    if device in {"auto", "mps"} and sys.platform == "darwin":
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
     import torch  # noqa: PLC0415
 
     if device == "auto":
-        return "cuda" if torch.cuda.is_available() else "cpu"
+        if torch.cuda.is_available():
+            return "cuda"
+        if _mps_available(torch):
+            return "mps"
+        return "cpu"
 
     if device.startswith("cuda") and not torch.cuda.is_available():
         msg = f"CUDA device requested ({device}) but CUDA is not available"
         raise RuntimeError(msg)
 
+    if device == "mps" and not _mps_available(torch):
+        msg = "MPS device requested (mps) but MPS is not available"
+        raise RuntimeError(msg)
+
     return device
+
+
+def _mps_available(torch: Any) -> bool:
+    """Return True when PyTorch exposes an available MPS backend."""
+    mps = getattr(getattr(torch, "backends", None), "mps", None)
+    return bool(mps is not None and mps.is_available())
 
 
 def _extract_text(hypothesis: Any) -> str:

--- a/docs/commands/server/whisper.md
+++ b/docs/commands/server/whisper.md
@@ -112,7 +112,7 @@ agent-cli server whisper \
 |--------|---------|-------------|
 | `--model, -m` | - | Whisper model(s) to load. Common models: `tiny`, `base`, `small`, `medium`, `large-v3`, `distil-large-v3`, `parakeet-tdt-0.6b-v3`, `parakeet-unified-en-0.6b` (NeMo backend). Can specify multiple for different accuracy/speed tradeoffs. Default: `large-v3` (`parakeet-unified-en-0.6b` with `--backend nemo`) |
 | `--default-model` | - | Model to use when client doesn't specify one. Must be in the `--model` list |
-| `--device, -d` | `auto` | Compute device: `auto` (detect GPU), `cuda`, `cuda:0`, `cpu`. MLX backend always uses Apple Silicon |
+| `--device, -d` | `auto` | Compute device: `auto` (detect GPU), `cuda`, `cuda:0`, `mps`, `cpu`. MLX backend always uses Apple Silicon |
 | `--compute-type` | `auto` | Precision for faster-whisper: `auto`, `float16`, `int8`, `int8_float16`. Lower precision = faster + less VRAM |
 | `--cache-dir` | - | Custom directory for downloaded models (default: HuggingFace cache) |
 | `--default-language` | - | Fallback language code for requests that omit `language`. Required for models that do not support language auto-detection (for example Cohere Transcribe). |
@@ -268,6 +268,13 @@ pip install "agent-cli[mlx-whisper]"
 ```
 
 The server will automatically detect and use the MLX backend when available.
+
+For NeMo/Parakeet models on Apple Silicon, `--device auto` uses PyTorch MPS when
+available. You can also request it explicitly:
+
+```bash
+agent-cli server whisper --backend nemo --model parakeet-unified-en-0.6b --device mps
+```
 
 ### HuggingFace Transformers
 

--- a/tests/test_nemo_backend.py
+++ b/tests/test_nemo_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 import wave
 from concurrent.futures import ThreadPoolExecutor
@@ -47,16 +48,27 @@ def _install_mock_nemo(
     monkeypatch.setitem(sys.modules, "nemo.collections.asr", asr_module)
 
 
-def _install_mock_torch(monkeypatch: pytest.MonkeyPatch, *, cuda_available: bool) -> None:
-    """Install a minimal mock torch module exposing cuda.is_available()."""
+def _install_mock_torch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cuda_available: bool,
+    mps_available: bool = False,
+) -> None:
+    """Install a minimal mock torch module exposing device availability."""
 
     class _Cuda:
         @staticmethod
         def is_available() -> bool:
             return cuda_available
 
+    class _Mps:
+        @staticmethod
+        def is_available() -> bool:
+            return mps_available
+
     torch_module: Any = ModuleType("torch")
     torch_module.cuda = _Cuda()
+    torch_module.backends = SimpleNamespace(mps=_Mps())
     monkeypatch.setitem(sys.modules, "torch", torch_module)
 
 
@@ -207,15 +219,27 @@ def test_resolve_device_auto_uses_cuda_when_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure auto device selection prefers CUDA when available."""
-    _install_mock_torch(monkeypatch, cuda_available=True)
+    _install_mock_torch(monkeypatch, cuda_available=True, mps_available=True)
     assert backend._resolve_device("auto") == "cuda"
+
+
+def test_resolve_device_auto_uses_mps_when_cuda_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure auto device selection uses Apple GPU when CUDA is unavailable."""
+    monkeypatch.delenv("PYTORCH_ENABLE_MPS_FALLBACK", raising=False)
+    monkeypatch.setattr(backend.sys, "platform", "darwin")
+    _install_mock_torch(monkeypatch, cuda_available=False, mps_available=True)
+
+    assert backend._resolve_device("auto") == "mps"
+    assert os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] == "1"
 
 
 def test_resolve_device_auto_falls_back_to_cpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure auto device selection falls back to CPU."""
-    _install_mock_torch(monkeypatch, cuda_available=False)
+    _install_mock_torch(monkeypatch, cuda_available=False, mps_available=False)
     assert backend._resolve_device("auto") == "cpu"
 
 
@@ -227,6 +251,16 @@ def test_resolve_device_explicit_cuda_requires_available_cuda(
 
     with pytest.raises(RuntimeError, match="CUDA device requested"):
         backend._resolve_device("cuda:0")
+
+
+def test_resolve_device_explicit_mps_requires_available_mps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure explicit MPS requests fail fast when MPS is unavailable."""
+    _install_mock_torch(monkeypatch, cuda_available=False, mps_available=False)
+
+    with pytest.raises(RuntimeError, match="MPS device requested"):
+        backend._resolve_device("mps")
 
 
 def test_resolve_device_preserves_explicit_cpu(


### PR DESCRIPTION
## Summary
- let the NeMo backend use PyTorch MPS when `--device auto` runs on Apple Silicon and CUDA is unavailable
- validate explicit `--device mps` and fail fast if PyTorch has no MPS backend
- set `PYTORCH_ENABLE_MPS_FALLBACK=1` before importing torch for NeMo MPS loads
- document the NeMo/Parakeet MPS path

## Why
Parakeet through NeMo was always reporting `device=cpu` on Macs. I tested `parakeet-unified-en-0.6b` with `--device mps` locally and it loads/transcribes correctly. On the same sample file, warm HTTP requests were about 1.6s on CPU and about 0.65s on MPS.

This is PyTorch MPS, not MLX. The MLX backend remains Whisper-only.

## Validation
- `PYTORCH_ENABLE_MPS_FALLBACK=1 ag server whisper --backend nemo --model parakeet-unified-en-0.6b --device mps --host 127.0.0.1 --port 10401 --no-wyoming --ttl 0 --preload`
- `curl -X POST http://127.0.0.1:10401/v1/audio/transcriptions -F file=@.../sample.wav -F model=parakeet-unified-en-0.6b`
- `uv run pytest tests/test_nemo_backend.py tests/test_server_whisper.py -q`
- `uv run ruff check agent_cli/server/whisper/backends/nemo.py agent_cli/server/cli.py tests/test_nemo_backend.py`
- `uv run ruff format --check agent_cli/server/whisper/backends/nemo.py agent_cli/server/cli.py tests/test_nemo_backend.py`
- `uv run markdown-code-runner docs/commands/server/whisper.md`
