### PR TITLE
Fix macOS F1 shortcut recorder crash

### DIFF
--- a/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/Shortcuts.swift
@@ -198,7 +198,26 @@ private enum ShortcutDisplay {
 
     private static func isFunctionRowKey(_ carbonKeyCode: Int) -> Bool {
         switch carbonKeyCode {
-        case kVK_F1...kVK_F20:
+        case kVK_F1,
+             kVK_F2,
+             kVK_F3,
+             kVK_F4,
+             kVK_F5,
+             kVK_F6,
+             kVK_F7,
+             kVK_F8,
+             kVK_F9,
+             kVK_F10,
+             kVK_F11,
+             kVK_F12,
+             kVK_F13,
+             kVK_F14,
+             kVK_F15,
+             kVK_F16,
+             kVK_F17,
+             kVK_F18,
+             kVK_F19,
+             kVK_F20:
             return true
         default:
             return false

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -103,6 +103,36 @@ def test_macos_app_depends_on_keyboardshortcuts_package() -> None:
     assert '.product(name: "KeyboardShortcuts", package: "KeyboardShortcuts")' in package
 
 
+def test_macos_app_checks_function_row_keys_without_invalid_carbon_range() -> None:
+    """Carbon function-row key codes are not an ordered contiguous Swift range."""
+    shortcuts = (SWIFT_SOURCE_DIR / "Shortcuts.swift").read_text(encoding="utf-8")
+
+    assert "case kVK_F1...kVK_F20:" not in shortcuts
+    for key in (
+        "kVK_F1",
+        "kVK_F2",
+        "kVK_F3",
+        "kVK_F4",
+        "kVK_F5",
+        "kVK_F6",
+        "kVK_F7",
+        "kVK_F8",
+        "kVK_F9",
+        "kVK_F10",
+        "kVK_F11",
+        "kVK_F12",
+        "kVK_F13",
+        "kVK_F14",
+        "kVK_F15",
+        "kVK_F16",
+        "kVK_F17",
+        "kVK_F18",
+        "kVK_F19",
+        "kVK_F20",
+    ):
+        assert key in shortcuts
+
+
 def test_macos_app_has_swift_unit_test_target() -> None:
     """Pure macOS app behavior should have an XCTest target."""
     package = (MACOS_APP / "Package.swift").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Replace invalid `kVK_F1...kVK_F20` Carbon key-code range with explicit function-key cases.
- Add macOS packaging regression coverage so the invalid range does not return.

## Test Plan
- `swift build --package-path macos/AgentCLI`
- `/tmp/agentcli-pytest-venv311/bin/python -m pytest tests/test_macos_app.py -q --no-cov`
