### PR TITLE
Retry Fn hotkeys after Accessibility approval

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AppDelegate.swift
@@ -27,6 +27,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         releaseInstanceLock()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        ConfigurableHotkeyController.shared.retryFunctionAwareHotkeysIfTrusted(runner: AgentCommandRunner.shared)
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -78,7 +78,10 @@ final class ConfigurableHotkeyController {
     private var suppressNextFunctionKeyRelease = false
     private var holdToTranscribeKeyState = HoldToTranscribeKeyState()
     private var pendingHoldToTranscribeWorkItem: DispatchWorkItem?
+    private var accessibilityRetryWorkItem: DispatchWorkItem?
     private let holdToTranscribeDelay: TimeInterval = 0.16
+    private let accessibilityRetryInterval: TimeInterval = 1
+    private let accessibilityRetryTimeout: TimeInterval = 120
 
     private init() {}
 
@@ -129,6 +132,9 @@ final class ConfigurableHotkeyController {
     }
 
     private func registerFunctionAwareTranscriptionHotkeys(runner: AgentCommandRunner) {
+        guard eventTap == nil else { return }
+        cancelAccessibilityRetry()
+
         let eventMask =
             CGEventMask(1 << CGEventType.keyDown.rawValue) |
             CGEventMask(1 << CGEventType.keyUp.rawValue) |
@@ -153,6 +159,7 @@ final class ConfigurableHotkeyController {
             userInfo: userInfo
         ) else {
             requestAccessibilityPermissionForFunctionHotkeys()
+            scheduleAccessibilityRetry(runner: runner, deadline: Date().addingTimeInterval(accessibilityRetryTimeout))
             Task { @MainActor in
                 runner.statusMessage = "Allow Accessibility permission for Fn transcription shortcuts"
             }
@@ -169,6 +176,7 @@ final class ConfigurableHotkeyController {
 
     func suspendFunctionAwareHotkeysForAccessibilityReset() {
         cancelPendingHoldToTranscribe()
+        cancelAccessibilityRetry()
 
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
@@ -187,6 +195,12 @@ final class ConfigurableHotkeyController {
 
     func resumeFunctionAwareHotkeysAfterAccessibilityReset(runner: AgentCommandRunner) {
         guard registered, eventTap == nil else { return }
+        self.runner = runner
+        registerFunctionAwareTranscriptionHotkeys(runner: runner)
+    }
+
+    func retryFunctionAwareHotkeysIfTrusted(runner: AgentCommandRunner) {
+        guard registered, eventTap == nil, AXIsProcessTrusted() else { return }
         self.runner = runner
         registerFunctionAwareTranscriptionHotkeys(runner: runner)
     }
@@ -317,6 +331,43 @@ final class ConfigurableHotkeyController {
     private func cancelPendingHoldToTranscribe() {
         pendingHoldToTranscribeWorkItem?.cancel()
         pendingHoldToTranscribeWorkItem = nil
+    }
+
+    private func scheduleAccessibilityRetry(runner: AgentCommandRunner, deadline: Date) {
+        guard Date() < deadline else { return }
+
+        var workItem: DispatchWorkItem?
+        workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  workItem?.isCancelled == false else {
+                return
+            }
+
+            self.accessibilityRetryWorkItem = nil
+            guard self.eventTap == nil else { return }
+
+            guard AXIsProcessTrusted() else {
+                self.scheduleAccessibilityRetry(runner: runner, deadline: deadline)
+                return
+            }
+
+            self.registerFunctionAwareTranscriptionHotkeys(runner: runner)
+            if self.eventTap != nil {
+                Task { @MainActor in
+                    runner.statusMessage = "Accessibility permission enabled"
+                }
+            }
+        }
+
+        accessibilityRetryWorkItem = workItem
+        if let workItem {
+            DispatchQueue.main.asyncAfter(deadline: .now() + accessibilityRetryInterval, execute: workItem)
+        }
+    }
+
+    private func cancelAccessibilityRetry() {
+        accessibilityRetryWorkItem?.cancel()
+        accessibilityRetryWorkItem = nil
     }
 
     private func requestHoldToTranscribeStart(

--- a/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/ConfigurableHotkeyController.swift
@@ -132,8 +132,8 @@ final class ConfigurableHotkeyController {
     }
 
     private func registerFunctionAwareTranscriptionHotkeys(runner: AgentCommandRunner) {
-        guard eventTap == nil else { return }
         cancelAccessibilityRetry()
+        guard eventTap == nil else { return }
 
         let eventMask =
             CGEventMask(1 << CGEventType.keyDown.rawValue) |
@@ -351,6 +351,7 @@ final class ConfigurableHotkeyController {
                 return
             }
 
+            self.runner = runner
             self.registerFunctionAwareTranscriptionHotkeys(runner: runner)
             if self.eventTap != nil {
                 Task { @MainActor in


### PR DESCRIPTION
## Summary
- retry Fn-key event tap registration after macOS Accessibility approval
- retry on app activation when permission is already trusted
- keep reset flow from requiring a second quit/open cycle

## Verification
- swift build
- swift test
- git diff --check HEAD~1..HEAD