### PR TITLE
Prevent Qwen long-audio truncation

### DIFF
--- a/agent_cli/server/cli.py
+++ b/agent_cli/server/cli.py
@@ -403,6 +403,17 @@ def whisper_cmd(  # noqa: C901, PLR0912, PLR0915
             ),
         ),
     ] = False,
+    max_new_tokens: Annotated[
+        int,
+        typer.Option(
+            "--max-new-tokens",
+            min=1,
+            help=(
+                "Maximum output tokens for autoregressive transformers ASR models. "
+                "Increase for unusually long audio"
+            ),
+        ),
+    ] = 4096,
     ttl: Annotated[
         int,
         typer.Option(
@@ -602,6 +613,7 @@ def whisper_cmd(  # noqa: C901, PLR0912, PLR0915
             compute_type=compute_type,
             default_language=default_language,
             trust_remote_code=trust_remote_code,
+            max_new_tokens=max_new_tokens,
             ttl_seconds=ttl,
             cache_dir=cache_dir,
             backend_type=resolved_backend,  # type: ignore[arg-type]

--- a/agent_cli/server/whisper/backends/base.py
+++ b/agent_cli/server/whisper/backends/base.py
@@ -32,6 +32,7 @@ class BackendConfig:
     cache_dir: Path | None = None
     default_language: str | None = None
     trust_remote_code: bool = False
+    max_new_tokens: int = 4096
 
 
 class InvalidAudioError(ValueError):

--- a/agent_cli/server/whisper/backends/transformers.py
+++ b/agent_cli/server/whisper/backends/transformers.py
@@ -47,6 +47,10 @@ _MODEL_MAP: dict[str, str] = {
 _REMOTE_CODE_MODEL_PREFIXES = ("CohereLabs/cohere-transcribe",)
 
 
+class TranscriptionTruncatedError(RuntimeError):
+    """Raised when an autoregressive ASR model exhausts its output budget."""
+
+
 def _resolve_model_name(model_name: str) -> str:
     """Resolve a model name to a HuggingFace repo."""
     if "/" in model_name:
@@ -276,6 +280,7 @@ def _transcribe_qwen3_asr(
     task: str,
     initial_prompt: str | None,
     duration: float,
+    max_new_tokens: int,
 ) -> dict[str, Any]:
     """Transcribe with Qwen3-ASR's native transformers interface."""
     if task != "transcribe":
@@ -294,11 +299,19 @@ def _transcribe_qwen3_asr(
     with torch.inference_mode():
         output_ids = _state.model.generate(
             **inputs,
-            max_new_tokens=256,
+            max_new_tokens=max_new_tokens,
             do_sample=False,
         )
 
     generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
+    if generated_ids.shape[1] >= max_new_tokens:
+        msg = (
+            "Qwen3-ASR transcription reached "
+            f"max_new_tokens={max_new_tokens} before completion. "
+            "Restart the server with a higher --max-new-tokens value "
+            "or split the audio into shorter chunks."
+        )
+        raise TranscriptionTruncatedError(msg)
     parsed = _state.processor.decode(generated_ids, return_format="parsed")[0]
     language = parsed["language"] or effective_language or "unknown"
 
@@ -416,6 +429,7 @@ def _transcribe_in_subprocess(kwargs: dict[str, Any]) -> dict[str, Any]:
             task=task,
             initial_prompt=kwargs.get("initial_prompt"),
             duration=_read_wav_duration(wav_path),
+            max_new_tokens=kwargs.get("max_new_tokens", 4096),
         )
 
     audio_array, sample_rate, duration = _read_wav_audio(wav_path)
@@ -548,6 +562,7 @@ class TransformersWhisperBackend:
             "default_language": self._config.default_language,
             "task": task,
             "initial_prompt": initial_prompt,
+            "max_new_tokens": self._config.max_new_tokens,
         }
 
         try:

--- a/agent_cli/server/whisper/backends/transformers.py
+++ b/agent_cli/server/whisper/backends/transformers.py
@@ -224,6 +224,22 @@ def _move_inputs_to_device(inputs: Any) -> Any:
     return {k: v.to(_state.device) if hasattr(v, "to") else v for k, v in inputs.items()}
 
 
+def _qwen_generation_was_truncated(generated_ids: Any, max_new_tokens: int) -> bool:
+    """Return whether Qwen exhausted its token budget without emitting EOS."""
+    if generated_ids.shape[1] < max_new_tokens:
+        return False
+
+    generation_config = getattr(_state.model, "generation_config", None)
+    eos_token_ids = getattr(generation_config, "eos_token_id", None)
+    if eos_token_ids is None:
+        return True
+    if isinstance(eos_token_ids, int):
+        eos_token_ids = [eos_token_ids]
+
+    last_token_id = generated_ids[:, -1:].tolist()[0][0]
+    return last_token_id not in eos_token_ids
+
+
 def _transcribe_cohere_asr(
     *,
     audio_array: Any,
@@ -304,7 +320,7 @@ def _transcribe_qwen3_asr(
         )
 
     generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
-    if generated_ids.shape[1] >= max_new_tokens:
+    if _qwen_generation_was_truncated(generated_ids, max_new_tokens):
         msg = (
             "Qwen3-ASR transcription reached "
             f"max_new_tokens={max_new_tokens} before completion. "

--- a/agent_cli/server/whisper/model_manager.py
+++ b/agent_cli/server/whisper/model_manager.py
@@ -30,6 +30,7 @@ class WhisperModelConfig(ModelConfig):
     backend_type: BackendType = "auto"
     default_language: str | None = None
     trust_remote_code: bool = False
+    max_new_tokens: int = 4096
 
 
 class WhisperModelManager:
@@ -50,6 +51,7 @@ class WhisperModelManager:
                 cache_dir=config.cache_dir,
                 default_language=config.default_language,
                 trust_remote_code=config.trust_remote_code,
+                max_new_tokens=config.max_new_tokens,
             ),
             backend_type=config.backend_type,
         )

--- a/docs/commands/server/whisper.md
+++ b/docs/commands/server/whisper.md
@@ -130,6 +130,7 @@ agent-cli server whisper \
 | `--cache-dir` | - | Custom directory for downloaded models (default: HuggingFace cache) |
 | `--default-language` | - | Fallback language code for requests that omit `language`. Required for models that do not support language auto-detection (for example Cohere Transcribe). |
 | `--trust-remote-code` | `false` | Allow Hugging Face model repositories to execute custom Python code. Known supported remote-code ASR models are trusted automatically. |
+| `--max-new-tokens` | `4096` | Maximum output tokens for autoregressive transformers ASR models. Increase for unusually long audio |
 | `--ttl` | `300` | Seconds of inactivity before unloading model from memory. Set to 0 to keep loaded indefinitely |
 | `--preload` | `false` | Load model(s) immediately at startup instead of on first request. Useful for reducing first-request latency |
 | `--host` | `0.0.0.0` | Network interface to bind. Use `0.0.0.0` for all interfaces |
@@ -310,6 +311,8 @@ agent-cli server whisper \
 ```
 
 Qwen3-ASR supports transcription, automatic language detection, and context or hotwords through the OpenAI-compatible `prompt` field. Translation and timestamped subtitle output are not currently supported.
+
+The default output budget is 4096 tokens, which accommodates long recordings. For unusually long or dense speech, increase it with `--max-new-tokens`. If Qwen3-ASR exhausts the configured budget, the request fails with a clear error instead of returning a silently truncated transcript.
 
 To install it as the standard `whisper` background daemon:
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -129,7 +129,45 @@ def test_server_whisper_command_in_cli() -> None:
     assert "--model" in clean_output
     assert "--ttl" in clean_output
     assert "--wyoming-port" in clean_output
+    assert "--max-new-tokens" in clean_output
     assert "nemo" in clean_output
+
+
+@patch("uvicorn.run")
+def test_server_whisper_propagates_max_new_tokens(mock_uvicorn_run: MagicMock) -> None:
+    """Whisper server should propagate the generation limit to model config."""
+    runner = CliRunner()
+    registry = MagicMock()
+    registry.default_model = "Qwen/Qwen3-ASR-1.7B-hf"
+
+    with (
+        patch("agent_cli.core.deps._check_and_install_extras", return_value=[]),
+        patch("agent_cli.server.cli._check_whisper_deps"),
+        patch("agent_cli.server.cli._check_transformers_audio_model_deps"),
+        patch(
+            "agent_cli.server.whisper.model_registry.create_whisper_registry",
+            return_value=registry,
+        ),
+    ):
+        result = runner.invoke(
+            cli_app,
+            [
+                "server",
+                "whisper",
+                "--model",
+                "Qwen/Qwen3-ASR-1.7B-hf",
+                "--backend",
+                "transformers",
+                "--no-wyoming",
+                "--max-new-tokens",
+                "2048",
+            ],
+        )
+
+    assert result.exit_code == 0
+    registered_config = registry.register.call_args.args[0]
+    assert registered_config.max_new_tokens == 2048
+    mock_uvicorn_run.assert_called_once()
 
 
 @patch("uvicorn.run")

--- a/tests/test_server_whisper.py
+++ b/tests/test_server_whisper.py
@@ -52,6 +52,7 @@ class TestModelConfig:
         assert config.backend_type == "auto"
         assert config.default_language is None
         assert config.trust_remote_code is False
+        assert config.max_new_tokens == 4096
 
     def test_custom_values(self) -> None:
         """Test custom configuration values."""
@@ -64,6 +65,7 @@ class TestModelConfig:
             cpu_threads=8,
             default_language="en",
             trust_remote_code=True,
+            max_new_tokens=2048,
         )
         assert config.model_name == "small"
         assert config.device == "cuda:0"
@@ -73,6 +75,7 @@ class TestModelConfig:
         assert config.cpu_threads == 8
         assert config.default_language == "en"
         assert config.trust_remote_code is True
+        assert config.max_new_tokens == 2048
 
     def test_zero_ttl_disables_auto_unload(self) -> None:
         """TTL 0 should be accepted as keep-loaded mode."""

--- a/tests/test_transformers_backend.py
+++ b/tests/test_transformers_backend.py
@@ -245,8 +245,10 @@ def test_transcribe_qwen3_asr_returns_parsed_transcription(
             return [{"language": "English", "transcription": "Agent CLI"}]
 
     class Model:
+        generation_config = SimpleNamespace(eos_token_id=[42, 99])
+
         def generate(self, **inputs: Tensor | int | bool) -> Tensor:
-            assert inputs["max_new_tokens"] == 1024
+            assert inputs["max_new_tokens"] == 2
             return Tensor([[1, 2, 3, 41, 42]])
 
     monkeypatch.setitem(
@@ -272,7 +274,7 @@ def test_transcribe_qwen3_asr_returns_parsed_transcription(
         task="transcribe",
         initial_prompt="Vocabulary: Agent CLI",
         duration=1.5,
-        max_new_tokens=1024,
+        max_new_tokens=2,
     )
 
     assert result == {
@@ -301,6 +303,9 @@ def test_transcribe_qwen3_asr_rejects_truncated_generation(
         def __getitem__(self, key: tuple[slice, slice]) -> Tensor:
             rows, columns = key
             return Tensor([row[columns] for row in self.values[rows]])
+
+        def tolist(self) -> list[list[int]]:
+            return self.values
 
     class Processor:
         def apply_transcription_request(self, **_kwargs: object) -> dict[str, Tensor]:

--- a/tests/test_transformers_backend.py
+++ b/tests/test_transformers_backend.py
@@ -245,7 +245,8 @@ def test_transcribe_qwen3_asr_returns_parsed_transcription(
             return [{"language": "English", "transcription": "Agent CLI"}]
 
     class Model:
-        def generate(self, **_inputs: Tensor) -> Tensor:
+        def generate(self, **inputs: Tensor | int | bool) -> Tensor:
+            assert inputs["max_new_tokens"] == 1024
             return Tensor([[1, 2, 3, 41, 42]])
 
     monkeypatch.setitem(
@@ -271,6 +272,7 @@ def test_transcribe_qwen3_asr_returns_parsed_transcription(
         task="transcribe",
         initial_prompt="Vocabulary: Agent CLI",
         duration=1.5,
+        max_new_tokens=1024,
     )
 
     assert result == {
@@ -281,6 +283,58 @@ def test_transcribe_qwen3_asr_returns_parsed_transcription(
         "segments": [],
         "supports_segments": False,
     }
+
+
+def test_transcribe_qwen3_asr_rejects_truncated_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Qwen3-ASR must not return partial text when generation exhausts its limit."""
+
+    class Tensor:
+        def __init__(self, values: list[list[int]]) -> None:
+            self.values = values
+            self.shape = (len(values), len(values[0]))
+
+        def to(self, *_args: object, **_kwargs: object) -> Tensor:
+            return self
+
+        def __getitem__(self, key: tuple[slice, slice]) -> Tensor:
+            rows, columns = key
+            return Tensor([row[columns] for row in self.values[rows]])
+
+    class Processor:
+        def apply_transcription_request(self, **_kwargs: object) -> dict[str, Tensor]:
+            return {"input_ids": Tensor([[1, 2, 3]])}
+
+        def decode(self, *_args: object, **_kwargs: object) -> list[dict[str, str]]:
+            raise AssertionError
+
+    class Model:
+        def generate(self, **_kwargs: object) -> Tensor:
+            return Tensor([[1, 2, 3, 41, 42]])
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(inference_mode=nullcontext))
+    monkeypatch.setattr(
+        backend,
+        "_state",
+        backend._SubprocessState(
+            model=Model(),
+            processor=Processor(),
+            dtype="float32",
+            device="cpu",
+            is_qwen3_asr=True,
+        ),
+    )
+
+    with pytest.raises(backend.TranscriptionTruncatedError, match="max_new_tokens=2"):
+        backend._transcribe_qwen3_asr(
+            audio_array=object(),
+            effective_language=None,
+            task="transcribe",
+            initial_prompt=None,
+            duration=180.0,
+            max_new_tokens=2,
+        )
 
 
 def test_transcribe_qwen3_asr_rejects_translation(
@@ -310,6 +364,7 @@ def test_transcribe_qwen3_asr_rejects_translation(
             task="translate",
             initial_prompt=None,
             duration=1.0,
+            max_new_tokens=4096,
         )
 
 
@@ -353,7 +408,11 @@ def test_transcribe_dispatches_qwen3_asr_to_native_adapter(
     )
 
     def transcribe_qwen3_asr(**kwargs: object) -> dict[str, object]:
-        if kwargs["audio_array"] is not qwen_audio or kwargs["duration"] != 0.5:
+        if (
+            kwargs["audio_array"] is not qwen_audio
+            or kwargs["duration"] != 0.5
+            or kwargs["max_new_tokens"] != 2048
+        ):
             return {**expected, "text": "wrong Qwen input"}
         return expected
 
@@ -364,6 +423,7 @@ def test_transcribe_dispatches_qwen3_asr_to_native_adapter(
             "wav_path": str(wav_path),
             "task": "transcribe",
             "initial_prompt": "Agent CLI",
+            "max_new_tokens": 2048,
         },
     )
 


### PR DESCRIPTION
## Summary

- raise the Qwen3-ASR generation budget from 256 to 4096 tokens
- expose `--max-new-tokens` for unusually long or dense recordings
- fail explicitly when Qwen exhausts the configured output budget
- document the long-audio behavior and add regression coverage

## Root cause

Qwen3-ASR received the complete audio but generation stopped at the hard-coded 256-token limit, producing a plausible-looking partial transcript.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest` — 1509 passed, 4 skipped
- focused Whisper/transformers tests — 82 passed