### PR TITLE
Render the shared consoles without colour during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,17 @@ def mock_console() -> Console:
     return Console(file=io.StringIO(), width=80, force_terminal=True)
 
 
+def force_plain_console(console: Console) -> None:
+    """Make a console audible and strip every escape sequence from its output.
+
+    `no_color` alone still emits bold and dim, so the colour system is switched
+    off outright.
+    """
+    console.quiet = False
+    console.no_color = True
+    console._color_system = None
+
+
 @pytest.fixture(autouse=True)
 def reset_rich_console_state() -> None:
     """Keep the shared consoles audible and plain for every test.
@@ -63,15 +74,12 @@ def reset_rich_console_state() -> None:
 
     Colour is disabled because Rich honours `FORCE_COLOR` even when stdout is
     captured, so a developer shell exporting it makes 29 tests fail on ANSI
-    escapes interleaved into otherwise-matching output. `no_color` alone still
-    emits bold/dim, so the colour system is switched off outright. The consoles
-    are mutated in place rather than rebound: 17 modules hold a direct
+    escapes interleaved into otherwise-matching output. The consoles are mutated
+    in place rather than rebound: 17 modules hold a direct
     `from agent_cli.core.utils import console` reference.
     """
     for console in (utils.console, utils.err_console):
-        console.quiet = False
-        console.no_color = True
-        console._color_system = None
+        force_plain_console(console)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,10 +56,22 @@ def mock_console() -> Console:
 
 
 @pytest.fixture(autouse=True)
-def reset_rich_console_quiet() -> None:
-    """Prevent JSON-mode CLI tests from silencing later command output."""
-    utils.console.quiet = False
-    utils.err_console.quiet = False
+def reset_rich_console_state() -> None:
+    """Keep the shared consoles audible and plain for every test.
+
+    `quiet` is reset so JSON-mode CLI tests cannot silence later command output.
+
+    Colour is disabled because Rich honours `FORCE_COLOR` even when stdout is
+    captured, so a developer shell exporting it makes 29 tests fail on ANSI
+    escapes interleaved into otherwise-matching output. `no_color` alone still
+    emits bold/dim, so the colour system is switched off outright. The consoles
+    are mutated in place rather than rebound: 17 modules hold a direct
+    `from agent_cli.core.utils import console` reference.
+    """
+    for console in (utils.console, utils.err_console):
+        console.quiet = False
+        console.no_color = True
+        console._color_system = None
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,3 +208,20 @@ async def test_signal_handling_context_uses_sync_handlers_on_windows(
     assert signal.getsignal(signal.SIGINT) is prev_sigint
     assert signal.getsignal(signal.SIGTERM) is prev_sigterm
     logger.debug.assert_called()
+
+
+def test_shared_consoles_render_without_ansi(capsys: pytest.CaptureFixture[str]) -> None:
+    """Rich honours FORCE_COLOR even into captured output, breaking substring asserts.
+
+    The autouse `reset_rich_console_state` fixture must keep both shared consoles
+    colourless so the suite passes regardless of the developer's shell.
+    """
+    assert utils.console.color_system is None
+    assert utils.err_console.color_system is None
+
+    utils.console.print("[bold red]stdout text[/bold red]")
+    utils.err_console.print("[dim]stderr text[/dim]")
+
+    captured = capsys.readouterr()
+    assert captured.out == "stdout text\n"
+    assert captured.err == "stderr text\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,10 @@ from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from rich.console import ColorSystem
 
 from agent_cli.core import process, utils
+from tests.conftest import force_plain_console
 
 
 @pytest.mark.parametrize(
@@ -225,3 +227,26 @@ def test_shared_consoles_render_without_ansi(capsys: pytest.CaptureFixture[str])
     captured = capsys.readouterr()
     assert captured.out == "stdout text\n"
     assert captured.err == "stderr text\n"
+
+
+@pytest.mark.parametrize("stream", ["console", "err_console"])
+def test_force_plain_console_strips_forced_colour(
+    stream: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reproduce a FORCE_COLOR shell rather than trusting the ambient environment.
+
+    Without this the coverage above is vacuous wherever Rich already detects a
+    colourless stream, which is every CI runner. Mutating the shared console is
+    safe: the autouse fixture restores it before the next test.
+    """
+    console = getattr(utils, stream)
+    console.no_color = False
+    console._color_system = ColorSystem.TRUECOLOR
+    assert console.color_system == "truecolor"
+
+    force_plain_console(console)
+
+    console.print("[bold red]coloured[/bold red]")
+    captured = capsys.readouterr()
+    assert (captured.err if stream == "err_console" else captured.out) == "coloured\n"


### PR DESCRIPTION
Closes #624.

## Problem

29 tests fail on a clean checkout of `main` whenever the developer's shell exports `FORCE_COLOR`. Rich honours it even when stdout is captured by `CliRunner` or `capsys`, so ANSI escapes get interleaved into output that plain-substring assertions then fail to match:

```
assert '~/Library/Logs/agent-cli-whisper/' in result.stdout
E  AssertionError: assert ... in '...\x1b[2mFull logs: ~\x1b[0m\x1b[2;35m/Library/Logs/agent-cli-whisper/\x1b[0m\n'
```

Three `test_daemon.py` tests fail harder — `JSONDecodeError` — because the JSON payload itself gets syntax-highlighted.

## Fix

The whole package renders through exactly two module-level `Console` objects (`agent_cli/core/utils.py:41-42`), and `tests/conftest.py` already has an autouse fixture reaching into them to reset `quiet`. Colour is switched off in the same place, via an extracted `force_plain_console` helper.

Details worth knowing, all verified:

- **Mutated in place, not rebound.** 17 modules hold a direct `from agent_cli.core.utils import console`, so reassigning `utils.console` would silently no-op for all of them.
- **`no_color` alone is insufficient** — Rich still emits bold and dim (`\x1b[1m`, `\x1b[2m`), which is enough to break the assertions. The colour system is disabled outright.
- **`NO_COLOR=1` has the same shortfall** (7 failures survive it). `TERM=dumb` does work fully, but must be set before `conftest.py` imports `agent_cli`, so `pytest_configure` is too late and it would depend on import ordering.

## Result

```bash
.venv/bin/pytest -q                                  # FORCE_COLOR=3 exported
# before: 29 failed, 1438 passed, 4 skipped
# after:  1470 passed, 4 skipped

env -u FORCE_COLOR -u COLORTERM .venv/bin/pytest -q
# 1470 passed, 4 skipped
```

## Regression coverage

`test_force_plain_console_strips_forced_colour` reproduces the forced-colour condition rather than trusting the ambient environment: it stamps `ColorSystem.TRUECOLOR` onto each shared console, asserts Rich reports `truecolor`, applies the helper, then checks the rendered output is plain. Parametrised over both consoles. Mutating the shared object is safe because the autouse fixture restores it before the next test.

Verified to have teeth — with the fix removed and `FORCE_COLOR` unset, i.e. CI conditions, both parametrisations fail:

```
FAILED tests/test_utils.py::test_force_plain_console_strips_forced_colour[console]
FAILED tests/test_utils.py::test_force_plain_console_strips_forced_colour[err_console]
```

`test_shared_consoles_render_without_ansi` additionally pins the post-fixture state.

## Deliberately not in this PR

- **The related product bug.** `agent_cli/daemon/cli.py:289,304,317` emit `--json` payloads through `console.print(json.dumps(payload))`, so Rich syntax-highlights them and `ag daemon ensure whisper --json | jq` breaks for anyone with `FORCE_COLOR` exported. Other `--json` paths use builtin `print`. That is a user-facing defect rather than test hygiene, and wants its own change.
- **Now-redundant ANSI stripping.** `tests/test_env_vars.py`, `tests/test_config.py` and `tests/test_api_integration.py` each `re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)` at 7 sites. Those regexes match nothing now. Left alone to keep the diff focused; happy to strip them as a follow-up.

## Testing

- `pytest` with and without `FORCE_COLOR` — 1470 passed, 4 skipped both ways
- Fault injection: fix removed, colourless environment — the two new parametrisations fail as intended
- `pre-commit` — clean