### PR TITLE
Add cmux support to agent-cli dev

### DIFF
--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -166,8 +166,8 @@ def _resolve_prompt_text(
 
 def _normalize_tmux_session(
     tmux_session: str | None,
-    multiplexer: Literal["tmux"] | None,
-) -> tuple[str | None, Literal["tmux"] | None]:
+    multiplexer: Literal["tmux", "cmux"] | None,
+) -> tuple[str | None, Literal["tmux", "cmux"] | None]:
     """Normalize `--tmux-session` and make it imply tmux launches."""
     if tmux_session is None:
         return None, multiplexer
@@ -457,12 +457,12 @@ def new(
         ),
     ] = None,
     multiplexer: Annotated[
-        Literal["tmux"] | None,
+        Literal["tmux", "cmux"] | None,
         typer.Option(
             "--multiplexer",
             "-m",
             case_sensitive=False,
-            help="Launch the agent in a specific multiplexer. Currently supported: tmux. When started outside tmux, creates or reuses a detached session and reports the pane handle",
+            help="Launch the agent in a specific multiplexer. Currently supported: tmux, cmux. When started outside tmux, creates or reuses a detached session and reports the pane handle. cmux opens a tab in a workspace named after the repo",
         ),
     ] = None,
     tmux_session: Annotated[
@@ -618,11 +618,13 @@ def new(
         summary_lines.append(
             f"[bold]Agent Handle:[/bold] {agent_handle.handle} ({agent_handle.terminal_name})",
         )
-        if agent_handle.session_name:
+        if agent_handle.session_name and agent_handle.terminal_name == "tmux":
             summary_lines.append(f"[bold]tmux Session:[/bold] {agent_handle.session_name}")
             summary_lines.append(
                 f"[bold]Attach:[/bold] tmux attach -t {shlex.quote(agent_handle.session_name)}",
             )
+        elif agent_handle.session_name and agent_handle.terminal_name == "cmux":
+            summary_lines.append(f"[bold]cmux Workspace:[/bold] {agent_handle.session_name}")
 
     console.print()
     console.print(
@@ -1049,12 +1051,12 @@ def start_agent(
         ),
     ] = None,
     multiplexer: Annotated[
-        Literal["tmux"] | None,
+        Literal["tmux", "cmux"] | None,
         typer.Option(
             "--multiplexer",
             "-m",
             case_sensitive=False,
-            help="Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux",
+            help="Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux, cmux",
         ),
     ] = None,
     tmux_session: Annotated[
@@ -1146,7 +1148,7 @@ def start_agent(
                 f"{handle.terminal_name} handle: {handle.handle}"
                 + (
                     f" (attach with: tmux attach -t {shlex.quote(handle.session_name)})"
-                    if handle.session_name
+                    if handle.session_name and handle.terminal_name == "tmux"
                     else ""
                 ),
             )
@@ -1280,7 +1282,7 @@ def list_terminals_cmd(
 ) -> None:
     """List available terminal multiplexers and their status.
 
-    Shows supported terminals: tmux, zellij, kitty, iTerm2, Terminal.app,
+    Shows supported terminals: tmux, zellij, cmux, kitty, iTerm2, Terminal.app,
     Warp, GNOME Terminal.
 
     These are used to open new tabs when launching AI agents with `dev new --start-agent`.

--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -166,8 +166,8 @@ def _resolve_prompt_text(
 
 def _normalize_tmux_session(
     tmux_session: str | None,
-    multiplexer: Literal["tmux", "cmux"] | None,
-) -> tuple[str | None, Literal["tmux", "cmux"] | None]:
+    multiplexer: Literal["tmux"] | None,
+) -> tuple[str | None, Literal["tmux"] | None]:
     """Normalize `--tmux-session` and make it imply tmux launches."""
     if tmux_session is None:
         return None, multiplexer
@@ -457,12 +457,12 @@ def new(
         ),
     ] = None,
     multiplexer: Annotated[
-        Literal["tmux", "cmux"] | None,
+        Literal["tmux"] | None,
         typer.Option(
             "--multiplexer",
             "-m",
             case_sensitive=False,
-            help="Launch the agent in a specific multiplexer. Currently supported: tmux, cmux. When started outside tmux, creates or reuses a detached session and reports the pane handle. cmux opens a tab in a workspace named after the repo",
+            help="Launch the agent in a specific multiplexer. Currently supported: tmux. When started outside tmux, creates or reuses a detached session and reports the pane handle",
         ),
     ] = None,
     tmux_session: Annotated[
@@ -1051,12 +1051,12 @@ def start_agent(
         ),
     ] = None,
     multiplexer: Annotated[
-        Literal["tmux", "cmux"] | None,
+        Literal["tmux"] | None,
         typer.Option(
             "--multiplexer",
             "-m",
             case_sensitive=False,
-            help="Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux, cmux",
+            help="Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux",
         ),
     ] = None,
     tmux_session: Annotated[

--- a/agent_cli/dev/launch.py
+++ b/agent_cli/dev/launch.py
@@ -321,6 +321,36 @@ def _launch_in_tmux(
     return handle
 
 
+def _launch_in_cmux(
+    path: Path,
+    agent: CodingAgent,
+    terminal: terminals.Terminal,
+    full_cmd: str,
+    tab_name: str,
+    repo_root: Path | None,
+) -> TerminalHandle | None:
+    """Launch an agent in a cmux tab inside a workspace named after the repo."""
+    from .terminals.cmux import Cmux  # noqa: PLC0415
+
+    if not isinstance(terminal, Cmux):
+        warn("Could not open new tab in cmux")
+        return None
+
+    workspace_name = (repo_root or path).name
+    handle = terminal.open_in_workspace(
+        path,
+        full_cmd,
+        tab_name=tab_name,
+        workspace_name=workspace_name,
+    )
+    if handle is None:
+        warn("Could not open new tab in cmux")
+        return None
+
+    success(f"Started {agent.name} in cmux workspace {workspace_name!r}")
+    return handle
+
+
 def _launch_in_terminal(
     path: Path,
     agent: CodingAgent,
@@ -332,6 +362,10 @@ def _launch_in_terminal(
     tmux_session: str | None,
 ) -> tuple[bool, TerminalHandle | None]:
     """Launch an agent in the resolved terminal."""
+    if terminal.name == "cmux":
+        handle = _launch_in_cmux(path, agent, terminal, full_cmd, tab_name, repo_root)
+        return handle is not None, handle
+
     if terminal.name == "tmux":
         handle = _launch_in_tmux(
             path,

--- a/agent_cli/dev/terminals/cmux.py
+++ b/agent_cli/dev/terminals/cmux.py
@@ -10,6 +10,7 @@ it, and each worktree launch opens a new tab inside that workspace.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shlex
@@ -17,10 +18,32 @@ import shutil
 import subprocess
 from typing import TYPE_CHECKING
 
+from agent_cli.dev.worktree import get_main_repo_root
+
 from .base import Terminal, TerminalHandle
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# Named colors accepted by `cmux workspace-action --action set-color`.
+_WORKSPACE_COLORS = (
+    "Red",
+    "Crimson",
+    "Orange",
+    "Amber",
+    "Olive",
+    "Green",
+    "Teal",
+    "Aqua",
+    "Blue",
+    "Navy",
+    "Indigo",
+    "Purple",
+    "Magenta",
+    "Rose",
+    "Brown",
+    "Charcoal",
+)
 
 
 class Cmux(Terminal):
@@ -44,8 +67,10 @@ class Cmux(Terminal):
         command: str | None = None,
         tab_name: str | None = None,
     ) -> bool:
-        """Open a new tab in a workspace named after the directory."""
-        handle = self.open_in_workspace(path, command, tab_name, workspace_name=path.name)
+        """Open a new tab in a workspace named after the repo containing ``path``."""
+        repo_root = get_main_repo_root(path)
+        workspace_name = (repo_root or path).name
+        handle = self.open_in_workspace(path, command, tab_name, workspace_name=workspace_name)
         return handle is not None
 
     def open_in_workspace(
@@ -63,7 +88,15 @@ class Cmux(Terminal):
         """
         if not self.is_available():
             return None
-        workspace_ref = self._find_workspace(workspace_name)
+        workspaces = self._list_workspaces()
+        if workspaces is None:
+            # The cmux CLI itself failed (e.g. app not running); creating a
+            # workspace would fail too, or duplicate one we could not see.
+            return None
+        workspace_ref = next(
+            (w.get("ref") for w in workspaces if w.get("title") == workspace_name),
+            None,
+        )
         if workspace_ref is None:
             return self._create_workspace(path, command, tab_name, workspace_name=workspace_name)
         return self._open_tab(
@@ -74,8 +107,8 @@ class Cmux(Terminal):
             workspace_name=workspace_name,
         )
 
-    def _find_workspace(self, workspace_name: str) -> str | None:
-        """Find the ref of the first workspace titled ``workspace_name``."""
+    def _list_workspaces(self) -> list[dict] | None:
+        """List workspace dicts via the cmux CLI, or None when the CLI call fails."""
         stdout = self._run(["workspace", "list", "--json"])
         if stdout is None:
             return None
@@ -83,10 +116,8 @@ class Cmux(Terminal):
             data = json.loads(stdout)
         except json.JSONDecodeError:
             return None
-        for workspace in data.get("workspaces", []):
-            if workspace.get("title") == workspace_name:
-                return workspace.get("ref")
-        return None
+        workspaces = data.get("workspaces", [])
+        return workspaces if isinstance(workspaces, list) else None
 
     def _create_workspace(
         self,
@@ -103,6 +134,17 @@ class Cmux(Terminal):
         workspace_ref = self._parse_ok_ref(self._run(cmd), "workspace:")
         if workspace_ref is None:
             return None
+        self._run(
+            [
+                "workspace-action",
+                "--action",
+                "set-color",
+                "--workspace",
+                workspace_ref,
+                "--color",
+                self._workspace_color(workspace_name),
+            ],
+        )
         if tab_name:
             # The freshly created workspace has a single tab, which is its
             # focused tab, so rename-tab needs no explicit surface target.
@@ -147,7 +189,7 @@ class Cmux(Terminal):
         shell_cmd = f"cd {shlex.quote(str(path))}"
         if command:
             shell_cmd += f" && {command}"
-        self._run(
+        sent = self._run(
             [
                 "send",
                 "--workspace",
@@ -158,11 +200,22 @@ class Cmux(Terminal):
                 shell_cmd + "\\n",
             ],
         )
+        if sent is None:
+            # The command never reached the tab, so the agent is not running;
+            # remove the idle tab and report failure instead of a dead handle.
+            self._run(["close-surface", "--workspace", workspace_ref, "--surface", surface_ref])
+            return None
         return TerminalHandle(
             terminal_name=self.name,
             handle=surface_ref,
             session_name=workspace_name,
         )
+
+    @staticmethod
+    def _workspace_color(workspace_name: str) -> str:
+        """Pick a deterministic cmux named color for a workspace."""
+        digest = hashlib.sha256(workspace_name.encode()).hexdigest()
+        return _WORKSPACE_COLORS[int(digest[:8], 16) % len(_WORKSPACE_COLORS)]
 
     @staticmethod
     def _run(args: list[str]) -> str | None:

--- a/agent_cli/dev/terminals/cmux.py
+++ b/agent_cli/dev/terminals/cmux.py
@@ -1,0 +1,194 @@
+"""cmux terminal adapter.
+
+cmux (https://cmux.dev) is a Ghostty-based macOS terminal organized as
+windows > workspaces > panes > surfaces (tabs), controlled via a Unix
+socket through the bundled ``cmux`` CLI.
+
+agent-cli maps repos to workspaces: each repo gets a workspace named after
+it, and each worktree launch opens a new tab inside that workspace.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+from .base import Terminal, TerminalHandle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Cmux(Terminal):
+    """cmux - Ghostty-based terminal with workspaces for AI coding agents."""
+
+    name = "cmux"
+
+    def detect(self) -> bool:
+        """Detect if running inside cmux via its auto-set environment variables."""
+        return bool(
+            os.environ.get("CMUX_WORKSPACE_ID") or os.environ.get("CMUX_SURFACE_ID"),
+        )
+
+    def is_available(self) -> bool:
+        """Check if the cmux CLI is available."""
+        return shutil.which("cmux") is not None
+
+    def open_new_tab(
+        self,
+        path: Path,
+        command: str | None = None,
+        tab_name: str | None = None,
+    ) -> bool:
+        """Open a new tab in a workspace named after the directory."""
+        handle = self.open_in_workspace(path, command, tab_name, workspace_name=path.name)
+        return handle is not None
+
+    def open_in_workspace(
+        self,
+        path: Path,
+        command: str | None = None,
+        tab_name: str | None = None,
+        *,
+        workspace_name: str,
+    ) -> TerminalHandle | None:
+        """Open a tab in the named cmux workspace, creating the workspace if needed.
+
+        Workspace targets are always passed explicitly because the cmux CLI
+        otherwise defaults to the caller's workspace (``CMUX_WORKSPACE_ID``).
+        """
+        if not self.is_available():
+            return None
+        workspace_ref = self._find_workspace(workspace_name)
+        if workspace_ref is None:
+            return self._create_workspace(path, command, tab_name, workspace_name=workspace_name)
+        return self._open_tab(
+            path,
+            command,
+            tab_name,
+            workspace_ref=workspace_ref,
+            workspace_name=workspace_name,
+        )
+
+    def _find_workspace(self, workspace_name: str) -> str | None:
+        """Find the ref of the first workspace titled ``workspace_name``."""
+        stdout = self._run(["workspace", "list", "--json"])
+        if stdout is None:
+            return None
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return None
+        for workspace in data.get("workspaces", []):
+            if workspace.get("title") == workspace_name:
+                return workspace.get("ref")
+        return None
+
+    def _create_workspace(
+        self,
+        path: Path,
+        command: str | None,
+        tab_name: str | None,
+        *,
+        workspace_name: str,
+    ) -> TerminalHandle | None:
+        """Create a workspace whose initial tab starts in ``path`` running ``command``."""
+        cmd = ["workspace", "create", "--name", workspace_name, "--cwd", str(path)]
+        if command:
+            cmd.extend(["--command", command])
+        workspace_ref = self._parse_ok_ref(self._run(cmd), "workspace:")
+        if workspace_ref is None:
+            return None
+        if tab_name:
+            # The freshly created workspace has a single tab, which is its
+            # focused tab, so rename-tab needs no explicit surface target.
+            self._run(["rename-tab", "--workspace", workspace_ref, "--title", tab_name])
+        return TerminalHandle(
+            terminal_name=self.name,
+            handle=workspace_ref,
+            session_name=workspace_name,
+        )
+
+    def _open_tab(
+        self,
+        path: Path,
+        command: str | None,
+        tab_name: str | None,
+        *,
+        workspace_ref: str,
+        workspace_name: str,
+    ) -> TerminalHandle | None:
+        """Open a new tab in an existing workspace and run ``command`` in ``path``."""
+        surface_ref = self._parse_ok_ref(
+            self._run(["new-surface", "--workspace", workspace_ref]),
+            "surface:",
+        )
+        if surface_ref is None:
+            return None
+        if tab_name:
+            self._run(
+                [
+                    "rename-tab",
+                    "--workspace",
+                    workspace_ref,
+                    "--surface",
+                    surface_ref,
+                    "--title",
+                    tab_name,
+                ],
+            )
+        # New surfaces don't accept a cwd/command, so type it into the shell.
+        # The terminal buffers the input until the shell is ready, and cmux
+        # turns the literal \n escape sequence into Enter.
+        shell_cmd = f"cd {shlex.quote(str(path))}"
+        if command:
+            shell_cmd += f" && {command}"
+        self._run(
+            [
+                "send",
+                "--workspace",
+                workspace_ref,
+                "--surface",
+                surface_ref,
+                "--",
+                shell_cmd + "\\n",
+            ],
+        )
+        return TerminalHandle(
+            terminal_name=self.name,
+            handle=surface_ref,
+            session_name=workspace_name,
+        )
+
+    @staticmethod
+    def _run(args: list[str]) -> str | None:
+        """Run a cmux CLI command and return its stdout, or None on failure."""
+        env = {**os.environ, "CMUX_QUIET": "1"}
+        try:
+            result = subprocess.run(
+                ["cmux", *args],  # noqa: S607
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+        except (subprocess.CalledProcessError, OSError):
+            return None
+        return result.stdout
+
+    @staticmethod
+    def _parse_ok_ref(stdout: str | None, prefix: str) -> str | None:
+        """Extract the first ``<prefix>N`` ref from an ``OK ...`` response line."""
+        if not stdout:
+            return None
+        for line in stdout.splitlines():
+            if not line.startswith("OK"):
+                continue
+            for token in line.split():
+                if token.startswith(prefix):
+                    return token
+        return None

--- a/agent_cli/dev/terminals/registry.py
+++ b/agent_cli/dev/terminals/registry.py
@@ -6,6 +6,7 @@ from agent_cli.dev.registry import Registry
 
 from .apple_terminal import AppleTerminal
 from .base import Terminal  # noqa: TC001
+from .cmux import Cmux
 from .gnome import GnomeTerminal
 from .iterm2 import ITerm2
 from .kitty import Kitty
@@ -18,6 +19,7 @@ from .zellij import Zellij
 _TERMINALS: list[type[Terminal]] = [
     Tmux,
     Zellij,
+    Cmux,
     ITerm2,
     Kitty,
     Warp,

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -87,7 +87,7 @@ agent-cli dev new [BRANCH] [OPTIONS]
 | `--agent-args` | - | Extra CLI args for the agent. Can be repeated. Example: --agent-args='--dangerously-skip-permissions' |
 | `--prompt, -p` | - | Initial task for the AI agent. Saved to a unique file in .claude/ to avoid conflicts. Implies starting the agent. Example: --prompt='Fix the login bug' |
 | `--prompt-file, -P` | - | Read the agent prompt from a file. Useful for long prompts to avoid shell quoting. Implies starting the agent |
-| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer. Currently supported: tmux, cmux. When started outside tmux, creates or reuses a detached session and reports the pane handle. cmux opens a tab in a workspace named after the repo |
+| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer. Currently supported: tmux. When started outside tmux, creates or reuses a detached session and reports the pane handle |
 | `--tmux-session` | - | Reuse or create a specific tmux session for the agent. Implies --multiplexer tmux |
 | `--hooks/--no-hooks` | `true` | Run built-in agent preparation (like Codex auto-trust) and configured pre-launch hooks before starting the agent |
 | `--verbose, -v` | `false` | Stream output from setup commands instead of hiding it |
@@ -305,7 +305,7 @@ agent-cli dev agent NAME [--agent/-a AGENT] [--agent-args ARGS] [--prompt/-p PRO
 | `--agent-args` | - | Extra CLI args for the agent. Example: --agent-args='--dangerously-skip-permissions' |
 | `--prompt, -p` | - | Initial task for the agent. Saved to a unique file in .claude/ to avoid conflicts. Example: --prompt='Add unit tests for auth' |
 | `--prompt-file, -P` | - | Read the agent prompt from a file instead of command line |
-| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux, cmux |
+| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux |
 | `--tmux-session` | - | Reuse or create a specific tmux session for the agent. Implies --multiplexer tmux |
 | `--hooks/--no-hooks` | `true` | Run built-in agent preparation (like Codex auto-trust) and configured pre-launch hooks before starting the agent |
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -87,7 +87,7 @@ agent-cli dev new [BRANCH] [OPTIONS]
 | `--agent-args` | - | Extra CLI args for the agent. Can be repeated. Example: --agent-args='--dangerously-skip-permissions' |
 | `--prompt, -p` | - | Initial task for the AI agent. Saved to a unique file in .claude/ to avoid conflicts. Implies starting the agent. Example: --prompt='Fix the login bug' |
 | `--prompt-file, -P` | - | Read the agent prompt from a file. Useful for long prompts to avoid shell quoting. Implies starting the agent |
-| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer. Currently supported: tmux. When started outside tmux, creates or reuses a detached session and reports the pane handle |
+| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer. Currently supported: tmux, cmux. When started outside tmux, creates or reuses a detached session and reports the pane handle. cmux opens a tab in a workspace named after the repo |
 | `--tmux-session` | - | Reuse or create a specific tmux session for the agent. Implies --multiplexer tmux |
 | `--hooks/--no-hooks` | `true` | Run built-in agent preparation (like Codex auto-trust) and configured pre-launch hooks before starting the agent |
 | `--verbose, -v` | `false` | Stream output from setup commands instead of hiding it |
@@ -305,7 +305,7 @@ agent-cli dev agent NAME [--agent/-a AGENT] [--agent-args ARGS] [--prompt/-p PRO
 | `--agent-args` | - | Extra CLI args for the agent. Example: --agent-args='--dangerously-skip-permissions' |
 | `--prompt, -p` | - | Initial task for the agent. Saved to a unique file in .claude/ to avoid conflicts. Example: --prompt='Add unit tests for auth' |
 | `--prompt-file, -P` | - | Read the agent prompt from a file instead of command line |
-| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux |
+| `--multiplexer, -m` | - | Launch the agent in a specific multiplexer instead of the current terminal. Currently supported: tmux, cmux |
 | `--tmux-session` | - | Reuse or create a specific tmux session for the agent. Implies --multiplexer tmux |
 | `--hooks/--no-hooks` | `true` | Run built-in agent preparation (like Codex auto-trust) and configured pre-launch hooks before starting the agent |
 
@@ -578,6 +578,7 @@ agent-cli dev terminals [OPTIONS]
 |----------|-----------|-----------------|
 | tmux | `TMUX` env var | `tmux new-window -c <path>` |
 | Zellij | `ZELLIJ` env var | `zellij action new-tab --cwd <path>` |
+| cmux | `CMUX_WORKSPACE_ID` env var | `cmux new-surface` in a workspace named after the repo (created on demand) |
 | Kitty | `KITTY_WINDOW_ID` | `kitten @ launch --type=tab` |
 | iTerm2 | `ITERM_SESSION_ID` | AppleScript |
 | Terminal.app | `TERM_PROGRAM=Apple_Terminal` | AppleScript + System Events * |

--- a/tests/dev/test_launch.py
+++ b/tests/dev/test_launch.py
@@ -196,7 +196,7 @@ class TestLaunchAgent:
         )
 
     def test_cmux_uses_workspace_named_after_repo(self, tmp_path: Path) -> None:
-        """Cmux launches open a tab in a workspace named after the repo."""
+        """Detected cmux opens a tab in a workspace named after the repo."""
         agent = MagicMock()
         agent.name = "codex"
         agent.launch_command.return_value = ["codex"]
@@ -205,14 +205,16 @@ class TestLaunchAgent:
         handle = TerminalHandle("cmux", "surface:5", "repo")
 
         with (
-            patch("agent_cli.dev.launch.terminals.get_terminal", return_value=cmux_terminal),
-            patch("agent_cli.dev.launch.terminals.detect_current_terminal", return_value=None),
+            patch(
+                "agent_cli.dev.launch.terminals.detect_current_terminal",
+                return_value=cmux_terminal,
+            ),
             patch.object(cmux_terminal, "is_available", return_value=True),
             patch.object(cmux_terminal, "open_in_workspace", return_value=handle) as mock_open,
             patch("agent_cli.dev.launch.worktree.get_main_repo_root", return_value=Path("/repo")),
             patch("agent_cli.dev.launch.worktree.get_current_branch", return_value="feature"),
         ):
-            result = launch_agent(tmp_path, agent, multiplexer_name="cmux")
+            result = launch_agent(tmp_path, agent)
 
         assert result == handle
         mock_open.assert_called_once_with(

--- a/tests/dev/test_launch.py
+++ b/tests/dev/test_launch.py
@@ -12,6 +12,7 @@ from agent_cli.dev.launch import (
     write_prompt_to_worktree,
 )
 from agent_cli.dev.terminals import TerminalHandle
+from agent_cli.dev.terminals.cmux import Cmux
 from agent_cli.dev.terminals.tmux import Tmux
 
 
@@ -192,6 +193,33 @@ class TestLaunchAgent:
             f"bash {shlex.quote(str(wrapper_script))}",
             tab_name="feature",
             session_name="agent-cli-repo-1234",
+        )
+
+    def test_cmux_uses_workspace_named_after_repo(self, tmp_path: Path) -> None:
+        """Cmux launches open a tab in a workspace named after the repo."""
+        agent = MagicMock()
+        agent.name = "codex"
+        agent.launch_command.return_value = ["codex"]
+
+        cmux_terminal = Cmux()
+        handle = TerminalHandle("cmux", "surface:5", "repo")
+
+        with (
+            patch("agent_cli.dev.launch.terminals.get_terminal", return_value=cmux_terminal),
+            patch("agent_cli.dev.launch.terminals.detect_current_terminal", return_value=None),
+            patch.object(cmux_terminal, "is_available", return_value=True),
+            patch.object(cmux_terminal, "open_in_workspace", return_value=handle) as mock_open,
+            patch("agent_cli.dev.launch.worktree.get_main_repo_root", return_value=Path("/repo")),
+            patch("agent_cli.dev.launch.worktree.get_current_branch", return_value="feature"),
+        ):
+            result = launch_agent(tmp_path, agent, multiplexer_name="cmux")
+
+        assert result == handle
+        mock_open.assert_called_once_with(
+            tmp_path,
+            "codex",
+            tab_name="feature",
+            workspace_name="repo",
         )
 
     def test_non_tmux_success_does_not_fall_back_to_manual_instructions(

--- a/tests/dev/test_terminals.py
+++ b/tests/dev/test_terminals.py
@@ -10,6 +10,7 @@ import pytest  # noqa: TC002
 
 from agent_cli.dev.terminals import (
     Terminal,
+    TerminalHandle,
     detect_current_terminal,
     get_all_terminals,
     get_available_terminals,
@@ -515,14 +516,15 @@ class TestCmux:
         ]
 
     def test_open_in_workspace_creates_missing_workspace(self) -> None:
-        """A missing workspace is created with cwd and command for its first tab.
+        """A missing workspace is created with cwd, command, and a stable color.
 
         Evidence (verified live against cmux 0.64.14): `cmux workspace create
         --name <t> --cwd <path> --command <cmd>` prints "OK workspace:N",
         starts the initial tab's shell in --cwd, and sends the command with
-        Enter after creation. `cmux rename-tab --workspace <ref> --title <t>`
-        targets that workspace's focused tab, which is the just-created
-        single tab.
+        Enter after creation. `cmux workspace-action --action set-color
+        --color <name>` accepts the named colors listed in its --help.
+        `cmux rename-tab --workspace <ref> --title <t>` targets that
+        workspace's focused tab, which is the just-created single tab.
         """
         terminal = Cmux()
         workspaces_json = '{"window_ref": "window:1", "workspaces": []}'
@@ -532,6 +534,7 @@ class TestCmux:
                 "subprocess.run",
                 side_effect=[
                     MagicMock(stdout=workspaces_json),
+                    MagicMock(stdout="OK workspace:13\n"),
                     MagicMock(stdout="OK workspace:13\n"),
                     MagicMock(stdout="OK action=rename tab=tab:33 workspace=workspace:13\n"),
                 ],
@@ -561,8 +564,85 @@ class TestCmux:
                 "--command",
                 "echo hello",
             ],
+            [
+                "cmux",
+                "workspace-action",
+                "--action",
+                "set-color",
+                "--workspace",
+                "workspace:13",
+                "--color",
+                "Magenta",
+            ],
             ["cmux", "rename-tab", "--workspace", "workspace:13", "--title", "feature"],
         ]
+
+    def test_workspace_color_is_deterministic(self) -> None:
+        """The same workspace name always maps to the same cmux named color."""
+        assert Cmux._workspace_color("my-repo") == "Magenta"
+        assert Cmux._workspace_color("my-repo") == Cmux._workspace_color("my-repo")
+
+    def test_open_tab_closes_surface_when_send_fails(self) -> None:
+        """A failed `send` closes the idle tab and reports failure.
+
+        Without this, the caller would print a success message while the
+        agent never started in the new tab.
+        """
+        terminal = Cmux()
+        send_error = subprocess.CalledProcessError(1, ["cmux", "send"])
+        workspaces_json = (
+            '{"window_ref": "window:1", "workspaces": [{"ref": "workspace:11", "title": "repo"}]}'
+        )
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/cmux"),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    MagicMock(stdout=workspaces_json),
+                    MagicMock(stdout="OK surface:32 pane:25 workspace:11\n"),
+                    send_error,
+                    MagicMock(stdout="OK surface:32\n"),
+                ],
+            ) as mock_run,
+        ):
+            handle = terminal.open_in_workspace(
+                Path("/some/path"),
+                "echo hello",
+                workspace_name="repo",
+            )
+
+        assert handle is None
+        assert mock_run.call_args_list[-1].args[0] == [
+            "cmux",
+            "close-surface",
+            "--workspace",
+            "workspace:11",
+            "--surface",
+            "surface:32",
+        ]
+
+    def test_open_new_tab_uses_repo_root_name(self, tmp_path: Path) -> None:
+        """The generic open_new_tab keeps the one-workspace-per-repo invariant.
+
+        Worktree paths resolve to the main repo root, so tabs land in the
+        repo's workspace rather than one named after the worktree directory.
+        """
+        terminal = Cmux()
+        handle = TerminalHandle("cmux", "surface:5", "repo")
+        with (
+            patch(
+                "agent_cli.dev.terminals.cmux.get_main_repo_root",
+                return_value=Path("/repo"),
+            ),
+            patch.object(terminal, "open_in_workspace", return_value=handle) as mock_open,
+        ):
+            assert terminal.open_new_tab(tmp_path / "worktree", "echo hi", tab_name="t") is True
+        mock_open.assert_called_once_with(
+            tmp_path / "worktree",
+            "echo hi",
+            "t",
+            workspace_name="repo",
+        )
 
     def test_run_sets_cmux_quiet(self) -> None:
         """CLI calls silence cmux deprecation notices via CMUX_QUIET.
@@ -576,12 +656,17 @@ class TestCmux:
         assert mock_run.call_args.kwargs["env"]["CMUX_QUIET"] == "1"
 
     def test_open_in_workspace_returns_none_on_cli_failure(self) -> None:
-        """A failing cmux CLI (e.g. app not running) yields None, not an exception."""
+        """A failing workspace listing aborts immediately, without a create attempt.
+
+        Listing failure (e.g. app not running) is distinct from "workspace
+        not found": creating anyway would fail too, or duplicate a workspace
+        the listing could not see.
+        """
         terminal = Cmux()
         error = subprocess.CalledProcessError(1, ["cmux", "workspace", "list", "--json"])
         with (
             patch("shutil.which", return_value="/usr/local/bin/cmux"),
-            patch("subprocess.run", side_effect=[error, error]),
+            patch("subprocess.run", side_effect=[error]) as mock_run,
         ):
             handle = terminal.open_in_workspace(
                 Path("/some/path"),
@@ -589,6 +674,7 @@ class TestCmux:
                 workspace_name="my-repo",
             )
         assert handle is None
+        assert mock_run.call_count == 1
 
 
 class TestRegistry:

--- a/tests/dev/test_terminals.py
+++ b/tests/dev/test_terminals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -461,6 +462,7 @@ class TestCmux:
           live by sending immediately after surface creation).
         """
         terminal = Cmux()
+        path = Path("/some/work tree")
         workspaces_json = (
             '{"window_ref": "window:1", "workspaces": ['
             '{"ref": "workspace:2", "title": "other"},'
@@ -479,7 +481,7 @@ class TestCmux:
             ) as mock_run,
         ):
             handle = terminal.open_in_workspace(
-                Path("/some/work tree"),
+                path,
                 "echo hello",
                 tab_name="feature",
                 workspace_name="agent-cli",
@@ -511,7 +513,7 @@ class TestCmux:
                 "--surface",
                 "surface:32",
                 "--",
-                "cd '/some/work tree' && echo hello\\n",
+                f"cd {shlex.quote(str(path))} && echo hello\\n",
             ],
         ]
 
@@ -527,6 +529,7 @@ class TestCmux:
         workspace's focused tab, which is the just-created single tab.
         """
         terminal = Cmux()
+        path = Path("/some/path")
         workspaces_json = '{"window_ref": "window:1", "workspaces": []}'
         with (
             patch("shutil.which", return_value="/usr/local/bin/cmux"),
@@ -541,7 +544,7 @@ class TestCmux:
             ) as mock_run,
         ):
             handle = terminal.open_in_workspace(
-                Path("/some/path"),
+                path,
                 "echo hello",
                 tab_name="feature",
                 workspace_name="my-repo",
@@ -560,7 +563,7 @@ class TestCmux:
                 "--name",
                 "my-repo",
                 "--cwd",
-                "/some/path",
+                str(path),
                 "--command",
                 "echo hello",
             ],

--- a/tests/dev/test_terminals.py
+++ b/tests/dev/test_terminals.py
@@ -15,6 +15,7 @@ from agent_cli.dev.terminals import (
     get_available_terminals,
     get_terminal,
 )
+from agent_cli.dev.terminals.cmux import Cmux
 from agent_cli.dev.terminals.kitty import Kitty
 from agent_cli.dev.terminals.tmux import Tmux, TmuxInventory, TmuxWindow
 from agent_cli.dev.terminals.zellij import Zellij
@@ -402,6 +403,194 @@ class TestKitty:
             assert terminal.is_available() is True
 
 
+class TestCmux:
+    """Tests for the cmux terminal.
+
+    Evidence: `cmux --help` (cmux 0.64.14) and live verification on 2026-06-10.
+    cmux is controlled via a Unix socket through its bundled CLI, so all
+    operations are `cmux <command>` subprocess calls that work from any
+    terminal, not just inside cmux.
+    """
+
+    def test_detect_cmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Detect cmux via CMUX_WORKSPACE_ID environment variable.
+
+        Evidence: `cmux --help` Environment section: "CMUX_WORKSPACE_ID
+        Auto-set in cmux terminals." (same for CMUX_SURFACE_ID).
+        """
+        monkeypatch.delenv("CMUX_SURFACE_ID", raising=False)
+        monkeypatch.setenv("CMUX_WORKSPACE_ID", "AB56033C-F3AB-46DC-83D2-2891F13F47C5")
+        terminal = Cmux()
+        assert terminal.detect() is True
+
+    def test_detect_cmux_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not in cmux when its environment variables are not set."""
+        monkeypatch.delenv("CMUX_WORKSPACE_ID", raising=False)
+        monkeypatch.delenv("CMUX_SURFACE_ID", raising=False)
+        terminal = Cmux()
+        assert terminal.detect() is False
+
+    def test_is_available(self) -> None:
+        """Cmux is available if the CLI is in PATH.
+
+        Evidence: the Homebrew cask installs the CLI binary at
+        /Applications/cmux.app/Contents/Resources/bin/cmux and cmux adds it
+        to PATH.
+        """
+        terminal = Cmux()
+        with patch(
+            "shutil.which", return_value="/Applications/cmux.app/Contents/Resources/bin/cmux"
+        ):
+            assert terminal.is_available() is True
+
+    def test_open_in_workspace_opens_tab_in_existing_workspace(self) -> None:
+        r"""An existing workspace (matched by title) gets a new named tab.
+
+        Evidence (verified live against cmux 0.64.14):
+        - `cmux workspace list --json` returns {"workspaces": [{"ref":
+          "workspace:N", "title": ...}]}.
+        - `cmux new-surface --workspace <ref>` creates a tab and prints
+          "OK surface:N pane:N workspace:N".
+        - `cmux rename-tab --workspace <ref> --surface <ref> --title <t>`
+          renames the tab.
+        - `cmux send` has no auto-Enter; per `cmux send --help` the literal
+          escape sequence \\n sends Enter. New surfaces don't accept a
+          cwd/command flag, so the launch command is typed into the shell;
+          the terminal buffers the input until the shell is ready (verified
+          live by sending immediately after surface creation).
+        """
+        terminal = Cmux()
+        workspaces_json = (
+            '{"window_ref": "window:1", "workspaces": ['
+            '{"ref": "workspace:2", "title": "other"},'
+            '{"ref": "workspace:11", "title": "agent-cli"}]}'
+        )
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/cmux"),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    MagicMock(stdout=workspaces_json),
+                    MagicMock(stdout="OK surface:32 pane:25 workspace:11\n"),
+                    MagicMock(stdout="OK action=rename tab=tab:32 workspace=workspace:11\n"),
+                    MagicMock(stdout="OK surface:32 workspace:11\n"),
+                ],
+            ) as mock_run,
+        ):
+            handle = terminal.open_in_workspace(
+                Path("/some/work tree"),
+                "echo hello",
+                tab_name="feature",
+                workspace_name="agent-cli",
+            )
+
+        assert handle is not None
+        assert handle.terminal_name == "cmux"
+        assert handle.handle == "surface:32"
+        assert handle.session_name == "agent-cli"
+        argvs = [call.args[0] for call in mock_run.call_args_list]
+        assert argvs == [
+            ["cmux", "workspace", "list", "--json"],
+            ["cmux", "new-surface", "--workspace", "workspace:11"],
+            [
+                "cmux",
+                "rename-tab",
+                "--workspace",
+                "workspace:11",
+                "--surface",
+                "surface:32",
+                "--title",
+                "feature",
+            ],
+            [
+                "cmux",
+                "send",
+                "--workspace",
+                "workspace:11",
+                "--surface",
+                "surface:32",
+                "--",
+                "cd '/some/work tree' && echo hello\\n",
+            ],
+        ]
+
+    def test_open_in_workspace_creates_missing_workspace(self) -> None:
+        """A missing workspace is created with cwd and command for its first tab.
+
+        Evidence (verified live against cmux 0.64.14): `cmux workspace create
+        --name <t> --cwd <path> --command <cmd>` prints "OK workspace:N",
+        starts the initial tab's shell in --cwd, and sends the command with
+        Enter after creation. `cmux rename-tab --workspace <ref> --title <t>`
+        targets that workspace's focused tab, which is the just-created
+        single tab.
+        """
+        terminal = Cmux()
+        workspaces_json = '{"window_ref": "window:1", "workspaces": []}'
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/cmux"),
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    MagicMock(stdout=workspaces_json),
+                    MagicMock(stdout="OK workspace:13\n"),
+                    MagicMock(stdout="OK action=rename tab=tab:33 workspace=workspace:13\n"),
+                ],
+            ) as mock_run,
+        ):
+            handle = terminal.open_in_workspace(
+                Path("/some/path"),
+                "echo hello",
+                tab_name="feature",
+                workspace_name="my-repo",
+            )
+
+        assert handle is not None
+        assert handle.handle == "workspace:13"
+        assert handle.session_name == "my-repo"
+        argvs = [call.args[0] for call in mock_run.call_args_list]
+        assert argvs == [
+            ["cmux", "workspace", "list", "--json"],
+            [
+                "cmux",
+                "workspace",
+                "create",
+                "--name",
+                "my-repo",
+                "--cwd",
+                "/some/path",
+                "--command",
+                "echo hello",
+            ],
+            ["cmux", "rename-tab", "--workspace", "workspace:13", "--title", "feature"],
+        ]
+
+    def test_run_sets_cmux_quiet(self) -> None:
+        """CLI calls silence cmux deprecation notices via CMUX_QUIET.
+
+        Evidence: legacy command forms print "set CMUX_QUIET=1 to silence
+        this notice", which would corrupt parsed output.
+        """
+        terminal = Cmux()
+        with patch("subprocess.run", return_value=MagicMock(stdout="PONG\n")) as mock_run:
+            assert terminal._run(["ping"]) == "PONG\n"
+        assert mock_run.call_args.kwargs["env"]["CMUX_QUIET"] == "1"
+
+    def test_open_in_workspace_returns_none_on_cli_failure(self) -> None:
+        """A failing cmux CLI (e.g. app not running) yields None, not an exception."""
+        terminal = Cmux()
+        error = subprocess.CalledProcessError(1, ["cmux", "workspace", "list", "--json"])
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/cmux"),
+            patch("subprocess.run", side_effect=[error, error]),
+        ):
+            handle = terminal.open_in_workspace(
+                Path("/some/path"),
+                "echo hello",
+                workspace_name="my-repo",
+            )
+        assert handle is None
+
+
 class TestRegistry:
     """Tests for terminal registry functions."""
 
@@ -442,6 +631,23 @@ class TestRegistry:
         terminal = detect_current_terminal()
         assert terminal is not None
         assert terminal.name == "zellij"
+
+    def test_detect_current_terminal_cmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Detect current terminal as cmux when no multiplexer is running."""
+        monkeypatch.delenv("TMUX", raising=False)
+        monkeypatch.delenv("ZELLIJ", raising=False)
+        monkeypatch.setenv("CMUX_WORKSPACE_ID", "AB56033C-F3AB-46DC-83D2-2891F13F47C5")
+        terminal = detect_current_terminal()
+        assert terminal is not None
+        assert terminal.name == "cmux"
+
+    def test_detect_tmux_wins_inside_cmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Tmux running inside a cmux tab is detected as tmux (innermost wins)."""
+        monkeypatch.setenv("TMUX", "/run/user/1000/tmux")
+        monkeypatch.setenv("CMUX_WORKSPACE_ID", "AB56033C-F3AB-46DC-83D2-2891F13F47C5")
+        terminal = detect_current_terminal()
+        assert terminal is not None
+        assert terminal.name == "tmux"
 
     def test_get_available_terminals(self) -> None:
         """Get available terminals returns list."""


### PR DESCRIPTION
## Summary

Adds [cmux](https://cmux.dev) (Ghostty-based macOS terminal for AI coding agents, controlled via a Unix socket through its bundled CLI) as a supported terminal for `agent-cli dev`.

The repo↔cmux mapping: **one workspace per repository name, one tab per worktree.**

- First launch for a repo: `cmux workspace create --name <repo> --cwd <worktree> --command <agent-cmd>` creates the workspace with the agent running in its first tab.
- Subsequent launches: `cmux new-surface --workspace <ref>` opens a tab in the existing workspace (matched by title via `cmux workspace list --json`), `rename-tab` names it after the branch, and `cmux send` types `cd <worktree> && <agent-cmd>` plus Enter. New surfaces don't accept cwd/command flags, so typing into the shell is the supported route; the terminal buffers the input until the shell is ready (verified live).

## Changes

- New `Cmux` terminal adapter (`agent_cli/dev/terminals/cmux.py`), detected via the `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` env vars that cmux auto-sets in its terminals
- Registered in the terminal registry after tmux/zellij, so multiplexers running inside a cmux tab still win detection
- Detection-only, like other GUI terminals — no `--multiplexer` involvement
- Success summary shows `cmux Workspace: <repo>`; the tmux `Attach:` hint is no longer printed for non-tmux handles
- Tests with evidence-based docstrings (cmux CLI help contracts + live verification against cmux 0.64.14), docs table

## Testing

- `pytest`: 1411 passed, 4 skipped
- `pre-commit run --all-files`: passes (jscpd fails locally on a clean tree due to a missing platform binary, unrelated)
- Live-tested against a running cmux app: first `dev new` in a scratch repo created the repo-named workspace with a branch-named tab running Claude in the worktree; second `dev new` reused the workspace and added a second tab whose agent started in the second worktree's directory