### PR TITLE
Publish diarization Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,7 +90,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Single-target images (transcribe-proxy)
+  # Single-target images (proxies and diarization)
   build-single-target:
     runs-on: ubuntu-latest
     permissions:
@@ -106,8 +106,16 @@ jobs:
             dockerfile: docker/rag-proxy.Dockerfile
           - image: memory-proxy
             dockerfile: docker/memory-proxy.Dockerfile
+          - image: diarization
+            dockerfile: docker/diarization.Dockerfile
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
         with:
@@ -153,3 +161,82 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  smoke-diarization:
+    needs: build-single-target
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          df -h
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4.5.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: image
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            tag="${RELEASE_TAG#v}"
+          else
+            tag="latest"
+          fi
+          echo "ref=${REGISTRY}/${GITHUB_REPOSITORY}-diarization:${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Pull published image
+        run: docker pull "${{ steps.image.outputs.ref }}"
+
+      - name: Verify package version
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          actual_version=$(
+            docker run --rm --entrypoint /app/.venv/bin/python "$IMAGE_REF" \
+              -c 'import importlib.metadata; print(importlib.metadata.version("agent-cli"))'
+          )
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            expected_version="${RELEASE_TAG#v}"
+            if [[ "${actual_version%%+*}" != "$expected_version" ]]; then
+              echo "Expected agent-cli $expected_version, got $actual_version" >&2
+              exit 1
+            fi
+          fi
+          echo "Verified agent-cli $actual_version"
+
+      - name: Verify health and API routes
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+        run: |
+          container_id=$(docker run --detach --publish 61337:61337 "$IMAGE_REF")
+          trap 'docker rm --force "$container_id" >/dev/null 2>&1 || true' EXIT
+
+          ready=false
+          for _ in {1..30}; do
+            if curl --fail --silent http://localhost:61337/health >/dev/null; then
+              ready=true
+              break
+            fi
+            sleep 2
+          done
+          if [[ "$ready" != "true" ]]; then
+            docker logs "$container_id"
+            exit 1
+          fi
+
+          curl --fail --silent http://localhost:61337/openapi.json > openapi.json
+          for route in /health /transcribe /diarize; do
+            jq --exit-status --arg route "$route" '.paths[$route]' openapi.json >/dev/null
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -165,6 +165,7 @@ jobs:
   smoke-diarization:
     needs: build-single-target
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: read
@@ -185,14 +186,8 @@ jobs:
 
       - name: Resolve image reference
         id: image
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            tag="${RELEASE_TAG#v}"
-          else
-            tag="latest"
-          fi
+          tag="sha-${GITHUB_SHA::7}"
           echo "ref=${REGISTRY}/${GITHUB_REPOSITORY}-diarization:${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Pull published image
@@ -225,7 +220,8 @@ jobs:
 
           ready=false
           for _ in {1..30}; do
-            if curl --fail --silent http://localhost:61337/health >/dev/null; then
+            if curl --fail --silent --connect-timeout 1 --max-time 2 \
+              http://localhost:61337/health | jq --exit-status '.status == "healthy"' >/dev/null; then
               ready=true
               break
             fi
@@ -236,7 +232,10 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent http://localhost:61337/openapi.json > openapi.json
-          for route in /health /transcribe /diarize; do
-            jq --exit-status --arg route "$route" '.paths[$route]' openapi.json >/dev/null
-          done
+          if ! curl --fail --silent --show-error --connect-timeout 1 --max-time 2 \
+            http://localhost:61337/openapi.json | jq --exit-status \
+              '.paths["/health"].get and .paths["/transcribe"].post and .paths["/diarize"].post' \
+              >/dev/null; then
+            docker logs "$container_id"
+            exit 1
+          fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -240,10 +240,10 @@ services:
     restart: unless-stopped
 
   # Optional transcription proxy with local diarization. Start explicitly with:
-  # docker compose -f docker/docker-compose.yml up --build diarization
+  # docker compose -f docker/docker-compose.yml up diarization
   # Shares port 61337 with transcribe-proxy; run one of them at a time.
   diarization:
-    image: agent-cli-diarization
+    image: ghcr.io/basnijholt/agent-cli-diarization:latest
     build:
       context: ..
       dockerfile: docker/diarization.Dockerfile

--- a/docs/commands/server/transcribe-proxy.md
+++ b/docs/commands/server/transcribe-proxy.md
@@ -211,15 +211,13 @@ docker compose -f docker/docker-compose.yml --profile cpu up transcribe-proxy
 
 ### Docker with diarization
 
-Build the image that includes pyannote, PyTorch, and FFmpeg:
+Run the published image, which includes pyannote, PyTorch, and FFmpeg:
 
 ```bash
-docker build -f docker/diarization.Dockerfile -t agent-cli-diarization .
-
 docker run --rm -p 61337:61337 \
   -e HF_TOKEN \
   -v agent-cli-diarization-cache:/home/transcribe/.cache \
-  agent-cli-diarization
+  ghcr.io/basnijholt/agent-cli-diarization:latest
 ```
 
 This runs `/diarize` on CPU. For NVIDIA GPU inference, add `--gpus all -e DIARIZATION_DEVICE=cuda` to `docker run`. For `/transcribe`, also provide your ASR environment variables, for example `-e ASR_PROVIDER=openai -e ASR_OPENAI_BASE_URL=http://your-whisper-host:10301/v1 -e OPENAI_API_KEY=dummy`.
@@ -228,10 +226,16 @@ The optional Compose service can run beside the existing Whisper server:
 
 ```bash
 # HF_TOKEN must be exported in the shell or set in docker/.env.
-docker compose -f docker/docker-compose.yml --profile cpu up --build whisper-cpu diarization
+docker compose -f docker/docker-compose.yml --profile cpu up whisper-cpu diarization
 ```
 
 Use `diarization` in place of `transcribe-proxy`, since both default to port 61337. Set `DIARIZATION_PORT` to use a different host port. The model cache persists in `agent-cli-diarization-cache`. GPU instructions are included beside the service in the Compose file.
+
+To build from source instead, add `--build` to the Compose command or run:
+
+```bash
+docker build -f docker/diarization.Dockerfile -t agent-cli-diarization .
+```
 
 ### Environment Variables
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -59,7 +59,7 @@ The Docker setup provides:
 | ----------------------- | --------------------------------- | ----------- | ------------------------------ |
 | **whisper**             | agent-cli-whisper (custom)        | 10300/10301 | Speech-to-text (Faster Whisper)|
 | **tts**                 | agent-cli-tts (custom)            | 10200/10201 | Text-to-speech (Kokoro/Piper)  |
-| **diarization**        | agent-cli-diarization (local build) | 61337       | Speaker timing and labeled transcripts (optional) |
+| **diarization**        | agent-cli-diarization               | 61337       | Speaker timing and labeled transcripts (optional) |
 | **transcribe-proxy**    | agent-cli-transcribe-proxy        | 61337       | ASR proxy for iOS/external apps|
 | **rag-proxy**           | agent-cli-rag-proxy               | 8000        | Document-aware chat (RAG)      |
 | **memory-proxy**        | agent-cli-memory-proxy            | 8100        | Long-term memory chat          |


### PR DESCRIPTION
## Summary

- publish the diarization container with versioned, latest, and immutable SHA tags
- smoke-test the published artifact version, health response, and API methods
- use the GHCR image by default in Compose and documentation while retaining source builds

## Validation

- `uv run pytest` — 1507 passed, 4 skipped
- `uv run pre-commit run --all-files`
- `actionlint .github/workflows/docker.yml`
- static workflow and documentation assertions