### PR TITLE
Fix Wyoming TTS voice selection and metadata

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -178,6 +178,15 @@ def _download_tts_models(
     console.print("[bold green]Download complete![/bold green]")
 
 
+def _default_tts_model(backend: str) -> str:
+    """Get the default model or voice for a resolved TTS backend."""
+    if backend == "kokoro":
+        from agent_cli.server.tts.backends.kokoro import DEFAULT_VOICE  # noqa: PLC0415
+
+        return DEFAULT_VOICE
+    return "en_US-lessac-medium"
+
+
 def _check_whisper_deps(backend: str, *, download_only: bool = False) -> None:
     """Check that Whisper dependencies are available."""
     _check_server_deps()
@@ -911,7 +920,7 @@ def tts_cmd(  # noqa: PLR0915
 
     # Default model based on backend (Kokoro auto-downloads from HuggingFace)
     if model is None:
-        model = ["kokoro"] if resolved_backend == "kokoro" else ["en_US-lessac-medium"]
+        model = [_default_tts_model(resolved_backend)]
 
     # Validate default model against model list
     if default_model is not None and default_model not in model:

--- a/agent_cli/server/tts/backends/__init__.py
+++ b/agent_cli/server/tts/backends/__init__.py
@@ -17,9 +17,10 @@ from agent_cli.server.tts.backends.base import (
 logger = logging.getLogger(__name__)
 
 BackendType = Literal["piper", "kokoro", "auto"]
+ResolvedBackendType = Literal["piper", "kokoro"]
 
 
-def detect_backend() -> Literal["piper", "kokoro"]:
+def detect_backend() -> ResolvedBackendType:
     """Detect the best backend for the current platform.
 
     Returns:
@@ -76,6 +77,7 @@ def create_backend(
 __all__ = [
     "BackendConfig",
     "BackendType",
+    "ResolvedBackendType",
     "SynthesisResult",
     "create_backend",
     "detect_backend",

--- a/agent_cli/server/tts/model_manager.py
+++ b/agent_cli/server/tts/model_manager.py
@@ -12,8 +12,10 @@ from agent_cli.server.model_manager import ModelConfig, ModelManager, ModelStats
 from agent_cli.server.tts.backends import (
     BackendConfig,
     BackendType,
+    ResolvedBackendType,
     SynthesisResult,
     create_backend,
+    detect_backend,
 )
 
 if TYPE_CHECKING:
@@ -40,15 +42,24 @@ class TTSModelManager:
     def __init__(self, config: TTSModelConfig) -> None:
         """Initialize the TTS model manager."""
         self.config = config
+        backend_type: ResolvedBackendType = (
+            detect_backend() if config.backend_type == "auto" else config.backend_type
+        )
+        self._backend_type = backend_type
         backend = create_backend(
             BackendConfig(
                 model_name=config.model_name,
                 device=config.device,
                 cache_dir=config.cache_dir,
             ),
-            backend_type=config.backend_type,
+            backend_type=backend_type,
         )
         self._manager = ModelManager(backend, config)
+
+    @property
+    def backend_type(self) -> ResolvedBackendType:
+        """Get the resolved backend type."""
+        return self._backend_type
 
     @property
     def stats(self) -> ModelStats:

--- a/agent_cli/server/tts/wyoming_handler.py
+++ b/agent_cli/server/tts/wyoming_handler.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from functools import partial
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
@@ -38,11 +37,18 @@ _KOKORO_LANGUAGE_TAGS = {
 def _tts_voice(name: str, backend_type: str) -> TtsVoice:
     """Build Wyoming voice metadata for a registered TTS model."""
     if backend_type == "kokoro":
-        from agent_cli.server.tts.backends.kokoro import DEFAULT_VOICE  # noqa: PLC0415
+        prefix, separator, voice_name = name.partition("_")
+        is_voice = (
+            separator == "_"
+            and prefix[:1] in _KOKORO_LANGUAGE_TAGS
+            and prefix[1:] in {"f", "m"}
+            and bool(voice_name)
+        )
+        if not is_voice:
+            from agent_cli.server.tts.backends.kokoro import DEFAULT_VOICE  # noqa: PLC0415
 
-        if name == "kokoro" or Path(name).suffix.lower() == ".pth":
             name = DEFAULT_VOICE
-        language = _KOKORO_LANGUAGE_TAGS.get(Path(name).stem[:1].lower(), "en")
+        language = _KOKORO_LANGUAGE_TAGS[name[0]]
         return TtsVoice(
             name=name,
             description=f"Kokoro TTS {name}",

--- a/agent_cli/server/tts/wyoming_handler.py
+++ b/agent_cli/server/tts/wyoming_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
@@ -20,6 +21,48 @@ if TYPE_CHECKING:
     from agent_cli.server.tts.model_registry import TTSModelRegistry
 
 logger = logging.getLogger(__name__)
+
+_KOKORO_LANGUAGE_TAGS = {
+    "a": "en-US",
+    "b": "en-GB",
+    "e": "es",
+    "f": "fr",
+    "h": "hi",
+    "i": "it",
+    "j": "ja",
+    "p": "pt-BR",
+    "z": "zh",
+}
+
+
+def _tts_voice(name: str, backend_type: str) -> TtsVoice:
+    """Build Wyoming voice metadata for a registered TTS model."""
+    if backend_type == "kokoro":
+        language = _KOKORO_LANGUAGE_TAGS.get(Path(name).stem[:1].lower(), "en")
+        return TtsVoice(
+            name=name,
+            description=f"Kokoro TTS {name}",
+            attribution=Attribution(
+                name="Kokoro",
+                url="https://huggingface.co/hexgrad/Kokoro-82M",
+            ),
+            installed=True,
+            languages=[language],
+            version="1.0",
+        )
+
+    return TtsVoice(
+        name=name,
+        description=f"Piper TTS {name}",
+        attribution=Attribution(
+            name="Piper",
+            url="https://github.com/rhasspy/piper",
+        ),
+        installed=True,
+        # Extract language from model name (e.g., "en_US-lessac-medium" -> "en")
+        languages=[name.split("_", maxsplit=1)[0] if "_" in name else "en"],
+        version="1.0",
+    )
 
 
 class WyomingTTSHandler(AsyncEventHandler):
@@ -88,11 +131,12 @@ class WyomingTTSHandler(AsyncEventHandler):
 
         try:
             manager = self._registry.get_manager()
+            voice = synthesize.voice.name if synthesize.voice else None
 
             if manager.supports_streaming:
-                await self._synthesize_streaming(manager, text, synthesize.voice)
+                await self._synthesize_streaming(manager, text, voice)
             else:
-                await self._synthesize_complete(manager, text, synthesize.voice)
+                await self._synthesize_complete(manager, text, voice)
 
         except Exception:
             logger.exception("Wyoming synthesis failed")
@@ -194,17 +238,9 @@ class WyomingTTSHandler(AsyncEventHandler):
 
         # Get list of available models as voices
         voices = [
-            TtsVoice(
-                name=status.name,
-                description=f"Piper TTS {status.name}",
-                attribution=Attribution(
-                    name="Piper",
-                    url="https://github.com/rhasspy/piper",
-                ),
-                installed=True,
-                # Extract language from model name (e.g., "en_US-lessac-medium" -> "en")
-                languages=[status.name.split("_")[0] if "_" in status.name else "en"],
-                version="1.0",
+            _tts_voice(
+                status.name,
+                self._registry.get_manager(status.name).config.backend_type,
             )
             for status in self._registry.list_status()
         ]

--- a/agent_cli/server/tts/wyoming_handler.py
+++ b/agent_cli/server/tts/wyoming_handler.py
@@ -38,6 +38,10 @@ _KOKORO_LANGUAGE_TAGS = {
 def _tts_voice(name: str, backend_type: str) -> TtsVoice:
     """Build Wyoming voice metadata for a registered TTS model."""
     if backend_type == "kokoro":
+        from agent_cli.server.tts.backends.kokoro import DEFAULT_VOICE  # noqa: PLC0415
+
+        if name == "kokoro" or Path(name).suffix.lower() == ".pth":
+            name = DEFAULT_VOICE
         language = _KOKORO_LANGUAGE_TAGS.get(Path(name).stem[:1].lower(), "en")
         return TtsVoice(
             name=name,
@@ -240,7 +244,7 @@ class WyomingTTSHandler(AsyncEventHandler):
         voices = [
             _tts_voice(
                 status.name,
-                self._registry.get_manager(status.name).config.backend_type,
+                self._registry.get_manager(status.name).backend_type,
             )
             for status in self._registry.list_status()
         ]

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -235,6 +235,33 @@ def test_server_tts_command_in_cli() -> None:
 
 
 @patch("uvicorn.run")
+def test_server_tts_kokoro_defaults_to_default_voice(mock_uvicorn_run: MagicMock) -> None:
+    """Kokoro server should register its default voice, not its model sentinel."""
+    runner = CliRunner()
+    registry = MagicMock(default_model="af_heart")
+
+    with (
+        patch("agent_cli.core.deps._check_and_install_extras", return_value=[]),
+        patch("agent_cli.server.cli._check_tts_deps"),
+        patch(
+            "agent_cli.server.tts.model_registry.create_tts_registry",
+            return_value=registry,
+        ) as mock_create_registry,
+    ):
+        result = runner.invoke(
+            cli_app,
+            ["server", "tts", "--backend", "kokoro", "--no-wyoming"],
+        )
+
+    assert result.exit_code == 0
+    mock_create_registry.assert_called_once_with(default_model="af_heart")
+    registered_config = registry.register.call_args.args[0]
+    assert registered_config.model_name == "af_heart"
+    assert registered_config.backend_type == "kokoro"
+    mock_uvicorn_run.assert_called_once()
+
+
+@patch("uvicorn.run")
 def test_server_tts_accepts_tts_wyoming_port_alias(mock_uvicorn_run: MagicMock) -> None:
     """TTS server should accept the client-style TTS Wyoming port alias."""
     runner = CliRunner()

--- a/tests/test_server_tts.py
+++ b/tests/test_server_tts.py
@@ -174,10 +174,32 @@ class TestTTSModelManager:
     def test_init(self, manager: TTSModelManager, config: TTSModelConfig) -> None:
         """Test manager initialization."""
         assert manager.config == config
+        assert manager.backend_type == "piper"
         assert not manager.is_loaded
         assert manager.ttl_remaining is None
         assert manager.device is None
         assert manager.stats.load_count == 0
+
+    def test_auto_backend_type_is_resolved(self) -> None:
+        """Auto detection should be retained as resolved manager metadata."""
+        config = TTSModelConfig(model_name="af_heart", backend_type="auto")
+        mock_backend = MagicMock(is_loaded=False, device=None)
+
+        with (
+            patch(
+                "agent_cli.server.tts.model_manager.detect_backend",
+                return_value="kokoro",
+            ),
+            patch(
+                "agent_cli.server.tts.model_manager.create_backend",
+                return_value=mock_backend,
+            ) as mock_create_backend,
+        ):
+            manager = TTSModelManager(config)
+
+        assert manager.backend_type == "kokoro"
+        assert config.backend_type == "auto"
+        assert mock_create_backend.call_args.kwargs["backend_type"] == "kokoro"
 
     @pytest.mark.asyncio
     async def test_start_stop(self, manager: TTSModelManager) -> None:

--- a/tests/test_server_tts_wyoming.py
+++ b/tests/test_server_tts_wyoming.py
@@ -33,6 +33,16 @@ def test_kokoro_voice_language_tags(name: str, language: str) -> None:
     assert _tts_voice(name, "kokoro").languages == [language]
 
 
+@pytest.mark.parametrize("model_name", ["kokoro", "/models/kokoro-v1_0.pth"])
+def test_kokoro_model_name_advertises_default_voice(model_name: str) -> None:
+    """Kokoro model identifiers should not be advertised as voice names."""
+    voice = _tts_voice(model_name, "kokoro")
+
+    assert voice.name == "af_heart"
+    assert voice.description == "Kokoro TTS af_heart"
+    assert voice.languages == ["en-US"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("supports_streaming", [True, False])
 async def test_synthesize_passes_voice_name(supports_streaming: bool) -> None:
@@ -68,9 +78,9 @@ async def test_describe_uses_backend_voice_metadata() -> None:
         SimpleNamespace(name="en_US-lessac-medium"),
     ]
     registry.get_manager.side_effect = [
-        SimpleNamespace(config=SimpleNamespace(backend_type="kokoro")),
-        SimpleNamespace(config=SimpleNamespace(backend_type="kokoro")),
-        SimpleNamespace(config=SimpleNamespace(backend_type="piper")),
+        SimpleNamespace(backend_type="kokoro"),
+        SimpleNamespace(backend_type="kokoro"),
+        SimpleNamespace(backend_type="piper"),
     ]
     handler = _handler(registry)
     write_event = AsyncMock()

--- a/tests/test_server_tts_wyoming.py
+++ b/tests/test_server_tts_wyoming.py
@@ -1,0 +1,94 @@
+"""Tests for the Wyoming TTS server handler."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from wyoming.info import Info
+from wyoming.tts import Synthesize, SynthesizeVoice
+
+from agent_cli.server.tts.wyoming_handler import WyomingTTSHandler, _tts_voice
+
+
+def _handler(registry: MagicMock) -> WyomingTTSHandler:
+    return WyomingTTSHandler(registry, MagicMock(), MagicMock())
+
+
+@pytest.mark.parametrize(
+    ("name", "language"),
+    [
+        ("af_heart", "en-US"),
+        ("bm_george", "en-GB"),
+        ("ef_dora", "es"),
+        ("ff_siwis", "fr"),
+        ("hf_alpha", "hi"),
+        ("if_sara", "it"),
+        ("jf_alpha", "ja"),
+        ("pf_dora", "pt-BR"),
+        ("zf_xiaobei", "zh"),
+    ],
+)
+def test_kokoro_voice_language_tags(name: str, language: str) -> None:
+    """Kokoro voice prefixes should map to language tags, not ISO codes."""
+    assert _tts_voice(name, "kokoro").languages == [language]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("supports_streaming", [True, False])
+async def test_synthesize_passes_voice_name(supports_streaming: bool) -> None:
+    """Wyoming voice objects should be reduced to the selected voice name."""
+    manager = MagicMock(supports_streaming=supports_streaming)
+    registry = MagicMock()
+    registry.get_manager.return_value = manager
+    handler = _handler(registry)
+    synthesize_streaming = AsyncMock()
+    synthesize_complete = AsyncMock()
+    event = Synthesize(
+        text="Hello",
+        voice=SynthesizeVoice(name="bm_george", speaker="speaker-1"),
+    ).event()
+
+    with (
+        patch.object(handler, "_synthesize_streaming", synthesize_streaming),
+        patch.object(handler, "_synthesize_complete", synthesize_complete),
+    ):
+        assert await handler.handle_event(event) is False
+
+    method = synthesize_streaming if supports_streaming else synthesize_complete
+    method.assert_awaited_once_with(manager, "Hello", "bm_george")
+
+
+@pytest.mark.asyncio
+async def test_describe_uses_backend_voice_metadata() -> None:
+    """Kokoro voices should advertise real languages and Kokoro attribution."""
+    registry = MagicMock()
+    registry.list_status.return_value = [
+        SimpleNamespace(name="af_heart"),
+        SimpleNamespace(name="bm_george"),
+        SimpleNamespace(name="en_US-lessac-medium"),
+    ]
+    registry.get_manager.side_effect = [
+        SimpleNamespace(config=SimpleNamespace(backend_type="kokoro")),
+        SimpleNamespace(config=SimpleNamespace(backend_type="kokoro")),
+        SimpleNamespace(config=SimpleNamespace(backend_type="piper")),
+    ]
+    handler = _handler(registry)
+    write_event = AsyncMock()
+
+    with patch.object(handler, "write_event", write_event):
+        assert await handler._handle_describe() is True
+
+    await_args = write_event.await_args
+    assert await_args is not None
+    event = await_args.args[0]
+    voices = Info.from_event(event).tts[0].voices
+    assert voices is not None
+    assert [(voice.name, voice.languages) for voice in voices] == [
+        ("af_heart", ["en-US"]),
+        ("bm_george", ["en-GB"]),
+        ("en_US-lessac-medium", ["en"]),
+    ]
+    assert voices[0].description == "Kokoro TTS af_heart"
+    assert voices[0].attribution.name == "Kokoro"
+    assert voices[2].description == "Piper TTS en_US-lessac-medium"
+    assert voices[2].attribution.name == "Piper"

--- a/tests/test_server_tts_wyoming.py
+++ b/tests/test_server_tts_wyoming.py
@@ -33,7 +33,10 @@ def test_kokoro_voice_language_tags(name: str, language: str) -> None:
     assert _tts_voice(name, "kokoro").languages == [language]
 
 
-@pytest.mark.parametrize("model_name", ["kokoro", "/models/kokoro-v1_0.pth"])
+@pytest.mark.parametrize(
+    "model_name",
+    ["kokoro", "/models/kokoro-v1_0.pth", "kokoro-v1_0", "custom-model"],
+)
 def test_kokoro_model_name_advertises_default_voice(model_name: str) -> None:
     """Kokoro model identifiers should not be advertised as voice names."""
     voice = _tts_voice(model_name, "kokoro")


### PR DESCRIPTION
## Summary

- Pass selected Wyoming voice name to TTS manager instead of raw `SynthesizeVoice` object.
- Advertise Kokoro voices with correct language tags and Kokoro attribution while preserving Piper metadata.
- Add protocol-level regression tests for streaming, complete synthesis, and describe responses.

Closes #592
Closes #593

## Testing

- `uv run pytest -q tests` (1461 passed, 4 skipped)
- Ruff, formatting, mypy, and pylint duplicate-code checks passed.