### PR TITLE
Add speaker diarization API and Docker image

### DIFF
--- a/agent_cli/core/diarization.py
+++ b/agent_cli/core/diarization.py
@@ -151,11 +151,19 @@ class SpeakerDiarizer:
         self.min_speakers = min_speakers
         self.max_speakers = max_speakers
 
-    def diarize(self, audio_path: Path) -> list[DiarizedSegment]:
+    def diarize(
+        self,
+        audio_path: Path,
+        *,
+        min_speakers: int | None = None,
+        max_speakers: int | None = None,
+    ) -> list[DiarizedSegment]:
         """Run diarization on audio file, return speaker segments.
 
         Args:
             audio_path: Path to the audio file (WAV format recommended).
+            min_speakers: Per-call hint, falling back to the constructor default.
+            max_speakers: Per-call hint, falling back to the constructor default.
 
         Returns:
             List of DiarizedSegment with speaker labels and timestamps.
@@ -163,10 +171,12 @@ class SpeakerDiarizer:
         """
         # Build kwargs for speaker count hints
         kwargs: dict[str, int] = {}
-        if self.min_speakers is not None:
-            kwargs["min_speakers"] = self.min_speakers
-        if self.max_speakers is not None:
-            kwargs["max_speakers"] = self.max_speakers
+        minimum = self.min_speakers if min_speakers is None else min_speakers
+        maximum = self.max_speakers if max_speakers is None else max_speakers
+        if minimum is not None:
+            kwargs["min_speakers"] = minimum
+        if maximum is not None:
+            kwargs["max_speakers"] = maximum
 
         # Pre-load audio to avoid torchcodec/FFmpeg issues
         waveform, sample_rate = _load_audio_for_diarization(audio_path)

--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -702,7 +702,11 @@ def transcribe_proxy_cmd(
     The server exposes:
 
     - `POST /transcribe` - Accepts audio files, returns `{raw_transcript, cleaned_transcript}`
+    - `POST /diarize` - Speaker timestamps (requires the `diarization` extra and `HF_TOKEN`)
     - `GET /health` - Health check endpoint
+
+    Pass `diarize=true` and `cleanup=false` to `/transcribe` for speaker-labeled segments.
+    Add `align_words=true` for forced word alignment. Docker: `docker/diarization.Dockerfile`.
 
     **When to use this vs `server whisper`:**
 

--- a/agent_cli/server/proxy/api.py
+++ b/agent_cli/server/proxy/api.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
 
 from agent_cli import config, opts
 from agent_cli.agents.transcribe import (
@@ -17,13 +18,18 @@ from agent_cli.agents.transcribe import (
     SYSTEM_PROMPT,
     _build_context_payload,
 )
+from agent_cli.core.alignment import ALIGN_MODELS
 from agent_cli.core.audio_format import (
     VALID_EXTENSIONS,
     convert_audio_to_wyoming_format,
     is_valid_audio_file,
 )
+from agent_cli.core.diarization import (
+    DiarizedSegment,  # noqa: TC001 - Pydantic needs this at runtime
+)
 from agent_cli.core.transcription_logger import TranscriptionLogger, get_default_logger
 from agent_cli.server.common import log_requests_middleware
+from agent_cli.server.proxy.diarization import DiarizationService, get_diarization_service
 from agent_cli.services import asr
 from agent_cli.services.llm import process_and_update_clipboard
 
@@ -88,6 +94,13 @@ class TranscriptionResponse(BaseModel):
     cleaned_transcript: str | None = None
     success: bool
     error: str | None = None
+    segments: list[DiarizedSegment] | None = None
+
+
+class DiarizationResponse(BaseModel):
+    """Speaker labels and timestamps, with text when aligned to a transcript."""
+
+    segments: list[DiarizedSegment]
 
 
 class HealthResponse(BaseModel):
@@ -102,15 +115,116 @@ class TranscriptionRequest(BaseModel):
 
     cleanup: bool = True
     extra_instructions: str | None = None
+    diarize: bool = False
+    min_speakers: int | None = None
+    max_speakers: int | None = None
+    align_words: bool = False
+    align_language: str = "en"
 
 
 async def _parse_transcription_form(
     cleanup: Annotated[str | bool, Form()] = True,
     extra_instructions: Annotated[str | None, Form()] = None,
+    diarize: Annotated[bool, Form()] = False,
+    min_speakers: Annotated[int | None, Form(ge=1)] = None,
+    max_speakers: Annotated[int | None, Form(ge=1)] = None,
+    align_words: Annotated[bool, Form()] = False,
+    align_language: Annotated[str, Form()] = "en",
 ) -> TranscriptionRequest:
     """Parse form data into TranscriptionRequest model."""
     cleanup_bool = cleanup.lower() in ("true", "1", "yes") if isinstance(cleanup, str) else cleanup
-    return TranscriptionRequest(cleanup=cleanup_bool, extra_instructions=extra_instructions)
+    _validate_speaker_hints(min_speakers, max_speakers)
+    if diarize and cleanup_bool:
+        raise HTTPException(status_code=422, detail="Diarization requires cleanup=false.")
+    if align_words and (not diarize or align_language not in ALIGN_MODELS):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Word alignment requires diarize=true and a language in {list(ALIGN_MODELS)}.",
+        )
+    return TranscriptionRequest(
+        cleanup=cleanup_bool,
+        extra_instructions=extra_instructions,
+        diarize=diarize,
+        min_speakers=min_speakers,
+        max_speakers=max_speakers,
+        align_words=align_words,
+        align_language=align_language,
+    )
+
+
+def _validate_speaker_hints(minimum: int | None, maximum: int | None) -> None:
+    """Reject contradictory speaker count hints."""
+    if minimum is not None and maximum is not None and minimum > maximum:
+        raise HTTPException(status_code=422, detail="min_speakers must be <= max_speakers.")
+
+
+def _get_diarizer(defaults: dict[str, Any]) -> DiarizationService:
+    """Resolve server-owned credentials before doing transcription work."""
+    token = _cfg("hf_token", defaults, opts.HF_TOKEN)
+    if not token or not str(token).strip():
+        raise HTTPException(status_code=503, detail="Configure HF_TOKEN to enable diarization.")
+    device = os.environ.get("DIARIZATION_DEVICE", "auto")
+    return get_diarization_service(token, device)
+
+
+async def _diarize_upload(
+    service: DiarizationService,
+    audio: bytes,
+    filename: str,
+    *,
+    transcript: str | None = None,
+    min_speakers: int | None = None,
+    max_speakers: int | None = None,
+    align_words: bool = False,
+    align_language: str = "en",
+) -> list[DiarizedSegment]:
+    """Run blocking inference off the event loop and report model failures."""
+    try:
+        return await run_in_threadpool(
+            service.diarize,
+            audio,
+            filename,
+            transcript=transcript,
+            min_speakers=min_speakers,
+            max_speakers=max_speakers,
+            align_words=align_words,
+            align_language=align_language,
+        )
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Install agent-cli[diarization] to enable diarization.",
+        ) from exc
+    except Exception as exc:
+        LOGGER.exception("Diarization failed")
+        raise HTTPException(
+            status_code=500, detail="Diarization failed. Check server logs."
+        ) from exc
+
+
+@app.post("/diarize", response_model=DiarizationResponse)
+async def diarize_audio(
+    request: Request,
+    audio: Annotated[UploadFile | None, File()] = None,
+    min_speakers: Annotated[int | None, Form(ge=1)] = None,
+    max_speakers: Annotated[int | None, Form(ge=1)] = None,
+) -> DiarizationResponse:
+    """Return speaker timestamps without calling a transcription provider."""
+    _validate_speaker_hints(min_speakers, max_speakers)
+    audio_file = await _extract_audio_file_from_request(request, audio)
+    _validate_audio_file(audio_file)
+    audio_data = await audio_file.read()
+    if not audio_data:
+        raise HTTPException(status_code=400, detail="Empty audio file")
+    defaults = _load_transcription_defaults()
+    segments = await _diarize_upload(
+        _get_diarizer(defaults),
+        audio_data,
+        audio_file.filename or "audio.wav",
+        min_speakers=min_speakers,
+        max_speakers=max_speakers,
+    )
+    return DiarizationResponse(segments=segments)
 
 
 @app.get("/health", response_model=HealthResponse)
@@ -202,6 +316,12 @@ def _cfg(key: str, defaults: dict[str, Any], opt: OptionInfo) -> Any:
     return defaults.get(key, opt.default)
 
 
+def _load_transcription_defaults() -> dict[str, Any]:
+    """Merge defaults without requiring any provider configuration."""
+    loaded_config = config.load_config()
+    return {**loaded_config.get("defaults", {}), **loaded_config.get("transcribe", {})}
+
+
 def _load_transcription_configs() -> tuple[
     config.ProviderSelection,
     config.WyomingASR,
@@ -213,10 +333,7 @@ def _load_transcription_configs() -> tuple[
     dict[str, Any],
 ]:
     """Load config objects. Priority: env var > config file > default."""
-    loaded_config = config.load_config()
-    wildcard_config = loaded_config.get("defaults", {})
-    command_config = loaded_config.get("transcribe", {})
-    defaults = {**wildcard_config, **command_config}
+    defaults = _load_transcription_defaults()
 
     provider_cfg = config.ProviderSelection(
         asr_provider=_cfg("asr_provider", defaults, opts.ASR_PROVIDER),
@@ -360,8 +477,13 @@ async def transcribe_audio(
             defaults,
         ) = _load_transcription_configs()
 
+        diarizer = _get_diarizer(defaults) if form_data.diarize else None
+
         # Read uploaded file
         audio_data = await audio_file.read()
+        original_audio = audio_data
+        if form_data.diarize and not audio_data:
+            raise HTTPException(status_code=400, detail="Empty audio file")  # noqa: TRY301
         LOGGER.info(
             "Received audio: filename=%s, size=%d bytes, content_type=%s",
             audio_file.filename,
@@ -388,6 +510,19 @@ async def transcribe_audio(
                 raw_transcript="",
                 success=False,
                 error="No transcript generated from audio",
+            )
+
+        segments = None
+        if diarizer is not None:
+            segments = await _diarize_upload(
+                diarizer,
+                original_audio,
+                audio_file.filename or "audio.wav",
+                transcript=raw_transcript,
+                min_speakers=form_data.min_speakers,
+                max_speakers=form_data.max_speakers,
+                align_words=form_data.align_words,
+                align_language=form_data.align_language,
             )
 
         if transcription_logger is None:
@@ -422,6 +557,7 @@ async def transcribe_audio(
             raw_transcript=raw_transcript,
             cleaned_transcript=cleaned_transcript,
             success=True,
+            segments=segments,
         )
 
     except HTTPException:

--- a/agent_cli/server/proxy/diarization.py
+++ b/agent_cli/server/proxy/diarization.py
@@ -1,0 +1,85 @@
+"""Lazy, serialized speaker diarization for uploaded audio."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import Lock
+
+from agent_cli.core.diarization import (
+    DiarizedSegment,
+    SpeakerDiarizer,
+    align_transcript_with_speakers,
+    align_transcript_with_words,
+)
+
+
+class DiarizationService:
+    """Keep one pipeline per server process and serialize inference in worker threads."""
+
+    def __init__(self, hf_token: str, device: str) -> None:
+        """Store model configuration without importing or loading pyannote."""
+        self._hf_token = hf_token
+        self._device = device
+        self._diarizer: SpeakerDiarizer | None = None
+        self._lock = Lock()
+
+    def diarize(
+        self,
+        audio: bytes,
+        filename: str,
+        *,
+        transcript: str | None = None,
+        min_speakers: int | None = None,
+        max_speakers: int | None = None,
+        align_words: bool = False,
+        align_language: str = "en",
+    ) -> list[DiarizedSegment]:
+        """Diarize an upload, optionally assigning transcript sentences to speakers.
+
+        Args:
+            audio: Original encoded audio file bytes.
+            filename: Source filename, used only to preserve the audio extension.
+            transcript: Optional transcript to align using estimated sentence timing.
+            min_speakers: Minimum speaker count hint for this request.
+            max_speakers: Maximum speaker count hint for this request.
+            align_words: Use forced alignment instead of estimated sentence timing.
+            align_language: Language of the forced alignment model.
+
+        Returns:
+            Speaker segments, with text when a transcript was supplied.
+
+        """
+        with self._lock:
+            if self._diarizer is None:
+                self._diarizer = SpeakerDiarizer(
+                    hf_token=self._hf_token,
+                    device=None if self._device == "auto" else self._device,
+                )
+            with TemporaryDirectory(prefix="agent-cli-diarize-") as directory:
+                audio_path = Path(directory) / f"audio{Path(filename).suffix.lower()}"
+                audio_path.write_bytes(audio)
+                segments = self._diarizer.diarize(
+                    audio_path,
+                    min_speakers=min_speakers,
+                    max_speakers=max_speakers,
+                )
+                if transcript:
+                    if align_words:
+                        segments = align_transcript_with_words(
+                            transcript,
+                            segments,
+                            audio_path,
+                            language=align_language,
+                            device=self._diarizer.device,
+                        )
+                    else:
+                        segments = align_transcript_with_speakers(transcript, segments)
+                return segments
+
+
+@lru_cache(maxsize=1)
+def get_diarization_service(hf_token: str, device: str) -> DiarizationService:
+    """Reuse the model for the server's configured token and device."""
+    return DiarizationService(hf_token, device)

--- a/docker/diarization.Dockerfile
+++ b/docker/diarization.Dockerfile
@@ -1,0 +1,43 @@
+# Transcription proxy with local speaker diarization (CPU or NVIDIA GPU).
+# docker build -f docker/diarization.Dockerfile -t agent-cli-diarization .
+# docker run --rm -p 61337:61337 -e HF_TOKEN agent-cli-diarization
+# Add --gpus all -e DIARIZATION_DEVICE=cuda to use an NVIDIA GPU.
+FROM python:3.13-slim-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+WORKDIR /app
+COPY pyproject.toml uv.lock README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project \
+    --extra server --extra wyoming --extra llm --extra diarization
+COPY .git ./.git
+COPY agent_cli ./agent_cli
+COPY scripts ./scripts
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable \
+    --extra server --extra wyoming --extra llm --extra diarization
+
+FROM python:3.13-slim-bookworm
+
+# PyTorch wheels include CUDA libraries and also support CPU inference.
+# FFmpeg shared libraries are needed by torchcodec, as well as audio conversion.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg libsndfile1 libgomp1 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 1000 transcribe && useradd -m -u 1000 -g 1000 transcribe
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /bin/uv /bin/uvx /bin/
+RUN ln -s /app/.venv/bin/agent-cli /usr/local/bin/agent-cli && \
+    mkdir -p /home/transcribe/.cache && chown -R transcribe:transcribe /home/transcribe
+USER transcribe
+EXPOSE 61337
+ENV PROXY_HOST=0.0.0.0 \
+    PROXY_PORT=61337 \
+    DIARIZATION_DEVICE=auto
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD /app/.venv/bin/python -c "import os, urllib.request; urllib.request.urlopen('http://localhost:' + os.environ['PROXY_PORT'] + '/health')" || exit 1
+ENTRYPOINT ["sh", "-c", "exec agent-cli server transcribe-proxy --host \"${PROXY_HOST}\" --port \"${PROXY_PORT}\" ${PROXY_EXTRA_ARGS:-}"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -239,6 +239,33 @@ services:
       # - OPENAI_API_KEY=your-api-key
     restart: unless-stopped
 
+  # Optional transcription proxy with local diarization. Start explicitly with:
+  # docker compose -f docker/docker-compose.yml up --build diarization
+  # Shares port 61337 with transcribe-proxy; run one of them at a time.
+  diarization:
+    image: agent-cli-diarization
+    build:
+      context: ..
+      dockerfile: docker/diarization.Dockerfile
+    profiles: [diarization]
+    ports:
+      - "${DIARIZATION_PORT:-61337}:61337"
+    volumes:
+      - diarization-cache:/home/transcribe/.cache
+    environment:
+      - HF_TOKEN=${HF_TOKEN:-}
+      - DIARIZATION_DEVICE=${DIARIZATION_DEVICE:-auto}
+      - ASR_PROVIDER=${ASR_PROVIDER:-wyoming}
+      - ASR_WYOMING_IP=${ASR_WYOMING_IP:-whisper-cpu}
+      - ASR_WYOMING_PORT=${ASR_WYOMING_PORT:-10300}
+      - ASR_OPENAI_BASE_URL=${ASR_OPENAI_BASE_URL:-}
+      - ASR_OPENAI_MODEL=${ASR_OPENAI_MODEL:-whisper-1}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+    # For NVIDIA inference, set DIARIZATION_DEVICE=cuda and uncomment:
+    # gpus: all
+    restart: unless-stopped
+
   # ===========================================================================
   # RAG Proxy
   # ===========================================================================
@@ -305,6 +332,8 @@ services:
     restart: unless-stopped
 
 volumes:
+  diarization-cache:
+    name: agent-cli-diarization-cache
   ollama-data:
     name: agent-cli-ollama-data
   openwakeword-data:

--- a/docs/commands/server/transcribe-proxy.md
+++ b/docs/commands/server/transcribe-proxy.md
@@ -56,7 +56,8 @@ agent-cli server transcribe-proxy --reload
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/transcribe` | POST | Transcribe audio file |
+| `/transcribe` | POST | Transcribe audio file, optionally with speaker labels |
+| `/diarize` | POST | Identify speaker timestamps without transcription |
 | `/health` | GET | Health check |
 | `/docs` | GET | Interactive API documentation |
 
@@ -70,6 +71,11 @@ Transcribe an audio file with optional LLM post-processing.
 |-----------|------|---------|-------------|
 | `audio` | file | required | Audio file (wav, mp3, m4a, ogg, flac, aac, webm) |
 | `cleanup` | boolean | `true` | Whether to apply LLM post-processing to clean up the transcript |
+| `diarize` | boolean | `false` | Return speaker-labeled `segments`; requires `cleanup=false` |
+| `min_speakers` | integer | - | Optional minimum number of speakers, at least 1 |
+| `max_speakers` | integer | - | Optional maximum number of speakers, at least the minimum |
+| `align_words` | boolean | `false` | Use forced word alignment; requires `diarize=true` |
+| `align_language` | string | `en` | Forced alignment language: `en`, `fr`, `de`, `es`, `it` |
 | `extra_instructions` | string | - | Additional instructions for the LLM cleanup (appended to any config file instructions) |
 
 **Disabling LLM Post-Processing:**
@@ -91,7 +97,8 @@ This skips the LLM step entirely, reducing latency and removing the LLM dependen
   "raw_transcript": "the original transcription",
   "cleaned_transcript": "The cleaned transcription.",
   "success": true,
-  "error": null
+  "error": null,
+  "segments": null
 }
 ```
 
@@ -101,6 +108,54 @@ This skips the LLM step entirely, reducing latency and removing the LLM dependen
 | `cleaned_transcript` | string or null | The LLM-cleaned transcript, or `null` if `cleanup=false` |
 | `success` | boolean | Whether the transcription succeeded |
 | `error` | string or null | Error message if something went wrong |
+| `segments` | array or null | Speaker segments (`speaker`, `start`, `end`, `text`), or `null` without diarization |
+
+## Speaker Diarization
+
+Install the optional dependencies and set `HF_TOKEN` on the server:
+
+```bash
+uv sync --extra server --extra wyoming --extra llm --extra diarization
+export HF_TOKEN=your-huggingface-token
+agent-cli server transcribe-proxy
+```
+
+Accept the model access conditions for [speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1), [segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0), and [wespeaker-voxceleb-resnet34-LM](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM). Use a token with read access to these models. The first request downloads the models; later requests reuse them.
+
+For a speaker-labeled transcript, configure your usual ASR backend and send:
+
+```bash
+curl http://localhost:61337/transcribe \
+  -F "audio=@interview.wav" \
+  -F "cleanup=false" -F "diarize=true" \
+  -F "min_speakers=2" -F "max_speakers=2" \
+  -F "align_words=true" -F "align_language=en"
+```
+
+`raw_transcript` contains the original ASR text. The additional `segments` field contains:
+
+```json
+[
+  {"speaker": "SPEAKER_00", "start": 0.4, "end": 2.1, "text": "Hello there."},
+  {"speaker": "SPEAKER_01", "start": 2.3, "end": 4.0, "text": "Welcome back."}
+]
+```
+
+`align_words=true` uses the existing wav2vec2 alignment and downloads an additional language model. Without it, sentence timing is estimated from transcript length, so speaker assignment is approximate. Word alignment also falls back to this estimate if it cannot align any words. Speaker labels are local to each upload; this API does not enroll or identify persistent voice profiles.
+
+### POST /diarize
+
+Return speaker labels and timestamps without using an ASR provider:
+
+```bash
+curl http://localhost:61337/diarize \
+  -F "audio=@interview.wav" \
+  -F "min_speakers=2" -F "max_speakers=2"
+```
+
+Accepts the same `audio` upload and optional `min_speakers` / `max_speakers` hints as `/transcribe`. Returns `{"segments": [{"speaker": "SPEAKER_00", "start": 0.4, "end": 2.1, "text": ""}]}`. Times are seconds from the start of the file. Overlapping speech can produce overlapping segments; silence returns an empty list.
+
+Both endpoints delete temporary audio after processing. The model loads lazily and remains in memory until the process exits; concurrent diarization requests run sequentially while health checks remain responsive. Use one server worker to avoid loading extra model copies. `/health` checks the HTTP service; it does not verify model access or readiness. Missing token or dependencies return HTTP 503, invalid options return 422, empty uploads return 400, and inference failures return 500.
 
 ## How It Works
 
@@ -154,12 +209,38 @@ docker run -p 61337:61337 ghcr.io/basnijholt/agent-cli-transcribe-proxy:latest
 docker compose -f docker/docker-compose.yml --profile cpu up transcribe-proxy
 ```
 
+### Docker with diarization
+
+Build the image that includes pyannote, PyTorch, and FFmpeg:
+
+```bash
+docker build -f docker/diarization.Dockerfile -t agent-cli-diarization .
+
+docker run --rm -p 61337:61337 \
+  -e HF_TOKEN \
+  -v agent-cli-diarization-cache:/home/transcribe/.cache \
+  agent-cli-diarization
+```
+
+This runs `/diarize` on CPU. For NVIDIA GPU inference, add `--gpus all -e DIARIZATION_DEVICE=cuda` to `docker run`. For `/transcribe`, also provide your ASR environment variables, for example `-e ASR_PROVIDER=openai -e ASR_OPENAI_BASE_URL=http://your-whisper-host:10301/v1 -e OPENAI_API_KEY=dummy`.
+
+The optional Compose service can run beside the existing Whisper server:
+
+```bash
+# HF_TOKEN must be exported in the shell or set in docker/.env.
+docker compose -f docker/docker-compose.yml --profile cpu up --build whisper-cpu diarization
+```
+
+Use `diarization` in place of `transcribe-proxy`, since both default to port 61337. Set `DIARIZATION_PORT` to use a different host port. The model cache persists in `agent-cli-diarization-cache`. GPU instructions are included beside the service in the Compose file.
+
 ### Environment Variables
 
 Configure the proxy using environment variables (priority: env var > config file > default):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `HF_TOKEN` | - | Hugging Face read token for diarization models |
+| `DIARIZATION_DEVICE` | `auto` | PyTorch device, e.g. `cpu`, `cuda`, `cuda:0`, `mps` |
 | `ASR_PROVIDER` | `wyoming` | ASR provider: `wyoming`, `openai`, `gemini` |
 | `ASR_WYOMING_IP` | `localhost` | Wyoming ASR server hostname/IP |
 | `ASR_WYOMING_PORT` | `10300` | Wyoming ASR server port |

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -59,11 +59,14 @@ The Docker setup provides:
 | ----------------------- | --------------------------------- | ----------- | ------------------------------ |
 | **whisper**             | agent-cli-whisper (custom)        | 10300/10301 | Speech-to-text (Faster Whisper)|
 | **tts**                 | agent-cli-tts (custom)            | 10200/10201 | Text-to-speech (Kokoro/Piper)  |
+| **diarization**        | agent-cli-diarization (local build) | 61337       | Speaker timing and labeled transcripts (optional) |
 | **transcribe-proxy**    | agent-cli-transcribe-proxy        | 61337       | ASR proxy for iOS/external apps|
 | **rag-proxy**           | agent-cli-rag-proxy               | 8000        | Document-aware chat (RAG)      |
 | **memory-proxy**        | agent-cli-memory-proxy            | 8100        | Long-term memory chat          |
 | **ollama**              | ollama/ollama                     | 11434       | LLM server                     |
 | **openwakeword**        | rhasspy/wyoming-openwakeword      | 10400       | Wake word detection            |
+
+For speaker diarization, see [Docker with diarization](../commands/server/transcribe-proxy.md#docker-with-diarization). This optional service reuses the transcription proxy and adds local pyannote inference.
 
 ## Configuration
 

--- a/tests/test_proxy_diarization.py
+++ b/tests/test_proxy_diarization.py
@@ -1,0 +1,317 @@
+"""HTTP diarization contracts, with only model inference and remote ASR replaced."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path  # noqa: TC003
+from threading import Event
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_cli.core.diarization import DiarizedSegment, SpeakerDiarizer
+from agent_cli.server.proxy import api
+from agent_cli.server.proxy.diarization import get_diarization_service
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    get_diarization_service.cache_clear()
+    monkeypatch.setenv("HF_TOKEN", "test-token")
+    monkeypatch.setenv("ASR_PROVIDER", "openai")
+    monkeypatch.setattr(api, "get_default_logger", MagicMock())
+    monkeypatch.setattr(api, "_process_transcript_cleanup", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        api,
+        "_transcribe_with_provider",
+        AsyncMock(return_value="Hello there. Welcome back."),
+    )
+    yield TestClient(api.app)
+    get_diarization_service.cache_clear()
+
+
+@pytest.fixture
+def inference(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Keep real request handling, temporary files and text alignment."""
+    paths: list[Path] = []
+
+    def initialize(self: SpeakerDiarizer, **kwargs: object) -> None:  # noqa: ARG001
+        self.device = "cpu"
+
+    def diarize(self: SpeakerDiarizer, audio_path: Path, **kwargs: object) -> list[DiarizedSegment]:  # noqa: ARG001
+        assert audio_path.read_bytes() == b"original audio"
+        paths.append(audio_path)
+        return [
+            DiarizedSegment("SPEAKER_00", 0.0, 2.0),
+            DiarizedSegment("SPEAKER_01", 2.0, 4.0),
+        ]
+
+    monkeypatch.setattr(SpeakerDiarizer, "__init__", initialize)
+    monkeypatch.setattr(SpeakerDiarizer, "diarize", diarize)
+    return paths
+
+
+def test_diarize_returns_timestamps_and_removes_upload(client: TestClient, inference: list[Path]):
+    response = client.post("/diarize", files={"audio": ("recording.wav", b"original audio")})
+    assert response.status_code == 200
+    assert response.json() == {
+        "segments": [
+            {"speaker": "SPEAKER_00", "start": 0.0, "end": 2.0, "text": ""},
+            {"speaker": "SPEAKER_01", "start": 2.0, "end": 4.0, "text": ""},
+        ],
+    }
+    assert len(inference) == 1
+    assert not inference[0].exists()
+
+
+def test_transcribe_returns_speaker_text(client: TestClient, inference: list[Path]):
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["raw_transcript"] == "Hello there. Welcome back."
+    assert [s["speaker"] for s in data["segments"]] == ["SPEAKER_00", "SPEAKER_01"]
+    assert [s["text"] for s in data["segments"]] == ["Hello there.", "Welcome back."]
+    assert not inference[0].exists()
+
+
+def test_diarization_uses_original_upload_for_wyoming(
+    client: TestClient,
+    inference: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ASR_PROVIDER", "wyoming")
+    monkeypatch.setattr(api, "_convert_audio_for_local_asr", lambda *_: b"raw PCM")
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.mp3", b"original audio")},
+        data={"diarize": "true", "cleanup": "false"},
+    )
+    assert response.json()["success"] is True
+    assert len(inference) == 1
+    assert inference[0].suffix == ".mp3"
+
+
+@pytest.mark.parametrize("route", ["/diarize", "/transcribe"])
+def test_diarization_requires_server_token(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    route: str,
+):
+    monkeypatch.delenv("HF_TOKEN")
+    monkeypatch.setattr(api.config, "load_config", dict)
+    response = client.post(
+        route,
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false"},
+    )
+    assert response.status_code == 503
+    assert "HF_TOKEN" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("route", ["/diarize", "/transcribe"])
+@pytest.mark.parametrize(
+    "hints", [{"min_speakers": "0"}, {"min_speakers": "3", "max_speakers": "2"}]
+)
+def test_invalid_speaker_hints(client: TestClient, route: str, hints: dict[str, str]):
+    response = client.post(
+        route,
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false", **hints},
+    )
+    assert response.status_code == 422
+
+
+def test_diarization_rejects_cleanup(client: TestClient):
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "true"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("route", ["/diarize", "/transcribe"])
+def test_empty_diarization_upload(client: TestClient, route: str):
+    response = client.post(
+        route,
+        files={"audio": ("recording.wav", b"")},
+        data={"diarize": "true", "cleanup": "false"},
+    )
+    assert response.status_code == 400
+
+
+def test_diarization_failure_is_not_success(
+    client: TestClient,
+    inference: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail(self: SpeakerDiarizer, audio_path: Path, **kwargs: object) -> list[DiarizedSegment]:  # noqa: ARG001
+        inference.append(audio_path)
+        msg = "model failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(SpeakerDiarizer, "diarize", fail)
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false"},
+    )
+    assert response.status_code == 500
+    assert not inference[0].exists()
+
+
+def test_request_speaker_hints_do_not_leak(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Per-request hints must not overwrite constructor defaults on a cached pipeline."""
+    diarizer = SpeakerDiarizer.__new__(SpeakerDiarizer)
+    diarizer.min_speakers = None
+    diarizer.max_speakers = None
+    diarizer.pipeline = MagicMock()
+    diarizer.pipeline.return_value.speaker_diarization.itertracks.return_value = []
+    monkeypatch.setattr(
+        "agent_cli.core.diarization._load_audio_for_diarization",
+        lambda _: (object(), 16000),
+    )
+    diarizer.diarize(tmp_path / "recording.wav", min_speakers=2, max_speakers=3)
+    diarizer.diarize(tmp_path / "recording.wav")
+    assert diarizer.pipeline.call_args_list[0].kwargs == {"min_speakers": 2, "max_speakers": 3}
+    assert diarizer.pipeline.call_args_list[1].kwargs == {}
+
+
+def test_word_alignment_uses_actual_timing(
+    client: TestClient,
+    inference: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Moving word alignment onto the sentence heuristic mislabels 'there'."""
+    from agent_cli.core.alignment import AlignedWord  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        "agent_cli.core.diarization.align",
+        lambda *_, **__: [
+            AlignedWord("Hello", 0.0, 1.0),
+            AlignedWord("there.", 2.0, 2.5),
+            AlignedWord("Welcome", 2.5, 3.0),
+            AlignedWord("back.", 3.0, 4.0),
+        ],
+    )
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false", "align_words": "true"},
+    )
+    assert response.json()["segments"] == [
+        {"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0, "text": "Hello"},
+        {"speaker": "SPEAKER_01", "start": 2.0, "end": 4.0, "text": "there. Welcome back."},
+    ]
+    assert not inference[0].exists()
+
+
+def test_unsupported_alignment_language(client: TestClient):
+    response = client.post(
+        "/transcribe",
+        files={"audio": ("recording.wav", b"original audio")},
+        data={"diarize": "true", "cleanup": "false", "align_words": "true", "align_language": "xx"},
+    )
+    assert response.status_code == 422
+
+
+def test_diarize_does_not_require_valid_asr_config(
+    client: TestClient,
+    inference: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("ASR_WYOMING_PORT", "not-a-port")
+    response = client.post("/diarize", files={"audio": ("recording.wav", b"original audio")})
+    assert response.status_code == 200
+    assert len(inference) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_reuse_model_and_keep_health_responsive(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Blocking inference must neither freeze health checks nor overlap on one pipeline."""
+    entered = Event()
+    release = Event()
+    loaded: list[str] = []
+    active = 0
+    peak_active = 0
+
+    def initialize(self: SpeakerDiarizer, **kwargs: object) -> None:  # noqa: ARG001
+        loaded.append("loaded")
+        self.device = "cpu"
+
+    def diarize(self: SpeakerDiarizer, audio_path: Path, **kwargs: object) -> list[DiarizedSegment]:  # noqa: ARG001
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(active, peak_active)
+        entered.set()
+        try:
+            assert release.wait(2)
+            return [DiarizedSegment("SPEAKER_00", 0, 1)]
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(SpeakerDiarizer, "__init__", initialize)
+    monkeypatch.setattr(SpeakerDiarizer, "diarize", diarize)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=client.app),
+        base_url="http://test",
+    ) as session:
+        first = asyncio.create_task(
+            session.post(
+                "/diarize",
+                files={"audio": ("one.wav", b"audio")},
+            )
+        )
+        second = None
+        try:
+            assert await asyncio.to_thread(entered.wait, 1)
+            second = asyncio.create_task(
+                session.post(
+                    "/diarize",
+                    files={"audio": ("two.wav", b"audio")},
+                )
+            )
+            health = await asyncio.wait_for(session.get("/health"), timeout=1)
+            assert health.status_code == 200
+            await asyncio.sleep(0.05)
+        finally:
+            release.set()
+            responses = await asyncio.gather(first, *([second] if second else []))
+    assert len(responses) == 2
+    assert all(response.status_code == 200 for response in responses)
+    assert loaded == ["loaded"]
+    assert peak_active == 1
+
+
+def test_model_load_failure_can_retry(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    attempts = 0
+
+    def initialize(self: SpeakerDiarizer, **kwargs: object) -> None:  # noqa: ARG001
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "Dependencies unavailable"
+            raise ImportError(msg)
+        self.device = "cpu"
+
+    monkeypatch.setattr(SpeakerDiarizer, "__init__", initialize)
+    monkeypatch.setattr(SpeakerDiarizer, "diarize", lambda *_, **__: [])
+    first = client.post("/diarize", files={"audio": ("recording.wav", b"audio")})
+    second = client.post("/diarize", files={"audio": ("recording.wav", b"audio")})
+    assert first.status_code == 503
+    assert second.status_code == 200
+    assert second.json() == {"segments": []}


### PR DESCRIPTION
Expose the existing pyannote speaker diarization through the transcription proxy. `POST /diarize` returns speaker labels and timestamps without an ASR backend; `/transcribe` accepts `diarize=true` with `cleanup=false` to return speaker-labeled transcript segments, with optional forced word alignment.

Reuse one model per process and serialize inference off the event loop. Validate speaker-count hints and alignment options, preserve the original upload for Wyoming requests, and remove temporary audio after processing. Add a Docker image and optional Compose service with a persistent model cache, plus usage examples.

Validation: 1,507 tests passed (4 skipped), including 19 new API/concurrency tests; all repository pre-commit hooks passed. The Docker image built and passed startup, API validation, diarization-stack import, and WAV/MP3 decoding checks. Real model inference requires Hugging Face model access and was not exercised locally.
