### PR TITLE
Clarify NeMo prompt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,8 +791,9 @@ the `[defaults]` section of your configuration file.
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ LLM Configuration ────────────────────────────────────────────────────────────────────╮
-│ --extra-instructions                TEXT  Extra instructions appended to the LLM       │
-│                                           cleanup prompt (requires --llm).             │
+│ --extra-instructions                TEXT  Extra ASR context where supported, and LLM   │
+│                                           cleanup instructions when --llm is enabled.  │
+│                                           The NeMo backend ignores ASR text prompts.   │
 │ --llm                   --no-llm          Clean up transcript with LLM: fix errors,    │
 │                                           add punctuation, remove filler words. Uses   │
 │                                           --extra-instructions if set (via CLI or      │

--- a/agent_cli/agents/transcribe.py
+++ b/agent_cli/agents/transcribe.py
@@ -598,7 +598,10 @@ def transcribe(  # noqa: PLR0912, PLR0911, PLR0915, C901
     extra_instructions: str | None = typer.Option(
         None,
         "--extra-instructions",
-        help="Extra instructions appended to the LLM cleanup prompt (requires `--llm`).",
+        help=(
+            "Extra ASR context where supported, and LLM cleanup instructions when "
+            "`--llm` is enabled. The NeMo backend ignores ASR text prompts."
+        ),
         rich_help_panel="LLM Configuration",
     ),
     from_file: Path | None = opts.FROM_FILE,

--- a/agent_cli/server/whisper/backends/nemo.py
+++ b/agent_cli/server/whisper/backends/nemo.py
@@ -344,6 +344,7 @@ class NemoWhisperBackend:
         self._resolved_model = _resolve_model_name(config.model_name)
         self._executor: ProcessPoolExecutor | None = None
         self._device: str | None = None
+        self._warned_initial_prompt_ignored = False
 
     @property
     def is_loaded(self) -> bool:
@@ -415,7 +416,7 @@ class NemoWhisperBackend:
         source_filename: str | None = None,
         language: str | None = None,
         task: Literal["transcribe", "translate"] = "transcribe",  # noqa: ARG002
-        initial_prompt: str | None = None,  # noqa: ARG002
+        initial_prompt: str | None = None,
         temperature: float = 0.0,  # noqa: ARG002
         vad_filter: bool = True,  # noqa: ARG002
         word_timestamps: bool = False,
@@ -424,6 +425,13 @@ class NemoWhisperBackend:
         if self._executor is None:
             msg = "Model not loaded. Call load() first."
             raise RuntimeError(msg)
+        if initial_prompt and not self._warned_initial_prompt_ignored:
+            logger.warning(
+                "Whisper-style initial prompts are not supported by the agent-cli NeMo backend; "
+                "ignoring prompt for model %s",
+                self._config.model_name,
+            )
+            self._warned_initial_prompt_ignored = True
 
         audio = await asyncio.to_thread(_prepare_audio_for_nemo, audio, source_filename)
 

--- a/docs/commands/transcribe.md
+++ b/docs/commands/transcribe.md
@@ -95,7 +95,7 @@ The `--from-file` option supports multiple audio formats:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--extra-instructions` | - | Extra instructions appended to the LLM cleanup prompt (requires `--llm`). |
+| `--extra-instructions` | - | Extra ASR context where supported, and LLM cleanup instructions when `--llm` is enabled. The NeMo backend ignores ASR text prompts. |
 | `--llm/--no-llm` | `false` | Clean up transcript with LLM: fix errors, add punctuation, remove filler words. Uses `--extra-instructions` if set (via CLI or config file). Not compatible with --diarize. |
 
 ### Audio Recovery

--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -373,7 +373,11 @@ struct SettingsView: View {
             } header: {
                 Text("Transcription Instructions")
             } footer: {
-                Text("Names, vocabulary, and guidance to pass as initial transcription context.")
+                Text(
+                    selectedTranscriptionBackend == .nemo && !useUserInstalledAgentCLI
+                        ? "Parakeet does not support names or vocabulary as text prompt context, so this field has no effect for bundled NeMo transcription."
+                        : "Names, vocabulary, and guidance to pass as initial transcription context."
+                )
             }
 
             Section {

--- a/tests/test_nemo_backend.py
+++ b/tests/test_nemo_backend.py
@@ -458,6 +458,44 @@ async def test_unload_waits_for_subprocess_shutdown() -> None:
 
 
 @pytest.mark.asyncio
+async def test_transcribe_warns_once_when_initial_prompt_is_ignored(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NeMo should make unsupported ASR prompts visible in logs."""
+    nemo_backend = backend.NemoWhisperBackend(
+        BackendConfig(model_name="parakeet-unified-en-0.6b"),
+    )
+    nemo_backend._executor = ThreadPoolExecutor(max_workers=1)  # type: ignore[assignment]
+
+    def transcribe(
+        audio: bytes,  # noqa: ARG001
+        kwargs: dict[str, Any],  # noqa: ARG001
+    ) -> dict[str, Any]:
+        return {
+            "text": "ok",
+            "language": "en",
+            "language_probability": 0.95,
+            "duration": 1.0,
+            "segments": [],
+        }
+
+    monkeypatch.setattr(backend, "_transcribe_in_subprocess", transcribe)
+
+    with caplog.at_level("WARNING", logger=backend.__name__):
+        await nemo_backend.transcribe(_create_test_wav(), initial_prompt="Bas Nijholt")
+        await nemo_backend.transcribe(_create_test_wav(), initial_prompt="Bas Nijholt")
+
+    await nemo_backend.unload()
+    assert (
+        caplog.text.count(
+            "Whisper-style initial prompts are not supported by the agent-cli NeMo backend",
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
 async def test_transcribe_recovers_from_broken_process_pool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- warn once when a Whisper-style initial prompt reaches the NeMo backend
- clarify the macOS bundled Parakeet settings text
- update transcribe docs so ASR context vs LLM cleanup is explicit

## Why
Parakeet models on the agent-cli NeMo path do not use names or vocabulary as arbitrary text prompt context. Before this, the field looked active while NeMo ignored it. Behavior stays the same; the limitation is now visible.

## Verification
- `uv run pytest tests/test_nemo_backend.py::test_transcribe_warns_once_when_initial_prompt_is_ignored tests/test_docs_gen.py -q`
- `uv run ruff check agent_cli/server/whisper/backends/nemo.py agent_cli/agents/transcribe.py tests/test_nemo_backend.py`
- `swift test --package-path macos/AgentCLI`
- `git diff --check`