### PR TITLE
Drop the broken Homebrew tap dispatch from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,17 +126,3 @@ jobs:
           git commit -m "Update AgentCLI release metadata to ${TAG_NAME}"
           git pull --rebase origin main
           git push origin HEAD:main
-      - name: Trigger Homebrew tap update
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          if [[ -z "$GH_TOKEN" ]]; then
-            echo "HOMEBREW_TAP_DISPATCH_TOKEN is required to update basnijholt/homebrew-tap." >&2
-            exit 1
-          fi
-
-          gh api repos/basnijholt/homebrew-tap/dispatches \
-            -f event_type=agent-cli-release \
-            -F "client_payload[tag_name]=$TAG_NAME" \
-            -F "client_payload[asset_url]=https://github.com/basnijholt/agent-cli/releases/download/${TAG_NAME}/AgentCLI.dmg"

--- a/macos/AgentCLI/README.md
+++ b/macos/AgentCLI/README.md
@@ -111,8 +111,11 @@ workflow expects these repository secrets:
 - `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for `notarytool`
 - `APPLE_TEAM_ID`: Apple Developer Team ID
 - `SPARKLE_PRIVATE_ED_KEY`: private Sparkle EdDSA key for signing updates
-- `HOMEBREW_TAP_DISPATCH_TOKEN`: fine-grained token with Contents write access
-  to `basnijholt/homebrew-tap`, used to trigger the tap cask update workflow
+
+The Homebrew cask is not published from here. `basnijholt/homebrew-tap` runs a
+daily cron that reads the latest release and bumps `Casks/agent-cli.rb` itself;
+run it on demand with
+`gh workflow run update-agent-cli-cask.yml --repo basnijholt/homebrew-tap`.
 
 The workflow also expects the repository variable `SPARKLE_PUBLIC_ED_KEY`.
 Generate the key pair with Sparkle's `generate_keys` tool and store only the

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -346,12 +346,11 @@ def test_release_workflow_publishes_macos_app_asset() -> None:
     assert "NOTARIZE=1" in workflow
     assert "gh release upload" in workflow
     assert "dist/macos/AgentCLI.dmg" in workflow
-    assert "name: Trigger Homebrew tap update" in workflow
-    assert "HOMEBREW_TAP_DISPATCH_TOKEN" in workflow
-    assert "repos/basnijholt/homebrew-tap/dispatches" in workflow
-    assert "event_type=agent-cli-release" in workflow
-    assert "client_payload[tag_name]" in workflow
-    assert "client_payload[asset_url]" in workflow
+    # The tap owns its own updates: basnijholt/homebrew-tap runs a daily cron that
+    # reads the latest release. Dispatching from here only duplicated that with an
+    # expiring cross-repo token, whose 401 turned every release run red.
+    assert "HOMEBREW_TAP_DISPATCH_TOKEN" not in workflow
+    assert "repos/basnijholt/homebrew-tap/dispatches" not in workflow
     assert "python3 .github/scripts/normalize_appcast.py macos/appcast.xml" in workflow
     assert workflow.index(
         "python3 .github/scripts/normalize_appcast.py macos/appcast.xml"


### PR DESCRIPTION
## Problem

Every release since at least v0.101.0 has reported **failure**, including v0.102.1 just now. The cause was identical each time, and it was always the workflow's final step:

```
Trigger Homebrew tap update → gh: Bad credentials (HTTP 401)
```

`HOMEBREW_TAP_DISPATCH_TOKEN` (last set 2026-06-03) has expired. By the time that step runs, the DMG has been built, notarized and uploaded and the Sparkle appcast has been committed — the release is already complete. Only the cross-repo dispatch fails.

## Why remove it rather than rotate the token

The step is redundant. `basnijholt/homebrew-tap` updates its cask from a daily cron (`17 8 * * *`) that reads the latest release itself, and **all 8 most recent tap runs were `schedule`** — the dispatch has not fired successfully in weeks, yet the cask has tracked every release anyway:

```
2026-07-25T09:59:43Z  schedule  success
2026-07-24T10:28:16Z  schedule  success
...
```

So the dispatch bought exactly one thing: updating the cask within a minute instead of within a day.

Against that: a release workflow that is permanently red trains you to ignore it. A genuine notarization or PyPI failure currently looks identical to a normal release. That is a worse failure mode than a cask lagging by up to a day.

Removing the step also retires a cross-repo credential that will keep expiring.

## If instant cask updates are wanted back

Rotate the token (PAT with `contents: write` on the tap), `gh secret set HOMEBREW_TAP_DISPATCH_TOKEN`, and revert this. Until then the tap can be nudged on demand:

```bash
gh workflow run update-agent-cli-cask.yml --repo basnijholt/homebrew-tap
```

## Also in this PR

`test_release_workflow_publishes_macos_app_asset` pinned the dispatch step, so deleting it broke the suite. Those assertions are flipped to assert the token and dispatch call are **gone**, with a comment recording why. `HOMEBREW_TAP_DISPATCH_TOKEN` is also dropped from the required-secrets list in `macos/AgentCLI/README.md`, which now documents the tap's own cron.

## Testing

- `pytest` — 1467 passed, 4 skipped
- `pre-commit` — clean
- Workflow YAML parses; remaining `build_macos_app` steps are checkout → uv → certificate → identity → build DMG → upload → appcast → appcast metadata.
- Only remaining mention of the token in the repo is the negative assertion in the test.
- The removed step was last in its job, so nothing depended on it.