### PR TITLE
Fix Docker image publishing and runtime extras

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,8 @@
 name: Publish Docker Images
 
 on:
-  workflow_run:
-    workflows: ["Upload Python Package"]
-    types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -13,7 +12,6 @@ jobs:
   # Images with cuda/cpu targets (whisper, tts)
   build-multi-target:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -62,11 +60,12 @@ jobs:
 
       - name: Get version from trigger
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
             # Extract version from release tag (v0.61.3 -> 0.61.3)
-            TAG="${{ github.event.workflow_run.head_branch }}"
-            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+            echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract metadata
@@ -94,7 +93,6 @@ jobs:
   # Single-target images (transcribe-proxy)
   build-single-target:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       packages: write
@@ -127,11 +125,12 @@ jobs:
 
       - name: Get version from trigger
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
             # Extract version from release tag (v0.61.3 -> 0.61.3)
-            TAG="${{ github.event.workflow_run.head_branch }}"
-            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+            echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract metadata

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -49,7 +49,8 @@ RUN userdel -r ubuntu && \
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv /app/.venv
+# Keep the environment writable so agent-cli can auto-install backend extras.
+COPY --chown=whisper:whisper --from=builder /app/.venv /app/.venv
 
 RUN ln -sf $(uv python find 3.13) /app/.venv/bin/python && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
@@ -91,7 +92,8 @@ RUN groupadd -g 1000 whisper && useradd -m -u 1000 -g 1000 whisper
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv /app/.venv
+# Keep the environment writable so agent-cli can auto-install backend extras.
+COPY --chown=whisper:whisper --from=builder /app/.venv /app/.venv
 
 # Install imageio-ffmpeg for bundled static ffmpeg binary (77MB vs 420MB for Debian package)
 RUN uv pip install --python /app/.venv/bin/python imageio-ffmpeg && \

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -36,7 +36,7 @@ FROM nvcr.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04 AS cuda
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get install -y --no-install-recommends ffmpeg git && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
@@ -95,8 +95,11 @@ WORKDIR /app
 # Keep the environment writable so agent-cli can auto-install backend extras.
 COPY --chown=whisper:whisper --from=builder /app/.venv /app/.venv
 
-# Install imageio-ffmpeg for bundled static ffmpeg binary (77MB vs 420MB for Debian package)
-RUN uv pip install --python /app/.venv/bin/python imageio-ffmpeg && \
+# Install git for runtime extras and imageio-ffmpeg for a bundled static ffmpeg binary.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    uv pip install --python /app/.venv/bin/python imageio-ffmpeg && \
     ln -s $(/app/.venv/bin/python -c "import imageio_ffmpeg; print(imageio_ffmpeg.get_ffmpeg_exe())") /usr/local/bin/ffmpeg && \
     ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
     mkdir -p /home/whisper/.cache && chown -R whisper:whisper /home/whisper


### PR DESCRIPTION
## Summary

- publish Docker images directly from published GitHub releases instead of coupling the workflow to another workflow’s display name
- derive version tags from the release event, so versioned images are built from the released tag while preserving manual dispatches
- keep the Whisper image virtual environment writable by its non-root runtime user and include Git for source-based backend extras

## Background

Docker publishing silently stopped when the release workflow was renamed from `Upload Python Package` to `Publish Release`, because the `workflow_run` trigger still referenced the old display name. As a result, `latest-cuda` remained at Agent CLI 0.94.2 even after the 0.103.0 release.

Recent Agent CLI versions install backend-specific dependencies on demand. The Whisper image copied `/app/.venv` as root and then ran as `whisper`, so those installations failed with `Permission denied`. The NeMo extra also uses a pinned Git source, requiring Git in the final image rather than only the builder.

## Verification

- `actionlint .github/workflows/docker.yml`
- `uv run pre-commit run --all-files`
- `uv run pytest -q` (`1488 passed, 4 skipped`)
- built both `cpu` and `cuda` targets
- verified both targets run as UID 1000, own `/app/.venv`, and can run `agent-cli install-extras speed`
- verified `agent-cli install-extras whisper-transformers` completes end-to-end in the CUDA image for the Qwen backend
- verified the pinned NeMo Git source can be cloned by the runtime user