### PR TITLE
Fix macOS voice level meter input source

### DIFF
--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -10,14 +10,14 @@ import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path  # noqa: TC003
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import typer
 
 from agent_cli import config, opts
 from agent_cli.cli import app
 from agent_cli.core import process
-from agent_cli.core.audio import setup_devices
+from agent_cli.core.audio import AudioLevelLogWriter, setup_devices
 from agent_cli.core.deps import requires_extras
 from agent_cli.core.diarization import (
     SpeakerDiarizer,
@@ -53,6 +53,9 @@ from agent_cli.services.asr import (
 from agent_cli.services.llm import process_and_update_clipboard
 
 LOGGER = logging.getLogger()
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class TranscriptResult(TypedDict, total=False):
@@ -361,6 +364,7 @@ async def _async_main(  # noqa: PLR0912, PLR0915, C901
     diarization_cfg: config.Diarization | None = None,
     emit_output: bool = True,
     raise_diarization_errors: bool = False,
+    audio_level_callback: Callable[[bytes], None] | None = None,
 ) -> TranscriptResult:
     """Unified async entry point for both live and file-based transcription."""
     start_time = time.monotonic()
@@ -451,6 +455,7 @@ async def _async_main(  # noqa: PLR0912, PLR0915, C901
                     save_recording=save_recording,
                     extra_instructions=extra_instructions,
                     recording_path_callback=_set_saved_recording_path,
+                    audio_level_callback=audio_level_callback,
                 )
 
         elapsed = time.monotonic() - start_time
@@ -641,6 +646,7 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     config_file: str | None = opts.CONFIG_FILE,
     print_args: bool = opts.PRINT_ARGS,
     transcription_log: Path | None = opts.TRANSCRIPTION_LOG,
+    voice_level_log: Path | None = opts.VOICE_LEVEL_LOG,
     # --- Diarization Options ---
     diarize: bool = opts.DIARIZE,
     diarize_format: opts.DiarizeFormat = opts.DIARIZE_FORMAT,
@@ -691,6 +697,9 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     # Expand user path for transcription log
     if transcription_log:
         transcription_log = transcription_log.expanduser()
+    voice_level_log = _option_default(voice_level_log)
+    if voice_level_log:
+        voice_level_log = voice_level_log.expanduser()
 
     enroll_speakers = _option_default(enroll_speakers)
     identify_speakers = _option_default(identify_speakers)
@@ -895,6 +904,7 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     # Use context manager before audio setup so --stop can target startup reliably.
     try:
         with process.pid_file_context(process_name), suppress(KeyboardInterrupt):
+            audio_level_writer = AudioLevelLogWriter(voice_level_log) if voice_level_log else None
             audio_in_cfg = config.AudioInput(
                 input_device_index=input_device_index,
                 input_device_name=input_device_name,
@@ -926,6 +936,9 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
                     diarization_cfg=diarization_cfg,
                     emit_output=not json_output,
                     raise_diarization_errors=diarize,
+                    audio_level_callback=audio_level_writer.write_chunk
+                    if audio_level_writer
+                    else None,
                 ),
             )
     except ImportError as exc:

--- a/agent_cli/agents/voice_edit.py
+++ b/agent_cli/agents/voice_edit.py
@@ -46,7 +46,7 @@ from agent_cli.agents._voice_agent_common import (
 )
 from agent_cli.cli import app
 from agent_cli.core import process
-from agent_cli.core.audio import setup_devices
+from agent_cli.core.audio import AudioLevelLogWriter, setup_devices
 from agent_cli.core.deps import requires_extras
 from agent_cli.core.utils import (
     enable_json_mode,
@@ -106,6 +106,7 @@ async def _async_main(
     openai_tts_cfg: config.OpenAITTS,
     kokoro_tts_cfg: config.KokoroTTS,
     gemini_tts_cfg: config.GeminiTTS,
+    audio_level_log: Path | None = None,
 ) -> str | None:
     """Core asynchronous logic for the voice assistant."""
     device_info = setup_devices(general_cfg, audio_in_cfg, audio_out_cfg)
@@ -114,6 +115,7 @@ async def _async_main(
     input_device_index, _, tts_output_device_index = device_info
     audio_in_cfg.input_device_index = input_device_index
     audio_out_cfg.output_device_index = tts_output_device_index
+    audio_level_writer = AudioLevelLogWriter(audio_level_log) if audio_level_log else None
 
     original_text = get_clipboard_text()
     if original_text is None:
@@ -132,6 +134,7 @@ async def _async_main(
             LOGGER,
             live=live,
             quiet=general_cfg.quiet,
+            audio_level_callback=audio_level_writer.write_chunk if audio_level_writer else None,
         )
 
         if not audio_data:
@@ -226,6 +229,7 @@ def voice_edit(
     list_devices: bool = opts.LIST_DEVICES,
     quiet: bool = opts.QUIET,
     json_output: bool = opts.JSON_OUTPUT,
+    voice_level_log: Path | None = opts.VOICE_LEVEL_LOG,
     config_file: str | None = opts.CONFIG_FILE,
     print_args: bool = opts.PRINT_ARGS,
 ) -> None:
@@ -255,6 +259,9 @@ def voice_edit(
         enable_json_mode()
 
     setup_logging(log_level, log_file, quiet=effective_quiet)
+    voice_level_log = getattr(voice_level_log, "default", voice_level_log)
+    if voice_level_log:
+        voice_level_log = voice_level_log.expanduser()
     general_cfg = config.General(
         log_level=log_level,
         log_file=log_file,
@@ -293,6 +300,7 @@ def voice_edit(
                 openai_tts_cfg=cfgs.openai_tts,
                 kokoro_tts_cfg=cfgs.kokoro_tts,
                 gemini_tts_cfg=cfgs.gemini_tts,
+                audio_level_log=voice_level_log,
             ),
         )
         if json_output:

--- a/agent_cli/core/audio.py
+++ b/agent_cli/core/audio.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import json
 import logging
+import math
+import struct
 import threading
+import time
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 
 from rich.text import Text
@@ -22,6 +27,7 @@ from agent_cli.core.utils import (
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+    from pathlib import Path
 
     import sounddevice as sd
     from rich.live import Live
@@ -30,6 +36,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 _AUDIO_SHUTDOWN_TIMEOUT_SECONDS = 0.5
+_MINIMUM_INPUT_DECIBELS = -55.0
 
 
 @dataclass
@@ -62,6 +69,74 @@ class StreamConfig:
             channels=self.channels,
             dtype=self.dtype,
         )
+
+
+def normalized_audio_level(chunk: bytes) -> float:
+    """Return a 0...1 speech level from mono little-endian int16 PCM."""
+    sample_count = len(chunk) // constants.AUDIO_FORMAT_WIDTH
+    if sample_count <= 0:
+        return 0.0
+
+    pcm = chunk[: sample_count * constants.AUDIO_FORMAT_WIDTH]
+    samples = struct.unpack(f"<{sample_count}h", pcm)
+    mean_square = sum((sample / 32768.0) ** 2 for sample in samples) / sample_count
+    if mean_square <= 0:
+        return 0.0
+
+    root_mean_square = math.sqrt(mean_square)
+    decibels = 20 * math.log10(root_mean_square)
+    if decibels <= _MINIMUM_INPUT_DECIBELS:
+        return 0.0
+
+    linear_level = (decibels - _MINIMUM_INPUT_DECIBELS) / abs(_MINIMUM_INPUT_DECIBELS)
+    return min(1.0, math.sqrt(linear_level))
+
+
+class AudioLevelLogWriter:
+    """Append normalized audio levels for UI consumers."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        interval_seconds: float = 0.05,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        timestamp_clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        """Create a writer and clear stale samples at the destination."""
+        self.path = path.expanduser()
+        self.interval_seconds = interval_seconds
+        self.monotonic_clock = monotonic_clock
+        self.timestamp_clock = timestamp_clock
+        self._last_write = -math.inf
+        self._enabled = True
+        self._lock = threading.Lock()
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text("")
+        except OSError:
+            self._enabled = False
+
+    def write_chunk(self, chunk: bytes) -> None:
+        """Append one normalized level sample for a PCM chunk."""
+        with self._lock:
+            if not self._enabled:
+                return
+            now = self.monotonic_clock()
+            if now - self._last_write < self.interval_seconds:
+                return
+            self._last_write = now
+
+            entry = {
+                "timestamp": self.timestamp_clock().isoformat(),
+                "level": round(normalized_audio_level(chunk), 4),
+            }
+            try:
+                with self.path.open("a", encoding="utf-8") as file:
+                    file.write(json.dumps(entry, separators=(",", ":")))
+                    file.write("\n")
+            except OSError:
+                self._enabled = False
 
 
 class _AudioTee:

--- a/agent_cli/opts.py
+++ b/agent_cli/opts.py
@@ -429,6 +429,13 @@ TRANSCRIPTION_LOG: Path | None = typer.Option(
     "Recent entries provide context for LLM cleanup.",
     rich_help_panel="General Options",
 )
+VOICE_LEVEL_LOG: Path | None = typer.Option(
+    None,
+    "--voice-level-log",
+    help="Append normalized microphone levels to a JSONL file for UI indicators.",
+    hidden=True,
+    rich_help_panel="General Options",
+)
 
 # --- Server Options ---
 SERVER_HOST: str = typer.Option(

--- a/agent_cli/services/asr.py
+++ b/agent_cli/services/asr.py
@@ -210,6 +210,31 @@ def create_recorded_audio_transcriber(
     raise ValueError(msg)
 
 
+def _schedule_audio_level_callback(
+    pending_tasks: set[asyncio.Task[None]],
+    audio_level_callback: Callable[[bytes], None],
+    chunk: bytes,
+    logger: logging.Logger,
+) -> None:
+    """Run level callbacks off the event loop so UI metering cannot delay ASR sends."""
+
+    async def run_callback() -> None:
+        try:
+            await asyncio.to_thread(audio_level_callback, chunk)
+        except Exception:
+            logger.exception("Audio level callback failed")
+
+    task = asyncio.create_task(run_callback())
+    pending_tasks.add(task)
+    task.add_done_callback(pending_tasks.discard)
+
+
+async def _finish_audio_level_callbacks(pending_tasks: set[asyncio.Task[None]]) -> None:
+    """Wait for scheduled level callbacks to finish before returning."""
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+
 async def _send_audio(
     client: AsyncClient,
     stream: sd.InputStream,
@@ -221,6 +246,7 @@ async def _send_audio(
     save_recording: bool = True,
     initial_prompt: str | None = None,
     recording_path_callback: Callable[[Path], None] | None = None,
+    audio_level_callback: Callable[[bytes], None] | None = None,
 ) -> None:
     """Read from mic and send to Wyoming server."""
     from wyoming.asr import Transcribe  # noqa: PLC0415
@@ -233,11 +259,19 @@ async def _send_audio(
 
     # Buffer to save audio if requested
     audio_buffer = io.BytesIO() if save_recording else None
+    pending_audio_level_tasks: set[asyncio.Task[None]] = set()
 
     async def send_chunk(chunk: bytes) -> None:
         """Send audio chunk to ASR server and optionally buffer it."""
         if audio_buffer is not None:
             audio_buffer.write(chunk)
+        if audio_level_callback:
+            _schedule_audio_level_callback(
+                pending_audio_level_tasks,
+                audio_level_callback,
+                chunk,
+                logger,
+            )
         await client.write_event(AudioChunk(audio=chunk, **constants.WYOMING_AUDIO_CONFIG).event())
 
     try:
@@ -252,16 +286,19 @@ async def _send_audio(
             progress_style="blue",
         )
     finally:
-        await client.write_event(AudioStop().event())
-        logger.debug("Sent AudioStop")
+        try:
+            await client.write_event(AudioStop().event())
+            logger.debug("Sent AudioStop")
 
-        # Save the recording to disk if requested
-        if save_recording and audio_buffer:
-            audio_data = audio_buffer.getvalue()
-            if audio_data:
-                saved_path = _save_audio_to_file(audio_data, logger)
-                if saved_path and recording_path_callback:
-                    recording_path_callback(saved_path)
+            # Save the recording to disk if requested
+            if save_recording and audio_buffer:
+                audio_data = audio_buffer.getvalue()
+                if audio_data:
+                    saved_path = _save_audio_to_file(audio_data, logger)
+                    if saved_path and recording_path_callback:
+                        recording_path_callback(saved_path)
+        finally:
+            await _finish_audio_level_callbacks(pending_audio_level_tasks)
 
 
 async def record_audio_to_buffer(queue: asyncio.Queue, logger: logging.Logger) -> bytes:
@@ -328,6 +365,7 @@ async def record_audio_with_manual_stop(
     live: Live | None = None,
     save_recording: bool = True,
     recording_path_callback: Callable[[Path], None] | None = None,
+    audio_level_callback: Callable[[bytes], None] | None = None,
 ) -> bytes:
     """Record audio to a buffer using a manual stop signal.
 
@@ -339,29 +377,41 @@ async def record_audio_with_manual_stop(
         live: Rich Live display for progress
         save_recording: If True, save the recording to disk
         recording_path_callback: Optional callback invoked with the saved WAV path.
+        audio_level_callback: Optional callback invoked with each PCM chunk.
 
     Returns:
         The recorded audio data as bytes
 
     """
     audio_buffer = io.BytesIO()
+    pending_audio_level_tasks: set[asyncio.Task[None]] = set()
 
     def buffer_chunk(chunk: bytes) -> None:
         """Buffer audio chunk."""
         audio_buffer.write(chunk)
+        if audio_level_callback:
+            _schedule_audio_level_callback(
+                pending_audio_level_tasks,
+                audio_level_callback,
+                chunk,
+                logger,
+            )
 
     stream_config = setup_input_stream(input_device_index)
     with open_audio_stream(stream_config) as stream:
-        await read_audio_stream(
-            stream=stream,
-            stop_event=stop_event,
-            chunk_handler=buffer_chunk,
-            logger=logger,
-            live=live,
-            quiet=quiet,
-            progress_message="Recording",
-            progress_style="green",
-        )
+        try:
+            await read_audio_stream(
+                stream=stream,
+                stop_event=stop_event,
+                chunk_handler=buffer_chunk,
+                logger=logger,
+                live=live,
+                quiet=quiet,
+                progress_message="Recording",
+                progress_style="green",
+            )
+        finally:
+            await _finish_audio_level_callbacks(pending_audio_level_tasks)
 
     audio_data = audio_buffer.getvalue()
 
@@ -431,6 +481,7 @@ async def _transcribe_live_audio_wyoming(
     final_callback: Callable[[str], None] | None = None,
     extra_instructions: str | None = None,
     recording_path_callback: Callable[[Path], None] | None = None,
+    audio_level_callback: Callable[[bytes], None] | None = None,
     **_kwargs: object,
 ) -> str | None:
     """Unified ASR transcription function."""
@@ -460,6 +511,7 @@ async def _transcribe_live_audio_wyoming(
                         save_recording=save_recording,
                         initial_prompt=effective_prompt,
                         recording_path_callback=recording_path_callback,
+                        audio_level_callback=audio_level_callback,
                     ),
                     _receive_transcript(
                         client,
@@ -488,6 +540,7 @@ async def _transcribe_live_audio_buffered(
     save_recording: bool = True,
     extra_instructions: str | None = None,
     recording_path_callback: Callable[[Path], None] | None = None,
+    audio_level_callback: Callable[[bytes], None] | None = None,
     **_kwargs: object,
 ) -> str | None:
     """Record audio to buffer, then transcribe.
@@ -502,6 +555,7 @@ async def _transcribe_live_audio_buffered(
         live=live,
         save_recording=save_recording,
         recording_path_callback=recording_path_callback,
+        audio_level_callback=audio_level_callback,
     )
     if not audio_data:
         return None

--- a/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentCommand.swift
@@ -76,6 +76,8 @@ struct AgentCommand {
             "transcribe",
             "--toggle",
             "--quiet",
+            "--voice-level-log",
+            VoiceLevelLog.defaultLogPath,
             "--transcription-log",
             RecentTranscriptionReader.defaultLogPath,
         ],
@@ -97,7 +99,13 @@ struct AgentCommand {
     static let voiceEdit = AgentCommand(
         identifier: "voice-edit",
         title: "Voice Edit Clipboard",
-        arguments: ["voice-edit", "--toggle", "--quiet"],
+        arguments: [
+            "voice-edit",
+            "--toggle",
+            "--quiet",
+            "--voice-level-log",
+            VoiceLevelLog.defaultLogPath,
+        ],
         bootstrapRequirement: .transcription,
         showsRecordingIndicator: true,
         startNotificationTitle: "Voice Edit Started",

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -177,6 +177,17 @@ struct AgentRuntime {
             }
         }
 
+        if CommandLine.arguments.contains("--agentcli-voice-level-self-test") {
+            do {
+                try Self.runVoiceLevelSelfTest()
+                print("AgentCLI voice-level self-test ok")
+                exit(0)
+            } catch {
+                print("AgentCLI voice-level self-test failed: \(error.localizedDescription)")
+                exit(1)
+            }
+        }
+
         guard CommandLine.arguments.contains("--agentcli-bootstrap-self-test") else { return }
 
         let bootstrap = ensureReady(for: .transcription, force: true)
@@ -199,6 +210,54 @@ struct AgentRuntime {
             print(transcription.output)
         }
         exit(0)
+    }
+
+    private static func runVoiceLevelSelfTest() throws {
+        guard argumentValue(AgentCommand.toggleTranscription.arguments, for: "--voice-level-log") == VoiceLevelLog.defaultLogPath else {
+            throw SelfTestError("Toggle Transcription does not pass --voice-level-log")
+        }
+        guard argumentValue(AgentCommand.voiceEdit.arguments, for: "--voice-level-log") == VoiceLevelLog.defaultLogPath else {
+            throw SelfTestError("Voice Edit does not pass --voice-level-log")
+        }
+
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+
+        try """
+        {"timestamp":"2026-06-04T12:00:00Z","level":0.25}
+        {"timestamp":"2026-06-04T12:00:01Z","level":0.75}
+        """.write(to: logURL, atomically: true, encoding: .utf8)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        guard let now = formatter.date(from: "2026-06-04T12:00:01Z") else {
+            throw SelfTestError("Could not construct voice-level test timestamp")
+        }
+        guard VoiceLevelLog.latestLevel(from: logURL, now: now) == CGFloat(0.75) else {
+            throw SelfTestError("VoiceLevelLog did not read latest fresh level")
+        }
+    }
+
+    private static func argumentValue(_ arguments: [String], for option: String) -> String? {
+        guard let index = arguments.firstIndex(of: option),
+              arguments.indices.contains(index + 1) else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    private struct SelfTestError: LocalizedError {
+        let message: String
+
+        init(_ message: String) {
+            self.message = message
+        }
+
+        var errorDescription: String? {
+            message
+        }
     }
 
     func ensureInstalled(

--- a/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/VoiceLevelOverlay.swift
@@ -1,5 +1,4 @@
 import AppKit
-import AVFoundation
 import Foundation
 import SwiftUI
 
@@ -136,82 +135,147 @@ final class VoiceLevelOverlayController {
     }
 }
 
-final class VoiceLevelMeter: NSObject, ObservableObject {
+enum VoiceLevelLog {
+    static let defaultLogPath = "~/.config/agent-cli/voice-levels.jsonl"
+    static var defaultLogURL: URL {
+        URL(fileURLWithPath: NSString(string: defaultLogPath).expandingTildeInPath)
+    }
+
+    private static let maximumFreshness: TimeInterval = 1.5
+    private static let maximumTailBytes = 16 * 1024
+
+    static func reset(_ url: URL = defaultLogURL) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try "".write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    static func latestLevel(
+        from url: URL = defaultLogURL,
+        now: Date = Date(),
+        maxAge: TimeInterval = maximumFreshness
+    ) -> CGFloat? {
+        for line in recentLines(from: url) {
+            guard let sample = parseLine(line) else { continue }
+            let age = now.timeIntervalSince(sample.timestamp)
+            guard age >= 0, age <= maxAge else { return nil }
+            return sample.level
+        }
+        return nil
+    }
+
+    private static func recentLines(from url: URL) -> [String] {
+        guard let file = try? FileHandle(forReadingFrom: url) else {
+            return []
+        }
+        defer { try? file.close() }
+
+        do {
+            let fileSize = try file.seekToEnd()
+            guard fileSize > 0 else { return [] }
+
+            let bytesToRead = min(fileSize, UInt64(maximumTailBytes))
+            try file.seek(toOffset: fileSize - bytesToRead)
+            guard let data = try file.readToEnd(),
+                  let text = String(data: data, encoding: .utf8) else {
+                return []
+            }
+            return text
+                .split(whereSeparator: { $0.isNewline })
+                .reversed()
+                .map(String.init)
+        } catch {
+            return []
+        }
+    }
+
+    private static func parseLine(_ line: String) -> (timestamp: Date, level: CGFloat)? {
+        let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedLine.isEmpty,
+              let data = trimmedLine.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let timestampText = object["timestamp"] as? String,
+              let timestamp = parseTimestamp(timestampText),
+              let rawLevel = object["level"] as? Double else {
+            return nil
+        }
+
+        return (timestamp, CGFloat(max(0, min(1, rawLevel))))
+    }
+
+    private static func parseTimestamp(_ text: String) -> Date? {
+        if let date = iso8601WithFractionalSeconds.date(from: text) {
+            return date
+        }
+        return iso8601.date(from: text)
+    }
+
+    private static let iso8601WithFractionalSeconds: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}
+
+final class VoiceLevelMeter: ObservableObject {
     static let shared = VoiceLevelMeter()
 
     @Published private(set) var amplitudes = VoiceLevelMeter.idleAmplitudes
 
     private static let barCount = 16
     private static let idleAmplitudes = Array(repeating: CGFloat(0.16), count: barCount)
+    private static let idleLevel = CGFloat(0.16)
     private static let minimumDisplayAmplitude = CGFloat(0.12)
-    private static let minimumInputDecibels: Float = -55
-    private var engine: AVAudioEngine?
+    private static let pollInterval: TimeInterval = 0.06
+    private let levelLogURL: URL
+    private let now: () -> Date
+    private var timer: Timer?
     private var phase = 0.0
     private var smoothedLevel = CGFloat(0.16)
 
-    private override init() {}
+    init(levelLogURL: URL = VoiceLevelLog.defaultLogURL, now: @escaping () -> Date = Date.init) {
+        self.levelLogURL = levelLogURL
+        self.now = now
+    }
 
     func start() {
-        guard engine == nil else { return }
+        guard timer == nil else { return }
+        VoiceLevelLog.reset(levelLogURL)
+        phase = 0
+        smoothedLevel = Self.idleLevel
+        amplitudes = Self.idleAmplitudes
 
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
-            startMetering()
-        case .notDetermined:
-            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
-                DispatchQueue.main.async {
-                    if granted {
-                        self?.startMetering()
-                    } else {
-                        self?.amplitudes = Self.idleAmplitudes
-                    }
-                }
-            }
-        default:
-            amplitudes = Self.idleAmplitudes
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            self?.pollLevel()
         }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
+        pollLevel()
     }
 
     func stop() {
-        engine?.inputNode.removeTap(onBus: 0)
-        engine?.stop()
-        engine = nil
+        timer?.invalidate()
+        timer = nil
         phase = 0
-        smoothedLevel = 0.16
+        smoothedLevel = Self.idleLevel
         amplitudes = Self.idleAmplitudes
     }
 
-    private func startMetering() {
-        phase = 0
-        smoothedLevel = 0.16
-        let engine = AVAudioEngine()
-        let input = engine.inputNode
-        let format = input.outputFormat(forBus: 0)
-        guard format.sampleRate > 0, format.channelCount > 0 else {
-            amplitudes = Self.idleAmplitudes
-            return
-        }
-
-        do {
-            input.installTap(onBus: 0, bufferSize: 1_024, format: format) { [weak self] buffer, _ in
-                self?.process(buffer: buffer)
-            }
-            try engine.start()
-            self.engine = engine
-        } catch {
-            input.removeTap(onBus: 0)
-            amplitudes = Self.idleAmplitudes
-        }
-    }
-
-    private func process(buffer: AVAudioPCMBuffer) {
-        guard let samples = Self.samples(from: buffer) else { return }
-        let level = Self.normalizedLevel(from: samples)
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self, self.engine != nil else { return }
-            self.updateDisplay(level: level)
-        }
+    private func pollLevel() {
+        let level = VoiceLevelLog.latestLevel(from: levelLogURL, now: now()) ?? Self.idleLevel
+        updateDisplay(level: level)
     }
 
     private func updateDisplay(level: CGFloat) {
@@ -226,58 +290,6 @@ final class VoiceLevelMeter: NSObject, ObservableObject {
         (0..<Self.barCount).map { index in
             let wave = 0.74 + 0.26 * sin(phase + Double(index) * 0.74)
             return max(Self.minimumDisplayAmplitude, min(1, level * CGFloat(wave)))
-        }
-    }
-
-    static func normalizedLevel(from samples: [Float]) -> CGFloat {
-        guard !samples.isEmpty else { return 0.08 }
-
-        let meanSquare = samples.reduce(0.0) { partialResult, sample in
-            let value = Double(sample)
-            return partialResult + (value * value)
-        } / Double(samples.count)
-        guard meanSquare > 0 else { return 0.08 }
-
-        let rootMeanSquare = sqrt(meanSquare)
-        let decibels = Float(20 * log10(rootMeanSquare))
-        return normalizedPower(decibels, minimumPower: minimumInputDecibels)
-    }
-
-    private static func normalizedPower(_ power: Float, minimumPower: Float) -> CGFloat {
-        guard power > minimumPower else { return 0.08 }
-        let linearLevel = CGFloat((power - minimumPower) / abs(minimumPower))
-        return CGFloat(sqrt(Double(linearLevel)))
-    }
-
-    private static func samples(from buffer: AVAudioPCMBuffer) -> [Float]? {
-        guard let channelData = buffer.floatChannelData else { return nil }
-        let frameLength = Int(buffer.frameLength)
-        guard frameLength > 0 else { return nil }
-
-        let channelCount = Int(buffer.format.channelCount)
-        guard channelCount > 0 else { return nil }
-
-        if channelCount == 1 {
-            return Array(UnsafeBufferPointer(start: channelData[0], count: frameLength))
-        }
-
-        if buffer.format.isInterleaved {
-            return (0..<frameLength).map { frameIndex in
-                var mixedSample = Float(0)
-                let sampleIndex = frameIndex * channelCount
-                for channelIndex in 0..<channelCount {
-                    mixedSample += channelData[0][sampleIndex + channelIndex]
-                }
-                return mixedSample / Float(channelCount)
-            }
-        }
-
-        return (0..<frameLength).map { frameIndex in
-            var mixedSample = Float(0)
-            for channelIndex in 0..<channelCount {
-                mixedSample += channelData[channelIndex][frameIndex]
-            }
-            return mixedSample / Float(channelCount)
         }
     }
 }

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -11,6 +11,8 @@ final class AgentCommandTests: XCTestCase {
                 "transcribe",
                 "--toggle",
                 "--quiet",
+                "--voice-level-log",
+                "~/.config/agent-cli/voice-levels.jsonl",
                 "--transcription-log",
                 "~/.config/agent-cli/transcriptions.jsonl",
             ]
@@ -27,6 +29,8 @@ final class AgentCommandTests: XCTestCase {
                 "transcribe",
                 "--toggle",
                 "--quiet",
+                "--voice-level-log",
+                "~/.config/agent-cli/voice-levels.jsonl",
                 "--transcription-log",
                 "~/.config/agent-cli/transcriptions.jsonl",
                 "--extra-instructions",

--- a/macos/AgentCLI/Tests/AgentCLITests/VoiceLevelMeterTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/VoiceLevelMeterTests.swift
@@ -4,25 +4,60 @@ import XCTest
 @testable import AgentCLI
 
 final class VoiceLevelMeterTests: XCTestCase {
-    func testQuietInputProducesVisibleLevel() {
-        let quietTone = Self.sineWave(amplitude: Float(pow(10.0, -35.0 / 20.0)))
-
-        let level = VoiceLevelMeter.normalizedLevel(from: quietTone)
-
-        XCTAssertGreaterThan(level, 0.5)
-    }
-
-    func testSilenceUsesIdleLevel() {
-        let level = VoiceLevelMeter.normalizedLevel(from: Array(repeating: Float(0), count: 1_024))
-
-        XCTAssertEqual(level, CGFloat(0.08))
-    }
-
     func testDisplayAmplitudesUseSineWaveShape() {
         let amplitudes = VoiceLevelMeter.displayAmplitudes(level: 0.6, phase: 0.22)
 
         XCTAssertEqual(amplitudes.count, 16)
         XCTAssertGreaterThan((amplitudes.max() ?? 0) - (amplitudes.min() ?? 0), 0.1)
+    }
+
+    func testVoiceLevelLogReadsMostRecentFreshLevel() throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+        try """
+        {"timestamp":"2026-06-04T12:00:00Z","level":0.21}
+        {"timestamp":"2026-06-04T12:00:01Z","level":0.73}
+        """.write(to: logURL, atomically: true, encoding: .utf8)
+
+        let now = try XCTUnwrap(Self.iso8601.date(from: "2026-06-04T12:00:01Z"))
+        let level = try XCTUnwrap(VoiceLevelLog.latestLevel(from: logURL, now: now))
+
+        XCTAssertEqual(level, CGFloat(0.73), accuracy: 0.0001)
+    }
+
+    func testVoiceLevelLogIgnoresStaleLevel() throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+        try #"{"timestamp":"2026-06-04T12:00:00Z","level":0.91}"#
+            .write(to: logURL, atomically: true, encoding: .utf8)
+        let now = try XCTUnwrap(Self.iso8601.date(from: "2026-06-04T12:00:05Z"))
+
+        XCTAssertNil(VoiceLevelLog.latestLevel(from: logURL, now: now, maxAge: 1.0))
+    }
+
+    func testVoiceLevelLogScansTailAndSkipsInvalidTrailingLine() throws {
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jsonl")
+        defer { try? FileManager.default.removeItem(at: logURL) }
+        let staleLines = Array(
+            repeating: #"{"timestamp":"2026-06-04T11:00:00Z","level":0.12}"#,
+            count: 2_000
+        ).joined(separator: "\n")
+        try """
+        \(staleLines)
+        {"timestamp":"2026-06-04T12:00:01Z","level":0.64}
+        not-json
+        """.write(to: logURL, atomically: true, encoding: .utf8)
+        let now = try XCTUnwrap(Self.iso8601.date(from: "2026-06-04T12:00:01Z"))
+
+        let level = try XCTUnwrap(VoiceLevelLog.latestLevel(from: logURL, now: now))
+
+        XCTAssertEqual(level, CGFloat(0.64), accuracy: 0.0001)
     }
 
     func testOverlayPanelLeavesRoomForShadowBlur() {
@@ -42,15 +77,10 @@ final class VoiceLevelMeterTests: XCTestCase {
         )
     }
 
-    private static func sineWave(
-        frequency: Double = 220,
-        sampleRate: Double = 16_000,
-        sampleCount: Int = 2_048,
-        amplitude: Float = 1
-    ) -> [Float] {
-        (0..<sampleCount).map { index in
-            amplitude * Float(sin(2 * Double.pi * frequency * Double(index) / sampleRate))
-        }
-    }
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
 }
 #endif

--- a/tests/core/test_audio_levels.py
+++ b/tests/core/test_audio_levels.py
@@ -1,0 +1,45 @@
+"""Tests for recorder-backed voice level logging."""
+
+from __future__ import annotations
+
+import json
+import struct
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from agent_cli.core.audio import AudioLevelLogWriter, normalized_audio_level
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _pcm_chunk(sample: int, count: int = 1024) -> bytes:
+    return struct.pack(f"<{count}h", *([sample] * count))
+
+
+def test_normalized_audio_level_tracks_pcm_energy() -> None:
+    silence = _pcm_chunk(0)
+    quiet = _pcm_chunk(1000)
+    loud = _pcm_chunk(16000)
+
+    assert normalized_audio_level(silence) == 0.0
+    assert 0 < normalized_audio_level(quiet) < normalized_audio_level(loud) <= 1
+
+
+def test_audio_level_log_writer_truncates_stale_file_and_appends_jsonl(tmp_path: Path) -> None:
+    log_path = tmp_path / "voice-levels.jsonl"
+    log_path.write_text('{"level": 1.0}\n')
+    writer = AudioLevelLogWriter(
+        log_path,
+        interval_seconds=0.0,
+        monotonic_clock=lambda: 1.0,
+        timestamp_clock=lambda: datetime(2026, 6, 4, 12, 0, tzinfo=UTC),
+    )
+
+    writer.write_chunk(_pcm_chunk(12000))
+
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["timestamp"] == "2026-06-04T12:00:00+00:00"
+    assert entry["level"] > 0.5

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,6 +28,7 @@ async def test_send_audio() -> None:
     mock_data.tobytes.return_value = b"fake_audio_chunk"
     stream.read.return_value = (mock_data, False)
     logger = MagicMock()
+    levels: list[bytes] = []
 
     # Act
     # No need to create a task and sleep, just await the coroutine.
@@ -38,6 +41,7 @@ async def test_send_audio() -> None:
         live=MagicMock(),
         quiet=False,
         save_recording=False,
+        audio_level_callback=levels.append,
     )
 
     # Assert
@@ -55,6 +59,55 @@ async def test_send_audio() -> None:
         ).event(),
     )
     client.write_event.assert_any_call(AudioStop().event())
+    assert levels == [b"fake_audio_chunk"]
+
+
+@pytest.mark.asyncio
+async def test_send_audio_does_not_wait_for_audio_level_callback() -> None:
+    """Test that level callbacks cannot block audio delivery to Wyoming."""
+    client = AsyncMock()
+    stream = MagicMock()
+    stop_event = MagicMock()
+    stop_event.is_set.side_effect = [False, True]
+    stop_event.ctrl_c_pressed = False
+
+    mock_data = MagicMock()
+    mock_data.tobytes.return_value = b"fake_audio_chunk"
+    stream.read.return_value = (mock_data, False)
+    logger = MagicMock()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+
+    def slow_audio_level_callback(_chunk: bytes) -> None:
+        callback_started.set()
+        release_callback.wait(timeout=2)
+
+    send_task = asyncio.create_task(
+        asr._send_audio(
+            client,
+            stream,
+            stop_event,
+            logger,
+            live=MagicMock(),
+            quiet=False,
+            save_recording=False,
+            audio_level_callback=slow_audio_level_callback,
+        ),
+    )
+
+    try:
+        for _ in range(100):
+            if callback_started.is_set() and client.write_event.call_count >= 3:
+                break
+            await asyncio.sleep(0.01)
+
+        assert callback_started.is_set()
+        assert client.write_event.call_count >= 3
+        assert not send_task.done()
+    finally:
+        release_callback.set()
+
+    await asyncio.wait_for(send_task, timeout=2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- write normalized microphone levels from the actual recorder PCM stream to a JSONL file
- have the macOS overlay poll that level log instead of opening a separate AVAudioEngine input tap
- wire transcribe and voice-edit app commands to pass the shared voice-level log path

## Test Plan
- [x] uv run ruff check agent_cli/core/audio.py agent_cli/services/asr.py agent_cli/agents/transcribe.py agent_cli/agents/voice_edit.py agent_cli/opts.py tests/core/test_audio_levels.py tests/test_asr.py
- [x] uv run --extra wyoming pytest tests/core/test_audio_levels.py tests/test_asr.py::test_send_audio tests/agents/test_transcribe.py::test_transcribe_main tests/agents/test_voice_edit_e2e.py -q
- [x] swift build && swift run AgentCLI --agentcli-voice-level-self-test