### PR TITLE
Cut ~1.3s off hotkey-to-microphone latency

### DIFF
--- a/agent_cli/__init__.py
+++ b/agent_cli/__init__.py
@@ -1,5 +1,18 @@
 """A suite of AI-powered command-line tools for text correction, audio transcription, and voice assistance."""
 
-from importlib.metadata import version
+from typing import TYPE_CHECKING
 
-__version__ = version("agent-cli")
+if TYPE_CHECKING:
+    __version__: str
+
+__all__ = ["__version__"]
+
+
+def __getattr__(name: str) -> str:
+    """Resolve `__version__` lazily; `importlib.metadata` costs ~40ms to import."""
+    if name == "__version__":
+        from importlib.metadata import version  # noqa: PLC0415
+
+        return version("agent-cli")
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/agent_cli/__init__.py
+++ b/agent_cli/__init__.py
@@ -5,11 +5,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     __version__: str
 
-__all__ = ["__version__"]
-
 
 def __getattr__(name: str) -> str:
-    """Resolve `__version__` lazily; `importlib.metadata` costs ~40ms to import."""
+    """Resolve `__version__` lazily; reading distribution metadata costs ~29ms."""
     if name == "__version__":
         from importlib.metadata import version  # noqa: PLC0415
 

--- a/agent_cli/cli.py
+++ b/agent_cli/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
+from rich.table import Table
 
 from .config import load_config, normalize_provider_defaults
 from .core.process import set_process_title
@@ -47,8 +48,6 @@ app = typer.Typer(
 
 def _version_callback(value: bool) -> None:
     if value:
-        from rich.table import Table  # noqa: PLC0415
-
         from . import __version__  # noqa: PLC0415
 
         path = Path(__file__).parent

--- a/agent_cli/cli.py
+++ b/agent_cli/cli.py
@@ -7,9 +7,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich.table import Table
 
-from . import __version__
 from .config import load_config, normalize_provider_defaults
 from .core.process import set_process_title
 from .core.utils import console
@@ -49,6 +47,10 @@ app = typer.Typer(
 
 def _version_callback(value: bool) -> None:
     if value:
+        from rich.table import Table  # noqa: PLC0415
+
+        from . import __version__  # noqa: PLC0415
+
         path = Path(__file__).parent
         data = [
             ("agent-cli version", __version__),

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -29,9 +29,11 @@ private final class UserInstalledCLICheckCache {
 
 /// Caches the login shell PATH lookup, which costs a full `zsh -lic` startup
 /// (~1s with a typical dotfiles setup) and would otherwise run on every command.
+/// Only successful lookups are cached, so a shell that fails once does not
+/// degrade PATH for the rest of the session.
 private final class LoginShellPATHCache {
     private let lock = NSLock()
-    private var resolved: String??
+    private var resolved: String?
 
     func value(compute: () -> String?) -> String? {
         lock.lock()
@@ -39,9 +41,8 @@ private final class LoginShellPATHCache {
         if let resolved {
             return resolved
         }
-        let value = compute()
-        resolved = value
-        return value
+        resolved = compute()
+        return resolved
     }
 
     func invalidate() {

--- a/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
+++ b/macos/AgentCLI/Sources/AgentCLI/AgentRuntime.swift
@@ -27,6 +27,28 @@ private final class UserInstalledCLICheckCache {
     }
 }
 
+/// Caches the login shell PATH lookup, which costs a full `zsh -lic` startup
+/// (~1s with a typical dotfiles setup) and would otherwise run on every command.
+private final class LoginShellPATHCache {
+    private let lock = NSLock()
+    private var resolved: String??
+
+    func value(compute: () -> String?) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let resolved {
+            return resolved
+        }
+        let value = compute()
+        resolved = value
+        return value
+    }
+
+    func invalidate() {
+        lock.withLock { resolved = nil }
+    }
+}
+
 typealias AgentProcessRunner = (URL, [String], [String: String]) -> CommandResult
 typealias LocalhostConnector = (UInt16) -> Bool
 
@@ -58,6 +80,7 @@ struct AgentRuntime {
     private let processRunner: AgentProcessRunner
     private let localhostConnector: LocalhostConnector
     private let userInstalledCLICheckCache: UserInstalledCLICheckCache
+    private let loginShellPATHCache: LoginShellPATHCache
     private let whisperReadyTimeout: TimeInterval
     let appSupportURL: URL
     let bundledUVURL: URL
@@ -90,6 +113,7 @@ struct AgentRuntime {
         self.processRunner = processRunner
         self.localhostConnector = localhostConnector
         self.userInstalledCLICheckCache = UserInstalledCLICheckCache()
+        self.loginShellPATHCache = LoginShellPATHCache()
         self.whisperReadyTimeout = whisperReadyTimeout
 
         if let override = environment["AGENTCLI_APP_SUPPORT_DIR"], !override.isEmpty {
@@ -343,6 +367,9 @@ struct AgentRuntime {
         progress: AgentBootstrapProgress = { _ in }
     ) -> CommandResult {
         let mode = runtimeMode
+        if force {
+            loginShellPATHCache.invalidate()
+        }
         do {
             try prepareDirectories(for: mode)
         } catch {
@@ -647,7 +674,7 @@ struct AgentRuntime {
         let existingPATH = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         environment["PATH"] = userInstalledCLIPath(
             existingPATH: existingPATH,
-            loginShellPATH: Self.loginShellPATH(environment: baseEnvironment)
+            loginShellPATH: loginShellPATHCache.value { loginShellPATH() }
         )
         return environment
     }
@@ -708,14 +735,14 @@ struct AgentRuntime {
             .joined(separator: ":")
     }
 
-    private static func loginShellPATH(environment: [String: String]) -> String? {
-        let shellPath = environment["SHELL"].flatMap { $0.isEmpty ? nil : $0 } ?? "/bin/zsh"
-        guard FileManager.default.isExecutableFile(atPath: shellPath) else { return nil }
+    private func loginShellPATH() -> String? {
+        let shellPath = baseEnvironment["SHELL"].flatMap { $0.isEmpty ? nil : $0 } ?? "/bin/zsh"
+        guard fileManager.isExecutableFile(atPath: shellPath) else { return nil }
 
-        let result = runProcess(
-            executableURL: URL(fileURLWithPath: shellPath),
-            arguments: ["-lic", "printf '%s\\n' \"$PATH\""],
-            environment: environment
+        let result = processRunner(
+            URL(fileURLWithPath: shellPath),
+            ["-lic", "printf '%s\\n' \"$PATH\""],
+            baseEnvironment
         )
         guard result.exitCode == 0 else { return nil }
 

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -242,14 +242,15 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(components.filter { $0 == "/usr/bin" }.count, 1)
     }
 
-    /// `zsh -lic` costs roughly a second with a real dotfiles setup, so the login shell
-    /// PATH must be resolved once per runtime instead of once per spawned command.
-    func testUserInstalledRuntimeCachesLoginShellPATHLookup() {
-        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-shell-path-cache")!
-        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-shell-path-cache")
+    /// Builds a user-installed runtime whose process runner counts `zsh -lic` PATH probes.
+    private func makeShellPATHProbingRuntime(
+        suiteName: String,
+        onShellProbe: @escaping () -> Void
+    ) -> AgentRuntime {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
         defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
-        var shellInvocations = 0
-        let runtime = AgentRuntime(
+        return AgentRuntime(
             environment: [
                 "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
                 "PATH": "/custom/bin",
@@ -260,45 +261,39 @@ final class AgentCommandTests: XCTestCase {
                 guard arguments.first == "-lic" else {
                     return CommandResult(exitCode: 0, output: "")
                 }
-                shellInvocations += 1
+                onShellProbe()
                 return CommandResult(exitCode: 0, output: "/shell/bin\n")
             }
         )
+    }
+
+    /// `zsh -lic` costs roughly a second with a real dotfiles setup, so the login shell
+    /// PATH must be resolved once per runtime instead of once per spawned command.
+    func testUserInstalledRuntimeCachesLoginShellPATHLookup() {
+        var shellProbes = 0
+        let runtime = makeShellPATHProbingRuntime(
+            suiteName: "AgentCLITests.user-runtime-shell-path-cache"
+        ) { shellProbes += 1 }
 
         _ = runtime.commandEnvironment()
         let environment = runtime.commandEnvironment()
         _ = runtime.runAgentCLI(arguments: ["--version"])
 
-        XCTAssertEqual(shellInvocations, 1)
+        XCTAssertEqual(shellProbes, 1)
         XCTAssertEqual(environment["PATH"]?.split(separator: ":").first.map(String.init), "/shell/bin")
     }
 
     func testForcedInstallRefreshesLoginShellPATHLookup() {
-        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-shell-path-refresh")!
-        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-shell-path-refresh")
-        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
-        var shellInvocations = 0
-        let runtime = AgentRuntime(
-            environment: [
-                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
-                "PATH": "/custom/bin",
-                "SHELL": "/bin/zsh",
-            ],
-            userDefaults: defaults,
-            processRunner: { _, arguments, _ in
-                guard arguments.first == "-lic" else {
-                    return CommandResult(exitCode: 0, output: "")
-                }
-                shellInvocations += 1
-                return CommandResult(exitCode: 0, output: "/shell/bin\n")
-            }
-        )
+        var shellProbes = 0
+        let runtime = makeShellPATHProbingRuntime(
+            suiteName: "AgentCLITests.user-runtime-shell-path-refresh"
+        ) { shellProbes += 1 }
 
         _ = runtime.commandEnvironment()
         _ = runtime.ensureInstalled(force: true)
         _ = runtime.commandEnvironment()
 
-        XCTAssertEqual(shellInvocations, 2)
+        XCTAssertEqual(shellProbes, 2)
     }
 
     func testTranscriptionBootstrapRepairsStaleWhisperDaemonMarker() throws {

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -242,6 +242,65 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(components.filter { $0 == "/usr/bin" }.count, 1)
     }
 
+    /// `zsh -lic` costs roughly a second with a real dotfiles setup, so the login shell
+    /// PATH must be resolved once per runtime instead of once per spawned command.
+    func testUserInstalledRuntimeCachesLoginShellPATHLookup() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-shell-path-cache")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-shell-path-cache")
+        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+        var shellInvocations = 0
+        let runtime = AgentRuntime(
+            environment: [
+                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
+                "PATH": "/custom/bin",
+                "SHELL": "/bin/zsh",
+            ],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                guard arguments.first == "-lic" else {
+                    return CommandResult(exitCode: 0, output: "")
+                }
+                shellInvocations += 1
+                return CommandResult(exitCode: 0, output: "/shell/bin\n")
+            }
+        )
+
+        _ = runtime.commandEnvironment()
+        let environment = runtime.commandEnvironment()
+        _ = runtime.runAgentCLI(arguments: ["--version"])
+
+        XCTAssertEqual(shellInvocations, 1)
+        XCTAssertEqual(environment["PATH"]?.split(separator: ":").first.map(String.init), "/shell/bin")
+    }
+
+    func testForcedInstallRefreshesLoginShellPATHLookup() {
+        let defaults = UserDefaults(suiteName: "AgentCLITests.user-runtime-shell-path-refresh")!
+        defaults.removePersistentDomain(forName: "AgentCLITests.user-runtime-shell-path-refresh")
+        defaults.set(true, forKey: RuntimeSettings.useUserInstalledAgentCLIKey)
+        var shellInvocations = 0
+        let runtime = AgentRuntime(
+            environment: [
+                "AGENTCLI_APP_SUPPORT_DIR": "/tmp/agentcli-test-support",
+                "PATH": "/custom/bin",
+                "SHELL": "/bin/zsh",
+            ],
+            userDefaults: defaults,
+            processRunner: { _, arguments, _ in
+                guard arguments.first == "-lic" else {
+                    return CommandResult(exitCode: 0, output: "")
+                }
+                shellInvocations += 1
+                return CommandResult(exitCode: 0, output: "/shell/bin\n")
+            }
+        )
+
+        _ = runtime.commandEnvironment()
+        _ = runtime.ensureInstalled(force: true)
+        _ = runtime.commandEnvironment()
+
+        XCTAssertEqual(shellInvocations, 2)
+    }
+
     func testTranscriptionBootstrapRepairsStaleWhisperDaemonMarker() throws {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("AgentCLITests-\(UUID().uuidString)", isDirectory: true)

--- a/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
+++ b/macos/AgentCLI/Tests/AgentCLITests/AgentCommandTests.swift
@@ -242,10 +242,10 @@ final class AgentCommandTests: XCTestCase {
         XCTAssertEqual(components.filter { $0 == "/usr/bin" }.count, 1)
     }
 
-    /// Builds a user-installed runtime whose process runner counts `zsh -lic` PATH probes.
+    /// Builds a user-installed runtime whose process runner intercepts `zsh -lic` PATH probes.
     private func makeShellPATHProbingRuntime(
         suiteName: String,
-        onShellProbe: @escaping () -> Void
+        onShellProbe: @escaping () -> CommandResult
     ) -> AgentRuntime {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -261,11 +261,12 @@ final class AgentCommandTests: XCTestCase {
                 guard arguments.first == "-lic" else {
                     return CommandResult(exitCode: 0, output: "")
                 }
-                onShellProbe()
-                return CommandResult(exitCode: 0, output: "/shell/bin\n")
+                return onShellProbe()
             }
         )
     }
+
+    private static let shellPATHProbeSuccess = CommandResult(exitCode: 0, output: "/shell/bin\n")
 
     /// `zsh -lic` costs roughly a second with a real dotfiles setup, so the login shell
     /// PATH must be resolved once per runtime instead of once per spawned command.
@@ -273,7 +274,10 @@ final class AgentCommandTests: XCTestCase {
         var shellProbes = 0
         let runtime = makeShellPATHProbingRuntime(
             suiteName: "AgentCLITests.user-runtime-shell-path-cache"
-        ) { shellProbes += 1 }
+        ) {
+            shellProbes += 1
+            return Self.shellPATHProbeSuccess
+        }
 
         _ = runtime.commandEnvironment()
         let environment = runtime.commandEnvironment()
@@ -287,13 +291,37 @@ final class AgentCommandTests: XCTestCase {
         var shellProbes = 0
         let runtime = makeShellPATHProbingRuntime(
             suiteName: "AgentCLITests.user-runtime-shell-path-refresh"
-        ) { shellProbes += 1 }
+        ) {
+            shellProbes += 1
+            return Self.shellPATHProbeSuccess
+        }
 
         _ = runtime.commandEnvironment()
         _ = runtime.ensureInstalled(force: true)
         _ = runtime.commandEnvironment()
 
         XCTAssertEqual(shellProbes, 2)
+    }
+
+    /// A login shell that fails once must not degrade PATH for the rest of the session,
+    /// matching how the CLI availability check only caches successful results.
+    func testFailedLoginShellPATHLookupIsRetried() {
+        var shellProbes = 0
+        let runtime = makeShellPATHProbingRuntime(
+            suiteName: "AgentCLITests.user-runtime-shell-path-failure"
+        ) {
+            shellProbes += 1
+            return shellProbes == 1
+                ? CommandResult(exitCode: 1, output: "")
+                : Self.shellPATHProbeSuccess
+        }
+
+        let degraded = runtime.commandEnvironment()
+        let recovered = runtime.commandEnvironment()
+
+        XCTAssertEqual(shellProbes, 2)
+        XCTAssertNotEqual(degraded["PATH"]?.split(separator: ":").first.map(String.init), "/shell/bin")
+        XCTAssertEqual(recovered["PATH"]?.split(separator: ":").first.map(String.init), "/shell/bin")
     }
 
     func testTranscriptionBootstrapRepairsStaleWhisperDaemonMarker() throws {


### PR DESCRIPTION
## Problem

Pressing the transcription hotkey in the macOS app shows the recording pill almost instantly, but the microphone does not actually open for another **~1.8s**. Speaking right away loses the first words.

## Root cause

`AgentRuntime.loginShellPATH` spawned a **login + interactive shell** (`zsh -lic`) to discover `PATH` on *every* command spawn, with no caching. With a real dotfiles setup that is 1.13–1.40s, paid on each hotkey press in user-installed CLI mode.

Measured breakdown per press, before:

| Step | Cost |
|---|---|
| 🔴 `zsh -lic` PATH probe | **~1.2 s** |
| Python boot + `agent_cli.cli` import | ~0.30 s |
| `import sounddevice` (PortAudio init) | ~0.09 s |
| InputStream create + start + first block | ~0.23 s |
| Wyoming TCP connect (localhost) | ~0.0001 s |

## Changes

**Swift**
- `LoginShellPATHCache`: the login shell `PATH` is resolved **once per runtime instance** instead of once per spawned command. It is already resolved during the startup warm-up, so even the first hotkey press is free. `AgentRuntime` is a `static let shared` singleton, so this is effectively process-wide.
- **Only successful lookups are cached.** A shell that fails once — plausible at login, since AgentCLI is a login item — is retried rather than leaving the app on the fallback PATH for the whole session. This matches how `UserInstalledCLICheckCache` already treats failures.
- The cache is invalidated on a forced install, so *Install or Update CLI* still picks up a relocated binary.
- The lookup goes through the injectable `processRunner` instead of the static `runProcess`, which makes the caching testable and stops tests from spawning a real login shell.
- The lock is load-bearing: `runAgentCLI` is called from background queues outside `bootstrapQueue.sync`, so concurrent commands would otherwise each spawn their own 1.2s shell.

**Python**
- `__version__` resolves lazily via a module `__getattr__`. The old module-level `version("agent-cli")` call parsed distribution metadata on every command: ~33ms, of which ~4ms is reclaimed later by pydantic anyway, so **~29ms net** for something only `--version` needs. The package version itself comes from `versioningit`, so packaging is unaffected.

## Result

Hotkey → first audio chunk: **~1.8s → ~0.4–0.6s**.

The remaining time is Python interpreter boot plus CoreAudio device open; removing that needs a pre-warmed helper process, which is out of scope here.

Note: the pill and start chime still fire before the microphone is live, just ~0.5s early instead of ~1.8s.

## Testing

Three tests covering the cache: probe-once across repeated `commandEnvironment()` / `runAgentCLI` calls, re-probe after a forced install, and retry after a failed probe.

- `pytest` — 1467 passed, 4 skipped
- `pre-commit` — clean
- `swift build --build-tests` — clean. `swift test --enable-xctest` cannot run locally (Command Line Tools only, no Xcode `PlatformPath`); CI covers it.
- Live: real transcription round trips against the local Wyoming/NeMo ASR server, plus end-to-end hotkey-to-first-audio-chunk timing.