### PR TITLE
Release unused CUDA cache after transformers transcription

### DIFF
--- a/agent_cli/server/whisper/backends/transformers.py
+++ b/agent_cli/server/whisper/backends/transformers.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import tempfile
 import time
+import traceback
 import wave
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
@@ -428,8 +429,8 @@ def _transcribe_with_generate(
     )
 
 
-def _transcribe_in_subprocess(kwargs: dict[str, Any]) -> dict[str, Any]:
-    """Run transcription in subprocess. Reuses model from _state."""
+def _transcribe_with_loaded_model(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch transcription using the model retained in this worker."""
     if _state.model is None or _state.processor is None:
         msg = "Model not loaded in subprocess. Call _load_model_in_subprocess first."
         raise RuntimeError(msg)
@@ -477,6 +478,44 @@ def _transcribe_in_subprocess(kwargs: dict[str, Any]) -> dict[str, Any]:
         beam_size=kwargs.get("beam_size", 5),
         duration=duration,
     )
+
+
+def _clear_exception_frames(exc: BaseException) -> None:
+    """Release helper locals retained by an exception and its chained failures."""
+    pending = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        traceback.clear_frames(current.__traceback__)
+        pending.extend(
+            error for error in (current.__cause__, current.__context__) if error is not None
+        )
+        if isinstance(current, BaseExceptionGroup):
+            pending.extend(current.exceptions)
+
+
+def _transcribe_in_subprocess(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Transcribe and return unused CUDA memory while keeping model weights loaded."""
+    if not _state.device or not _state.device.startswith("cuda"):
+        return _transcribe_with_loaded_model(kwargs)
+
+    import torch  # noqa: PLC0415
+
+    try:
+        return _transcribe_with_loaded_model(kwargs)
+    except BaseException as exc:
+        # Failed helper frames otherwise keep temporary tensors live until the
+        # executor serializes the exception, which happens after our finally.
+        # Clear locals without losing the traceback's function names and lines.
+        _clear_exception_frames(exc)
+        raise
+    finally:
+        # Helper frames have returned, so their temporary tensors are now free.
+        # Only unused allocator blocks are released; model weights stay resident.
+        torch.cuda.empty_cache()
 
 
 class TransformersWhisperBackend:

--- a/docs/commands/server/whisper.md
+++ b/docs/commands/server/whisper.md
@@ -55,6 +55,7 @@ Run a local ASR server with automatic backend selection based on your platform:
 - **OpenAI-compatible API** at `/v1/audio/transcriptions` - drop-in replacement for OpenAI's Whisper API
 - **Wyoming protocol** for [Home Assistant](https://www.home-assistant.io/) voice integration (Wyoming is the standard protocol for local voice services)
 - **TTL-based memory management** - models unload after idle period, freeing RAM/VRAM
+- **CUDA cache cleanup** - the transformers backend releases unused GPU cache after each transcription while keeping model weights loaded
 - **Multiple models** - run different model sizes with independent TTLs
 - **Background preloading** - downloads start at startup without blocking; use `--preload` to wait
 - **Multi-platform support** - automatically uses the optimal backend for your hardware (`auto` switches to `nemo` for Parakeet models)

--- a/tests/test_transformers_backend.py
+++ b/tests/test_transformers_backend.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import sys
+import traceback
 import wave
+import weakref
 from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -433,3 +435,103 @@ def test_transcribe_dispatches_qwen3_asr_to_native_adapter(
     )
 
     assert result == expected
+
+
+@pytest.mark.parametrize("device", ["cuda", "cuda:0", "cpu", "mps"])
+@pytest.mark.parametrize(
+    "failure", [None, "direct", "interrupt", "cause", "context", "group", "cycle"]
+)
+def test_transcription_releases_unused_cuda_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    device: str,
+    failure: str | None,
+) -> None:
+    """A completed or failed request must not retain CUDA's peak working set.
+
+    PyTorch's caching allocator keeps freed tensor storage reserved until
+    empty_cache(), which releases unused storage without unloading live tensors:
+    https://docs.pytorch.org/docs/stable/notes/cuda.html#memory-management
+    The small allocator double models that external boundary without a GPU.
+    """
+
+    class Buffer:
+        def __init__(self, size: int) -> None:
+            self.size = size
+
+    class Allocator:
+        def __init__(self) -> None:
+            self.live: weakref.WeakSet[Buffer] = weakref.WeakSet()
+            self.reserved = 0
+
+        def allocate(self, size: int) -> Buffer:
+            buffer = Buffer(size)
+            self.live.add(buffer)
+            self.reserved += size
+            return buffer
+
+        def empty_cache(self) -> None:
+            if not device.startswith("cuda"):
+                pytest.fail("CPU/MPS transcription must not initialize CUDA")
+            self.reserved = sum(buffer.size for buffer in self.live)
+
+    allocator = Allocator()
+    weights = allocator.allocate(100)
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=allocator))
+    monkeypatch.setattr(
+        backend,
+        "_state",
+        backend._SubprocessState(
+            model=weights,
+            processor=object(),
+            device=device,
+            is_qwen3_asr=True,
+        ),
+    )
+    wav_path = tmp_path / "request.wav"
+    with wave.open(str(wav_path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        wav_file.writeframes(b"\x00\x00")
+    monkeypatch.setattr(backend, "_load_qwen_audio", lambda _: object())
+
+    def infer_inner() -> dict[str, object]:
+        temporary = allocator.allocate(900)
+        if failure:
+            # Its traceback holds `temporary` until the worker clears frame locals.
+            message = "inference failed"
+            error_type = KeyboardInterrupt if failure == "interrupt" else RuntimeError
+            raise error_type(message)
+        return {"text": "transcribed", "working_set": temporary.size}
+
+    def infer(**_kwargs: object) -> dict[str, object]:
+        try:
+            return infer_inner()
+        except RuntimeError as exc:
+            message = "inference failed"
+            if failure == "cause":
+                raise ValueError(message) from exc
+            if failure == "context":
+                raise ValueError(message) from None
+            if failure == "group":
+                raise ExceptionGroup(message, [exc]) from None
+            if failure == "cycle":
+                wrapped = ValueError(message)
+                exc.__cause__ = wrapped
+                raise wrapped from exc
+            raise
+
+    monkeypatch.setattr(backend, "_transcribe_qwen3_asr", infer)
+    if failure:
+        with pytest.raises(BaseException, match="inference failed") as error:
+            backend._transcribe_in_subprocess({"wav_path": str(wav_path)})
+        assert "infer" in [frame.name for frame in traceback.extract_tb(error.value.__traceback__)]
+    else:
+        assert backend._transcribe_in_subprocess({"wav_path": str(wav_path)}) == {
+            "text": "transcribed",
+            "working_set": 900,
+        }
+
+    assert allocator.reserved == (100 if device.startswith("cuda") else 1000)
+    assert backend._state.model is weights


### PR DESCRIPTION
Long recordings can leave the transformers ASR worker holding its peak CUDA allocator reservation for the model's entire idle TTL. In a Qwen3-ASR reproduction, a 10-minute recording left 10.58 GiB reserved despite only 3.80 GiB of live tensors; later short recordings retained that reservation.

Release unused CUDA cache after each transcription while keeping model weights loaded. Inference runs in a separate helper so temporary tensors are gone before cleanup. On failure, clear completed traceback frames across exception causes, contexts, and groups, with cycle protection, before releasing cache. CPU and MPS bypass CUDA cleanup.

Validation:

- Full suite: 1,537 passed, 4 skipped; all repository pre-commit hooks passed.
- Regression tests cover successful requests, direct errors, interruptions, wrapped errors, exception groups, and cycles across CUDA, indexed CUDA, CPU, and MPS.
- Real CUDA probes released a 256 MiB temporary allocation back to a 16 MiB resident-weight baseline on success and direct/chained/grouped failures, using only `empty_cache()`.
- Deployed a cache-only backport to the Qwen3-ASR service: process VRAM stayed at 4.13 GiB after a 10-minute recording and a short follow-up, with one model load and no unloads. Before the fix, the same long-recording reproduction retained 10.89 GiB. A spoken sample transcribed exactly before and after deployment.

Per-request cache release trades allocator reuse for making idle VRAM available to other workloads.
