### PR TITLE
Copy local agent instructions into dev worktrees

### DIFF
--- a/agent_cli/config.py
+++ b/agent_cli/config.py
@@ -316,7 +316,7 @@ class Dev(BaseModel):
     )
     agent_env: dict[str, dict[str, str]] | None = None
     setup: bool = True  # Run project setup (npm install, etc.)
-    copy_env: bool = True  # Copy .env files from main repo
+    copy_env: bool = True  # Copy env and local agent instruction files from main repo
     fetch: bool = True  # Git fetch before creating worktree
 
 

--- a/agent_cli/dev/cli.py
+++ b/agent_cli/dev/cli.py
@@ -290,12 +290,12 @@ def _setup_worktree_env(
     direnv: bool | None,
     verbose: bool,
 ) -> None:
-    """Copy env files, run project setup, and configure direnv."""
+    """Copy local setup files, run project setup, and configure direnv."""
     if copy_env:
         copied = copy_env_files(repo_root, worktree_path)
         if copied:
             names = ", ".join(f.name for f in copied)
-            success(f"Copied env file(s): {names}")
+            success(f"Copied local setup file(s): {names}")
 
     project = None
     if setup:
@@ -413,7 +413,7 @@ def new(
         bool,
         typer.Option(
             "--copy-env/--no-copy-env",
-            help="Copy .env, .env.local, .env.example from main repo to worktree",
+            help="Copy env and local agent instruction files from main repo to worktree",
         ),
     ] = True,
     fetch: Annotated[
@@ -525,7 +525,7 @@ def new(
     **What happens:**
 
     1. Creates git worktree at `../REPO-worktrees/BRANCH/`
-    2. Copies .env files from main repo (--copy-env)
+    2. Copies env and local agent instruction files from main repo (--copy-env)
     3. Runs project setup: npm install, uv sync, etc. (--setup)
     4. Sets up direnv if installed (--direnv)
     5. Opens editor if requested (-e/--editor)

--- a/agent_cli/dev/project.py
+++ b/agent_cli/dev/project.py
@@ -366,6 +366,8 @@ def copy_env_files(
             ".env.local",
             ".env.example",
             ".envrc",
+            "AGENTS.local.md",
+            "CLAUDE.local.md",
         ]
 
     copied: list[Path] = []

--- a/agent_cli/dev/project.py
+++ b/agent_cli/dev/project.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+_LOCAL_AGENT_INSTRUCTION_FILES = ("AGENTS.local.md", "CLAUDE.local.md")
+
 
 @dataclass
 class ProjectType:
@@ -366,8 +368,7 @@ def copy_env_files(
             ".env.local",
             ".env.example",
             ".envrc",
-            "AGENTS.local.md",
-            "CLAUDE.local.md",
+            *_LOCAL_AGENT_INSTRUCTION_FILES,
         ]
 
     copied: list[Path] = []
@@ -382,7 +383,12 @@ def copy_env_files(
 
         for src_file in source_files:
             if src_file.is_file():
-                dest_file = dest / src_file.relative_to(source)
+                relative_path = src_file.relative_to(source)
+                dest_file = dest / relative_path
+                if relative_path.as_posix() in _LOCAL_AGENT_INSTRUCTION_FILES and os.path.lexists(
+                    dest_file
+                ):
+                    continue
                 dest_file.parent.mkdir(parents=True, exist_ok=True)
                 dest_file.write_bytes(src_file.read_bytes())
                 copied.append(dest_file)

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -78,7 +78,7 @@ agent-cli dev new [BRANCH] [OPTIONS]
 | `--agent` | - | Which AI agent to start: claude, codex, gemini, aider, copilot, cn (Continue), opencode, cursor-agent, or auto. Implies starting the agent |
 | `--with-editor` | - | Which editor to open: cursor, vscode, zed, nvim, vim, emacs, sublime, idea, pycharm, etc. |
 | `--setup/--no-setup` | `true` | Run project setup after creation: npm/pnpm/yarn install, poetry/uv sync, cargo build, etc. Auto-detects project type |
-| `--copy-env/--no-copy-env` | `true` | Copy .env, .env.local, .env.example from main repo to worktree |
+| `--copy-env/--no-copy-env` | `true` | Copy env and local agent instruction files from main repo to worktree |
 | `--fetch/--no-fetch` | `true` | Run 'git fetch' before creating the worktree to ensure refs are up-to-date |
 | `--branch-name-mode` | `random` | How to auto-name branches when BRANCH is omitted: random (default), auto (AI only when --prompt/--prompt-file is set), or ai (always try AI first) |
 | `--branch-name-agent` | - | Headless agent for AI branch naming: claude, codex, or gemini. If omitted, uses --agent when supported, otherwise tries available agents in that order |
@@ -606,7 +606,7 @@ direnv = true          # Always generate .envrc (--direnv)
 
 # Worktree creation behavior
 setup = true           # Run project setup (npm install, etc.)
-copy_env = true        # Copy .env files from main repo
+copy_env = true        # Copy env and local agent instruction files
 fetch = true           # Git fetch before creating
 
 # Branch naming behavior when BRANCH argument is omitted
@@ -702,7 +702,7 @@ git lfs pull
 
 This ensures large files tracked by LFS are available in the worktree.
 
-### Environment Files
+### Local Setup Files
 
 The following files are automatically copied to new dev environments:
 
@@ -710,6 +710,8 @@ The following files are automatically copied to new dev environments:
 - `.env.local`
 - `.env.example`
 - `.envrc`
+- `AGENTS.local.md`
+- `CLAUDE.local.md`
 
 Use `--no-copy-env` to skip this.
 

--- a/docs/commands/dev.md
+++ b/docs/commands/dev.md
@@ -713,6 +713,9 @@ The following files are automatically copied to new dev environments:
 - `AGENTS.local.md`
 - `CLAUDE.local.md`
 
+If the target branch already contains either local agent instruction file,
+its checked-out version is preserved.
+
 Use `--no-copy-env` to skip this.
 
 ### Direnv Integration

--- a/tests/dev/test_project.py
+++ b/tests/dev/test_project.py
@@ -534,6 +534,25 @@ class TestCopyEnvFiles:
         copied = copy_env_files(source, dest)
         assert len(copied) == 2
 
+    def test_copy_local_agent_instruction_files(self, tmp_path: Path) -> None:
+        """Copy local agent instruction files."""
+        source = tmp_path / "source"
+        dest = tmp_path / "dest"
+        source.mkdir()
+        dest.mkdir()
+        files = {
+            "AGENTS.local.md": "Use pytest.\n",
+            "CLAUDE.local.md": "Use ruff.\n",
+        }
+        for name, content in files.items():
+            (source / name).write_text(content)
+
+        copied = copy_env_files(source, dest)
+
+        assert {path.name for path in copied} == set(files)
+        for name, content in files.items():
+            assert (dest / name).read_text() == content
+
     def test_skip_missing_files(self, tmp_path: Path) -> None:
         """Skip files that don't exist."""
         source = tmp_path / "source"

--- a/tests/dev/test_project.py
+++ b/tests/dev/test_project.py
@@ -553,6 +553,47 @@ class TestCopyEnvFiles:
         for name, content in files.items():
             assert (dest / name).read_text() == content
 
+    @pytest.mark.parametrize("name", ["AGENTS.local.md", "CLAUDE.local.md"])
+    def test_preserve_existing_local_agent_instruction_file(
+        self,
+        tmp_path: Path,
+        name: str,
+    ) -> None:
+        """Preserve local agent instructions checked out by the target branch."""
+        source = tmp_path / "source"
+        dest = tmp_path / "dest"
+        source.mkdir()
+        dest.mkdir()
+        (source / name).write_text("main worktree instructions\n")
+        (dest / name).write_text("target branch instructions\n")
+
+        copied = copy_env_files(source, dest)
+
+        assert copied == []
+        assert (dest / name).read_text() == "target branch instructions\n"
+
+    def test_preserve_dangling_local_agent_instruction_symlink(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Preserve a dangling instruction symlink checked out by the target branch."""
+        source = tmp_path / "source"
+        dest = tmp_path / "dest"
+        source.mkdir()
+        dest.mkdir()
+        (source / "AGENTS.local.md").write_text("main worktree instructions\n")
+        dest_file = dest / "AGENTS.local.md"
+        try:
+            dest_file.symlink_to("missing-instructions.md")
+        except OSError as exc:
+            pytest.skip(f"Symlinks unavailable: {exc}")
+
+        copied = copy_env_files(source, dest)
+
+        assert copied == []
+        assert dest_file.is_symlink()
+        assert not (dest / "missing-instructions.md").exists()
+
     def test_skip_missing_files(self, tmp_path: Path) -> None:
         """Skip files that don't exist."""
         source = tmp_path / "source"


### PR DESCRIPTION
## Summary

- copy `AGENTS.local.md` and `CLAUDE.local.md` into new dev worktrees
- keep copying under existing `--copy-env/--no-copy-env` behavior
- update CLI help, docs, and filesystem coverage

## Tests

- `uv run --all-extras pytest` (1473 passed, 4 skipped)
- `uv run pre-commit run --all-files`